### PR TITLE
refactor(highligt): use mark tag by default

### DIFF
--- a/packages/vue-instantsearch-highlight/README.md
+++ b/packages/vue-instantsearch-highlight/README.md
@@ -23,7 +23,7 @@ Basic usage:
 Changing the highlighting tag:
 
  ```html
-<ais-highlight :result="result" attribute-name="description" tag-name="mark"></ais-highlight>
+<ais-highlight :result="result" attribute-name="description" tag-name="em"></ais-highlight>
  ```
 
 **Note that the tag name has to be passed without carets.**
@@ -36,12 +36,12 @@ Disable html escaping (**not recommended**):
 
 ## Props
 
-| Name           | Required | Type    | Default | Description                                           |
-|:---------------|:---------|:--------|:--------|:------------------------------------------------------|
-| result         | true     | Object  |         | A single Algolia result as it is returned by the API. |
-| attribute-name | true     | String  |         | The attribute name to be highlighted.                 |
-| tag-name       | false    | String  | `'em'`  | The tag name used for highlighting.                   |
-| escape-html    | false    | Boolean | `true`  | Whether to escape the HTML or not.                    |
+| Name           | Required | Type    | Default  | Description                                           |
+|:---------------|:---------|:--------|:---------|:------------------------------------------------------|
+| result         | true     | Object  |          | A single Algolia result as it is returned by the API. |
+| attribute-name | true     | String  |          | The attribute name to be highlighted.                 |
+| tag-name       | false    | String  | `'mark'` | The tag name used for highlighting.                   |
+| escape-html    | false    | Boolean | `true`   | Whether to escape the HTML or not.                    |
 
 ## CSS Classes
 

--- a/packages/vue-instantsearch-highlight/src/Highlight.vue
+++ b/packages/vue-instantsearch-highlight/src/Highlight.vue
@@ -15,7 +15,7 @@
       },
       tagName: {
         type: String,
-        default: 'em'
+        default: 'mark'
       },
       escapeHtml: {
         type: Boolean,

--- a/packages/vue-instantsearch-snippet/README.md
+++ b/packages/vue-instantsearch-snippet/README.md
@@ -23,7 +23,7 @@ Basic usage:
 Changing the highlighting tag:
 
  ```html
-<ais-snippet :result="result" attribute-name="description" tag-name="mark"></ais-snippet>
+<ais-snippet :result="result" attribute-name="description" tag-name="em"></ais-snippet>
  ```
 
 **Note that the tag name has to be passed without carets.**
@@ -36,12 +36,12 @@ Disable html escaping (**not recommended**):
 
 ## Props
 
-| Name           | Required | Type    | Default | Description                                           |
-|:---------------|:---------|:--------|:--------|:------------------------------------------------------|
-| result         | true     | Object  |         | A single Algolia result as it is returned by the API. |
-| attribute-name | true     | String  |         | The attribute name to be snippeted.                   |
-| tag-name       | false    | String  | `'em'`  | The tag name used for highlighting.                   |
-| escape-html    | false    | Boolean | `true`  | Whether to escape the HTML or not.                    |
+| Name           | Required | Type    | Default  | Description                                           |
+|:---------------|:---------|:--------|:---------|:------------------------------------------------------|
+| result         | true     | Object  |          | A single Algolia result as it is returned by the API. |
+| attribute-name | true     | String  |          | The attribute name to be snippeted.                   |
+| tag-name       | false    | String  | `'mark'` | The tag name used for highlighting.                   |
+| escape-html    | false    | Boolean | `true`   | Whether to escape the HTML or not.                    |
 
 ## CSS Classes
 

--- a/packages/vue-instantsearch-snippet/src/Snippet.vue
+++ b/packages/vue-instantsearch-snippet/src/Snippet.vue
@@ -15,7 +15,7 @@
       },
       tagName: {
         type: String,
-        default: 'em'
+        default: 'mark'
       },
       escapeHtml: {
         type: Boolean,


### PR DESCRIPTION
CSS frameworks properly style the `<mark>` tag.
And it is the HTML most correct way of representing highlighted segments.
Let's enforce good defaults here.