### PR TITLE
docs(highlighting): remove unused languages

### DIFF
--- a/docs/docgen/syntaxHighlighting.js
+++ b/docs/docgen/syntaxHighlighting.js
@@ -1,8 +1,4 @@
 import {runMode} from 'codemirror/addon/runmode/runmode.node';
-import 'codemirror/mode/groovy/groovy';
-import 'codemirror/mode/xml/xml';
-import 'codemirror/mode/clike/clike';
-import 'codemirror/mode/jsx/jsx';
 import 'codemirror/mode/htmlmixed/htmlmixed';
 import 'codemirror/mode/javascript/javascript';
 import 'codemirror/mode/shell/shell';


### PR DESCRIPTION
AFAIK, these languages aren’t used, unless I misunderstood something. Let’s check it in the deploy preview