### PR TITLE
chore(travis): use latest stable version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
-node_js:
-  - "6"
+node_js: stable
 before_script:
   - yarn boot
   - yarn build:cjs


### PR DESCRIPTION
This way as soon as there's a new node.js stable version. If your project is not compatible, you'll know it and have to fix it.