### PR TITLE
Update search-box.md

### DIFF
--- a/docs/components/search-box.md
+++ b/docs/components/search-box.md
@@ -8,7 +8,7 @@ A search input with a clear and submit button.
 Basic usage:
 
 ```html
-<ais-search-box :placeholder="Find products..."></ais-search-box>
+<ais-search-box placeholder="Find products..."></ais-search-box>
 ```
 
 ## Props


### PR DESCRIPTION
`placeholder` cannot use `v-bind:` here because it tries to interpret `Find products...` as JavaScript.
Removed the binding because there's no point in binding here anyway.