### PR TITLE
feat(pagination): emit pageChanged event

### DIFF
--- a/docs/docgen/src/components/pagination.md
+++ b/docs/docgen/src/components/pagination.md
@@ -39,13 +39,13 @@ Scroll to the top of the page after a page was changed:
 
 ## Slots
 
-| Name     | Props        | Default                           | Description        |
-|----------|--------------|-----------------------------------|--------------------|
-| first    |              | `&lt;&lt;`                        | First page text    |
-| previous |              | `&lt;`                            | Previous page text |
-| default  | active, item | {% raw %}`{{ item }}`{% endraw %} | Page text          |
-| next     |              | `&gt;`                            | Next page text     |
-| last     |              | `&gt;&gt;`                        | Last page text     |
+| Name     | Props        | Default      | Description        |
+|----------|--------------|--------------|--------------------|
+| first    |              | `&lt;&lt;`   | First page text    |
+| previous |              | `&lt;`       | Previous page text |
+| default  | active, item | `{{ item }}` | Page text          |
+| next     |              | `&gt;`       | Next page text     |
+| last     |              | `&gt;&gt;`   | Last page text     |
 
 ## CSS Classes
 

--- a/docs/docgen/src/components/pagination.md
+++ b/docs/docgen/src/components/pagination.md
@@ -27,8 +27,21 @@ Customize the number of pages to display around the active one:
 
 Scroll to the top of the page after a page was changed:
 
-```html
-<ais-pagination v-on:page-change="window.scrollTo(0, 0)"></ais-pagination>
+```vue
+<template>
+    <!-- ... -->
+    <ais-pagination v-on:page-change="onPageChange"></ais-pagination>
+    <!-- ... -->
+</template>
+<script>
+  export default {
+    methods: {
+      onPageChange() {
+        window.scrollTo(0,0);
+      }
+    }
+  }
+</script>
 ```
 
 ## Props
@@ -41,11 +54,11 @@ Scroll to the top of the page after a page was changed:
 
 | Name     | Props        | Default      | Description        |
 |----------|--------------|--------------|--------------------|
-| first    |              | `&lt;&lt;`   | First page text    |
-| previous |              | `&lt;`       | Previous page text |
+| first    |              | `<<`         | First page text    |
+| previous |              | `<`          | Previous page text |
 | default  | active, item | `{{ item }}` | Page text          |
-| next     |              | `&gt;`       | Next page text     |
-| last     |              | `&gt;&gt;`   | Last page text     |
+| next     |              | `>`          | Next page text     |
+| last     |              | `>>`         | Last page text     |
 
 ## CSS Classes
 

--- a/docs/docgen/src/components/pagination.md
+++ b/docs/docgen/src/components/pagination.md
@@ -25,16 +25,22 @@ Customize the number of pages to display around the active one:
 <ais-pagination :padding="5"></ais-pagination>
 ```
 
+Scroll to the top of the page after a page was changed:
+
+```html
+<ais-pagination v-on:page-change="window.scrollTo(0, 0)"></ais-pagination>
+```
+
 ## Props
 
 | Name    | Type   | Default | Description                                       |
-|:--------|:-------|:--------|:--------------------------------------------------|
+|---------|--------|---------|---------------------------------------------------|
 | padding | Number | `3`     | Number of pages to display around the active page |
 
 ## Slots
 
 | Name     | Props        | Default                           | Description        |
-|:---------|:-------------|:----------------------------------|:-------------------|
+|----------|--------------|-----------------------------------|--------------------|
 | first    |              | `&lt;&lt;`                        | First page text    |
 | previous |              | `&lt;`                            | Previous page text |
 | default  | active, item | {% raw %}`{{ item }}`{% endraw %} | Page text          |
@@ -44,10 +50,16 @@ Customize the number of pages to display around the active one:
 ## CSS Classes
 
 | ClassName                      | Description        |
-|:-------------------------------|:-------------------|
+|--------------------------------|--------------------|
 | ais-pagination                 | Container class    |
 | ais-pagination__item           | Page link item     |
 | ais-pagination__item--first    | First link item    |
 | ais-pagination__item--previous | Previous link item |
 | ais-pagination__item--next     | Next link item     |
 | ais-pagination__item--last     | Last link item     |
+
+## Events
+
+| Event name  | Description                                                                                  |
+|-------------|----------------------------------------------------------------------------------------------|
+| page-change | Triggered right after a page was changed due to an action taken on the pagination component. |

--- a/docs/docgen/syntaxHighlighting.js
+++ b/docs/docgen/syntaxHighlighting.js
@@ -6,6 +6,7 @@ import 'codemirror/mode/jsx/jsx';
 import 'codemirror/mode/htmlmixed/htmlmixed';
 import 'codemirror/mode/javascript/javascript';
 import 'codemirror/mode/shell/shell';
+import 'codemirror/mode/vue/vue';
 import escape from 'escape-html';
 
 export default function highlight(source, lang = 'javascript', inline = false) {

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -90,8 +90,13 @@ export default {
   },
   methods: {
     goToPage(page) {
-      const p = Math.max(1, page);
-      this.searchStore.page = Math.min(this.totalPages, p);
+      let p = Math.max(1, page);
+      p = Math.min(this.totalPages, p);
+      if (this.searchStore.page === p) {
+        return;
+      }
+      this.searchStore.page = p;
+      this.$emit('page-change');
     },
     goToFirstPage() {
       this.goToPage(1);

--- a/src/components/__tests__/pagination.js
+++ b/src/components/__tests__/pagination.js
@@ -89,3 +89,27 @@ test('it should be hidden if there are no results in the current context', () =>
 
   expect(vm.$el.outerHTML).toMatchSnapshot();
 });
+
+test('it should emit a "page-change" event when page changes', () => {
+  const searchStore = {
+    page: 1,
+    totalPages: 20,
+    totalResults: 4000,
+  };
+  const Component = Vue.extend(Pagination);
+  const vm = new Component({
+    propsData: {
+      searchStore,
+    },
+  });
+
+  const onPageChange = jest.fn();
+  vm.$on('page-change', onPageChange);
+
+  vm.$mount();
+
+  expect(onPageChange).not.toHaveBeenCalled();
+
+  vm.$el.getElementsByTagName('li')[3].getElementsByTagName('a')[0].click();
+  expect(onPageChange).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
allows to listen for page change and to act upon it for example for scrolling to the top of the page.

Closes: #231

**WIP:**
- [x] emit new event
- [x] define a convention for event names (page-change, pageChange) also see https://github.com/vuejs/vue/issues/4044 & https://github.com/pablohpsilva/vuejs-component-style-guide#component-event-names
- [x] add tests
- [x] add documentation + example