### PR TITLE
Ensure page never drops below 1 in pagination component

### DIFF
--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -3,6 +3,8 @@ Vue InstantSearch Pagination
 
 A component to navigate between results pages.
 
+If there are no results in the current search context, pagination will be hidden.
+
 ## Usage
 
 Basic usage:

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -90,10 +90,7 @@ export default {
   },
   methods: {
     goToPage(page) {
-      let p = page;
-      if (page <= 1) {
-        p = 1;
-      }
+      const p = Math.max(1, page);
       this.searchStore.page = Math.min(this.totalPages, p);
     },
     goToFirstPage() {

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -87,7 +87,11 @@ export default {
   },
   methods: {
     goToPage(page) {
-      this.searchStore.page = Math.min(this.totalPages, page);
+      let p = page;
+      if (page <= 1) {
+        p = 1;
+      }
+      this.searchStore.page = Math.min(this.totalPages, p);
     },
     goToFirstPage() {
       this.goToPage(1);

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul :class="bem()">
+  <ul :class="bem()" v-show="totalResults > 0">
     <li :class="[bem('item', 'first'), page === 1 ? bem('item', 'disabled') : '']">
       <a href="#" @click.prevent="goToFirstPage">
         <slot name="first">&lt;&lt;</slot>
@@ -83,6 +83,9 @@ export default {
       }
 
       return pages;
+    },
+    totalResults() {
+      return this.searchStore.totalResults;
     },
   },
   methods: {

--- a/src/components/__tests__/__snapshots__/pagination.js.snap
+++ b/src/components/__tests__/__snapshots__/pagination.js.snap
@@ -52,6 +52,70 @@ exports[`accepts custom padding 1`] = `
 
 `;
 
+exports[`it should be hidden if there are no results in the current context 1`] = `
+
+<ul class="ais-pagination"
+    style="display: none;"
+>
+  <li class="ais-pagination__item ais-pagination__item--first ais-pagination__item ais-pagination__item--disabled">
+    <a href="#">
+      &lt;&lt;
+    </a>
+  </li>
+  <li class="ais-pagination__item ais-pagination__item--previous ais-pagination__item ais-pagination__item--disabled">
+    <a href="#">
+      &lt;
+    </a>
+  </li>
+  <li class="ais-pagination__item ais-pagination__item ais-pagination__item--active">
+    <a href="#">
+      1
+    </a>
+  </li>
+  <li class="ais-pagination__item">
+    <a href="#">
+      2
+    </a>
+  </li>
+  <li class="ais-pagination__item">
+    <a href="#">
+      3
+    </a>
+  </li>
+  <li class="ais-pagination__item">
+    <a href="#">
+      4
+    </a>
+  </li>
+  <li class="ais-pagination__item">
+    <a href="#">
+      5
+    </a>
+  </li>
+  <li class="ais-pagination__item">
+    <a href="#">
+      6
+    </a>
+  </li>
+  <li class="ais-pagination__item">
+    <a href="#">
+      7
+    </a>
+  </li>
+  <li class="ais-pagination__item ais-pagination__item--next">
+    <a href="#">
+      &gt;
+    </a>
+  </li>
+  <li class="ais-pagination__item ais-pagination__item--last">
+    <a href="#">
+      &gt;&gt;
+    </a>
+  </li>
+</ul>
+
+`;
+
 exports[`renders proper HTML 1`] = `
 
 <ul class="ais-pagination">

--- a/src/components/__tests__/__snapshots__/pagination.js.snap
+++ b/src/components/__tests__/__snapshots__/pagination.js.snap
@@ -1,0 +1,115 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`accepts custom padding 1`] = `
+
+<ul class="ais-pagination">
+  <li class="ais-pagination__item ais-pagination__item--first">
+    <a href="#">
+      &lt;&lt;
+    </a>
+  </li>
+  <li class="ais-pagination__item ais-pagination__item--previous">
+    <a href="#">
+      &lt;
+    </a>
+  </li>
+  <li class="ais-pagination__item">
+    <a href="#">
+      3
+    </a>
+  </li>
+  <li class="ais-pagination__item">
+    <a href="#">
+      4
+    </a>
+  </li>
+  <li class="ais-pagination__item ais-pagination__item ais-pagination__item--active">
+    <a href="#">
+      5
+    </a>
+  </li>
+  <li class="ais-pagination__item">
+    <a href="#">
+      6
+    </a>
+  </li>
+  <li class="ais-pagination__item">
+    <a href="#">
+      7
+    </a>
+  </li>
+  <li class="ais-pagination__item ais-pagination__item--next">
+    <a href="#">
+      &gt;
+    </a>
+  </li>
+  <li class="ais-pagination__item ais-pagination__item--last">
+    <a href="#">
+      &gt;&gt;
+    </a>
+  </li>
+</ul>
+
+`;
+
+exports[`renders proper HTML 1`] = `
+
+<ul class="ais-pagination">
+  <li class="ais-pagination__item ais-pagination__item--first">
+    <a href="#">
+      &lt;&lt;
+    </a>
+  </li>
+  <li class="ais-pagination__item ais-pagination__item--previous">
+    <a href="#">
+      &lt;
+    </a>
+  </li>
+  <li class="ais-pagination__item">
+    <a href="#">
+      1
+    </a>
+  </li>
+  <li class="ais-pagination__item ais-pagination__item ais-pagination__item--active">
+    <a href="#">
+      2
+    </a>
+  </li>
+  <li class="ais-pagination__item">
+    <a href="#">
+      3
+    </a>
+  </li>
+  <li class="ais-pagination__item">
+    <a href="#">
+      4
+    </a>
+  </li>
+  <li class="ais-pagination__item">
+    <a href="#">
+      5
+    </a>
+  </li>
+  <li class="ais-pagination__item">
+    <a href="#">
+      6
+    </a>
+  </li>
+  <li class="ais-pagination__item">
+    <a href="#">
+      7
+    </a>
+  </li>
+  <li class="ais-pagination__item ais-pagination__item--next">
+    <a href="#">
+      &gt;
+    </a>
+  </li>
+  <li class="ais-pagination__item ais-pagination__item--last">
+    <a href="#">
+      &gt;&gt;
+    </a>
+  </li>
+</ul>
+
+`;

--- a/src/components/__tests__/pagination.js
+++ b/src/components/__tests__/pagination.js
@@ -5,6 +5,7 @@ test('renders proper HTML', () => {
   const searchStore = {
     page: 2,
     totalPages: 10,
+    totalResults: 4000,
   };
   const Component = Vue.extend(Pagination);
   const vm = new Component({
@@ -21,6 +22,7 @@ test('accepts custom padding', () => {
   const searchStore = {
     page: 5,
     totalPages: 10,
+    totalResults: 4000,
   };
   const Component = Vue.extend(Pagination);
   const vm = new Component({
@@ -38,6 +40,7 @@ test('it should not try to go to a previous page that would be inferior to 1', (
   const searchStore = {
     page: 1,
     totalPages: 20,
+    totalResults: 4000,
   };
   const Component = Vue.extend(Pagination);
   const vm = new Component({
@@ -55,6 +58,7 @@ test('it should not try to go to a next page that would be superior to total exi
   const searchStore = {
     page: 20,
     totalPages: 20,
+    totalResults: 4000,
   };
   const Component = Vue.extend(Pagination);
   const vm = new Component({
@@ -66,4 +70,22 @@ test('it should not try to go to a next page that would be superior to total exi
   vm.goToNextPage();
 
   expect(searchStore.page).toEqual(20);
+});
+
+test('it should be hidden if there are no results in the current context', () => {
+  const searchStore = {
+    page: 1,
+    totalPages: 20,
+    totalResults: 0,
+  };
+  const Component = Vue.extend(Pagination);
+  const vm = new Component({
+    propsData: {
+      searchStore,
+    },
+  });
+
+  vm.$mount();
+
+  expect(vm.$el.outerHTML).toMatchSnapshot();
 });

--- a/src/components/__tests__/pagination.js
+++ b/src/components/__tests__/pagination.js
@@ -1,0 +1,39 @@
+import Vue from 'vue';
+import { Pagination } from 'vue-instantsearch';
+
+test('renders proper HTML', () => {
+  const goToPage = jest.fn();
+  const searchStore = {
+    page: 2,
+    totalPages: 10,
+    goToPage,
+  };
+  const Component = Vue.extend(Pagination);
+  const vm = new Component({
+    propsData: {
+      searchStore,
+    },
+  });
+  vm.$mount();
+
+  expect(vm.$el.outerHTML).toMatchSnapshot();
+});
+
+test('accepts custom padding', () => {
+  const goToPage = jest.fn();
+  const searchStore = {
+    page: 5,
+    totalPages: 10,
+    goToPage,
+  };
+  const Component = Vue.extend(Pagination);
+  const vm = new Component({
+    propsData: {
+      padding: 2,
+      searchStore,
+    },
+  });
+  vm.$mount();
+
+  expect(vm.$el.outerHTML).toMatchSnapshot();
+});

--- a/src/components/__tests__/pagination.js
+++ b/src/components/__tests__/pagination.js
@@ -2,11 +2,9 @@ import Vue from 'vue';
 import { Pagination } from 'vue-instantsearch';
 
 test('renders proper HTML', () => {
-  const goToPage = jest.fn();
   const searchStore = {
     page: 2,
     totalPages: 10,
-    goToPage,
   };
   const Component = Vue.extend(Pagination);
   const vm = new Component({
@@ -20,11 +18,9 @@ test('renders proper HTML', () => {
 });
 
 test('accepts custom padding', () => {
-  const goToPage = jest.fn();
   const searchStore = {
     page: 5,
     totalPages: 10,
-    goToPage,
   };
   const Component = Vue.extend(Pagination);
   const vm = new Component({
@@ -36,4 +32,38 @@ test('accepts custom padding', () => {
   vm.$mount();
 
   expect(vm.$el.outerHTML).toMatchSnapshot();
+});
+
+test('it should not try to go to a previous page that would be inferior to 1', () => {
+  const searchStore = {
+    page: 1,
+    totalPages: 20,
+  };
+  const Component = Vue.extend(Pagination);
+  const vm = new Component({
+    propsData: {
+      searchStore,
+    },
+  });
+
+  vm.goToPreviousPage();
+
+  expect(searchStore.page).toEqual(1);
+});
+
+test('it should not try to go to a next page that would be superior to total existing pages', () => {
+  const searchStore = {
+    page: 20,
+    totalPages: 20,
+  };
+  const Component = Vue.extend(Pagination);
+  const vm = new Component({
+    propsData: {
+      searchStore,
+    },
+  });
+
+  vm.goToNextPage();
+
+  expect(searchStore.page).toEqual(20);
 });


### PR DESCRIPTION
Makes sure pagination never goes below 1.
Also hides the pagination component if there are not search results in the current context. Thanks @olance for spotting that weird behaviour 👍 

fixes #182