### PR TITLE
Update no-results.md

### DIFF
--- a/docs/components/no-results.md
+++ b/docs/components/no-results.md
@@ -8,7 +8,7 @@ A convenience component that will only be showed when no results are to be yield
 Basic usage:
 
 ```html
-<no-results></no-results>
+<ais-no-results></ais-no-results>
 ```
 
 Overriding the default content:


### PR DESCRIPTION
Component tag was missing the `ais-` prefix in the first example