### PR TITLE
fix(clear): use clearsQuery instead of clearQuery

### DIFF
--- a/packages/vue-instantsearch-clear/README.md
+++ b/packages/vue-instantsearch-clear/README.md
@@ -35,8 +35,8 @@ Only clear the facet refinements:
 
 ## Props
 
-| Name        | Type    | Default | Description                                                                       |
-|:------------|:--------|:--------|:----------------------------------------------------------------------------------|
+| Name         | Type    | Default | Description                                                                       |
+|:-------------|:--------|:--------|:----------------------------------------------------------------------------------|
 | clearsQuery  | boolean | `true`  | If `true`, when the button is clicked, the `query` will be emptied.               |
 | clearsFacets | boolean | `true`  | If `true`, when the button is clicked, all the facet refinements will be removed. |
 

--- a/packages/vue-instantsearch-clear/src/Clear.vue
+++ b/packages/vue-instantsearch-clear/src/Clear.vue
@@ -11,52 +11,52 @@
 </template>
 
 <script>
-  import algoliaComponent from 'vue-instantsearch-component'
+import algoliaComponent from 'vue-instantsearch-component';
 
-  export default {
-    mixins: [algoliaComponent],
-    props: {
-      clearsQuery: {
-        type: Boolean,
-        required: false,
-        default: true
-      },
-      clearsFacets: {
-        type: Boolean,
-        required: false,
-        default: true
-      }
+export default {
+  mixins: [algoliaComponent],
+  props: {
+    clearsQuery: {
+      type: Boolean,
+      required: false,
+      default: true
     },
-    data () {
-      return {
-        blockClassName: 'ais-clear'
+    clearsFacets: {
+      type: Boolean,
+      required: false,
+      default: true
+    }
+  },
+  data() {
+    return {
+      blockClassName: 'ais-clear'
+    };
+  },
+  computed: {
+    disabled: function() {
+      if (this.clearsQuery && this.searchStore.query.length > 0) {
+        return false;
       }
-    },
-    computed: {
-      disabled: function () {
-        if (this.clearsQuery && this.searchStore.query.length > 0) {
-          return false
-        }
 
-        if (this.clearsFacets && this.searchStore.activeRefinements.length > 0) {
-          return false
-        }
-
-        return true
+      if (this.clearsFacets && this.searchStore.activeRefinements.length > 0) {
+        return false;
       }
-    },
-    methods: {
-      clear: function () {
-        this.searchStore.stop()
-        if (this.clearsQuery && this.searchStore.query.length > 0) {
-          this.searchStore.query = ''
-        }
 
-        if (this.clearsFacets && this.searchStore.activeRefinements.length > 0) {
-          this.searchStore.clearRefinements()
-        }
-        this.searchStore.start()
+      return true;
+    }
+  },
+  methods: {
+    clear: function() {
+      this.searchStore.stop();
+      if (this.clearsQuery && this.searchStore.query.length > 0) {
+        this.searchStore.query = '';
       }
+
+      if (this.clearsFacets && this.searchStore.activeRefinements.length > 0) {
+        this.searchStore.clearRefinements();
+      }
+      this.searchStore.start();
     }
   }
+};
 </script>

--- a/packages/vue-instantsearch-clear/src/__tests__/index.js
+++ b/packages/vue-instantsearch-clear/src/__tests__/index.js
@@ -13,7 +13,7 @@ describe('Clear component', () => {
     activeRefinements: ['whatever'],
     stop,
     start,
-    clearRefinements,
+    clearRefinements
   };
 
   beforeEach(() => {
@@ -26,7 +26,7 @@ describe('Clear component', () => {
 
   test('can clear the search query and the facets at the same time', () => {
     const vm = new Component({
-      propsData: { searchStore },
+      propsData: { searchStore }
     });
 
     vm.clear();
@@ -39,7 +39,7 @@ describe('Clear component', () => {
   test('can disable query clearing', () => {
     searchStore.query = 'whatever';
     const vm = new Component({
-      propsData: { searchStore, clearsQuery: false },
+      propsData: { searchStore, clearsQuery: false }
     });
     vm.clear();
     expect(searchStore.query).toEqual('whatever');
@@ -51,7 +51,7 @@ describe('Clear component', () => {
   test('can disable facets clearing', () => {
     searchStore.query = 'whatever';
     const vm = new Component({
-      propsData: { searchStore, clearsFacets: false },
+      propsData: { searchStore, clearsFacets: false }
     });
     vm.clear();
     expect(searchStore.query).toEqual('');
@@ -62,7 +62,7 @@ describe('Clear component', () => {
 
   test('has proper HTML rendering', () => {
     const vm = new Component({
-      propsData: { searchStore },
+      propsData: { searchStore }
     });
     vm.$mount();
 
@@ -73,7 +73,7 @@ describe('Clear component', () => {
     searchStore.query = '';
     searchStore.activeRefinements = [];
     const vm = new Component({
-      propsData: { searchStore },
+      propsData: { searchStore }
     });
     vm.$mount();
 


### PR DESCRIPTION
In both instantsearch.js and react-instantsearch we use clearsQuery, not clearQuery. This spelling makes more sense to me.

The default is false in both other implementations, but it makes sense to have a 'clear start' here.