### PR TITLE
fix(store): catch errors on facet values retrieval

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -283,12 +283,15 @@ export class Store {
       return [];
     }
 
-    // Todo: make sure the attribute is already added.
-    // Todo: Not sure this should be here because will make it very hard to debug I suppose.
+    let values;
+    try {
+      values = this._helper.lastResults.getFacetValues(attribute, {
+        sortBy,
+      });
+    } catch (e) {
+      values = [];
+    }
 
-    const values = this._helper.lastResults.getFacetValues(attribute, {
-      sortBy,
-    });
     if (limit === -1) {
       return values;
     }


### PR DESCRIPTION
This solves the following scenario:

**Issue solved:**
1. create a new store
2. start it and get the first results
3. dynamically register a facet
4. component will try to getFacetValues out of the previous results that do not have facet values yet

**Solution:**
We catch the exception when trying to get the facet values out of the helper.lastResults.


Closes: #184 

cc @olance 