### PR TITLE
Make all components SSR ready

### DIFF
--- a/docs/docgen/src/components/index.md
+++ b/docs/docgen/src/components/index.md
@@ -51,8 +51,8 @@ Provide search query parameters:
 | index-name       | String  | ``      | The index name                                                                                                                                     |
 | query            | String  | ``      | The search query                                                                                                                                   |
 | query-parameters | Object  | ``      | The search query parameters. Available options are [documented here](https://www.algolia.com/doc/api-client/javascript/search/#search-parameters). |
-| cache            | Boolean | `true`  | Wether to cache results or not. See: https://www.algolia.com/doc/tutorials/getting-started/quick-start-with-the-api-client/javascript/#cache       |
-| auto-search      | Boolean | `true`  | Wether to initiate a query to Algolia when this component is mounted                                                                               |
+| cache            | Boolean | `true`  | Whether to cache results or not. See: https://www.algolia.com/doc/tutorials/getting-started/quick-start-with-the-api-client/javascript/#cache       |
+| auto-search      | Boolean | `true`  | Whether to initiate a query to Algolia when this component is mounted                                                                               |
 
 ## Slots
 

--- a/docs/docgen/src/components/index.md
+++ b/docs/docgen/src/components/index.md
@@ -52,6 +52,7 @@ Provide search query parameters:
 | query            | String  | ``      | The search query                                                                                                                                   |
 | query-parameters | Object  | ``      | The search query parameters. Available options are [documented here](https://www.algolia.com/doc/api-client/javascript/search/#search-parameters). |
 | cache            | Boolean | `true`  | Wether to cache results or not. See: https://www.algolia.com/doc/tutorials/getting-started/quick-start-with-the-api-client/javascript/#cache       |
+| auto-search      | Boolean | `true`  | Wether to initiate a query to Algolia when this component is mounted                                                                               |
 
 ## Slots
 

--- a/docs/docgen/src/getting-started/custom-components.md
+++ b/docs/docgen/src/getting-started/custom-components.md
@@ -77,7 +77,7 @@ To ensure consistency and re-usability for custom components, we recommend revie
 ### Vue component
 
 * Use the `Component` mixin that we provide. This will make sure your component can resolve the `searchStore` if not provided. It ensures the `searchStore` prop is available in your component at any time.
-* If you need to mutate the `searchStore` multiple times, please use `searchStore.stop()` and `searchStore.start()`, so that other components don't update their rendering on every intermediary state mutation.
+* If you need to mutate the `searchStore` multiple times, please use `searchStore.stop()` and `searchStore.start()`, so that other components don't update their rendering on every intermediary state mutation. Do not forget the `searchStore.refresh()` if you want to sync the store afterwards.
 * Make sure that when the component is mounted, you catch up with the `searchStore`. You can optionally mutate the state of the `searchStore` at this stage.
 * When a component is `unmounted` or `destroyed`, make sure that you leave the `searchStore` in a state that does not include things you might have added (facets / filters / etc.).
 * Make sure your component gracefully handles any state of the `searchStore`.

--- a/docs/docgen/src/getting-started/search-store.md
+++ b/docs/docgen/src/getting-started/search-store.md
@@ -133,11 +133,13 @@ store.query = '';
 store.queryParameters({'distinct': true});
 
 store.start();
+store.refresh();
 ```
 
-In this example, even if the state is mutated several times, only one call to Algolia will be made after the Store is resumed by the `start()` call.
+In this example, even if the state is mutated several times, only one call to Algolia will be made after the Store is resumed by the `start()` and `refresh()` calls.
 
-**Important:** When you manually create a search store, it is stopped by default. You need to manually call `start()` to trigger the first call. This gives you full control over the initial state of the store before the first call to Algolia is sent.
+**Important:** When you manually create a search store, it is stopped by default. You need to manually call `start()` and `refresh()` to trigger the first call. This gives you full control over the initial state of the store before the first call to Algolia is sent.
+If you pass the store as a prop to an `<ais-index>` component though, it will be started and refreshed when mounted.
 
 ```javascript
 import { createFromAlgoliaCredentials } from 'vue-instantsearch';
@@ -145,6 +147,7 @@ import { createFromAlgoliaCredentials } from 'vue-instantsearch';
 const store = createFromAlgoliaCredentials('appId', 'search_apiKey');
 store.indexName = 'new_index';
 store.start();
+store.refresh();
 ```
 
 In the example above, the first query will be sent to Algolia after `store.start()` has been called.

--- a/src/__tests__/store.js
+++ b/src/__tests__/store.js
@@ -421,6 +421,7 @@ describe('Store', () => {
         return { clearCache };
       },
     };
+    store.start();
     store.disableCache();
     store.refresh();
     expect(clearCache).toHaveBeenCalledTimes(1);

--- a/src/components/Clear.vue
+++ b/src/components/Clear.vue
@@ -55,6 +55,7 @@ export default {
         this.searchStore.clearRefinements();
       }
       this.searchStore.start();
+      this.searchStore.refresh();
     },
   },
 };

--- a/src/components/Index.vue
+++ b/src/components/Index.vue
@@ -60,7 +60,7 @@ export default {
     autoSearch: {
       type: Boolean,
       default: true,
-    }
+    },
   },
   data() {
     return {

--- a/src/components/Index.vue
+++ b/src/components/Index.vue
@@ -57,6 +57,10 @@ export default {
       type: Boolean,
       default: true,
     },
+    autoSearch: {
+      type: Boolean,
+      default: true,
+    }
   },
   data() {
     return {
@@ -97,6 +101,9 @@ export default {
   },
   mounted() {
     this._localSearchStore.start();
+    if (this.autoSearch) {
+      this._localSearchStore.refresh();
+    }
   },
   watch: {
     indexName() {

--- a/src/components/Input.vue
+++ b/src/components/Input.vue
@@ -32,6 +32,7 @@ export default {
         // without triggering in between ghost queries.
         this.$nextTick(function() {
           this.searchStore.start();
+          this.searchStore.refresh();
         });
       },
     },

--- a/src/components/PriceRange.vue
+++ b/src/components/PriceRange.vue
@@ -95,6 +95,7 @@ export default {
         }
 
         this.searchStore.start();
+        this.searchStore.refresh();
       },
     },
     to: {
@@ -125,6 +126,7 @@ export default {
           this.searchStore.addNumericRefinement(this.attributeName, '<', value);
         }
         this.searchStore.start();
+        this.searchStore.refresh();
       },
     },
   },

--- a/src/components/Rating.vue
+++ b/src/components/Rating.vue
@@ -141,6 +141,7 @@ export default {
         this.searchStore.addFacetRefinement(this.attributeName, val);
       }
       this.searchStore.start();
+      this.searchStore.refresh();
       return undefined;
     },
     clear() {

--- a/src/components/Rating.vue
+++ b/src/components/Rating.vue
@@ -51,7 +51,7 @@ export default {
       blockClassName: 'ais-rating',
     };
   },
-  mounted() {
+  created() {
     this.searchStore.addFacet(this.attributeName, FACET_OR);
   },
   destroyed() {

--- a/src/components/RefinementList.vue
+++ b/src/components/RefinementList.vue
@@ -58,7 +58,7 @@ export default {
       blockClassName: 'ais-refinement-list',
     };
   },
-  mounted() {
+  created() {
     this.searchStore.addFacet(this.attributeName, this.operator);
   },
   destroyed() {

--- a/src/components/Results.vue
+++ b/src/components/Results.vue
@@ -30,7 +30,7 @@ export default {
       blockClassName: 'ais-results',
     };
   },
-  mounted() {
+  created() {
     this.updateResultsPerPage();
   },
   watch: {

--- a/src/components/ResultsPerPageSelector.vue
+++ b/src/components/ResultsPerPageSelector.vue
@@ -33,7 +33,7 @@ export default {
       },
     },
   },
-  mounted() {
+  created() {
     if (this.options.indexOf(this.searchStore.resultsPerPage) === -1) {
       this.searchStore.resultsPerPage = this.options[0];
     }

--- a/src/components/SortBySelector.vue
+++ b/src/components/SortBySelector.vue
@@ -33,7 +33,7 @@ export default {
       },
     },
   },
-  mounted() {
+  created() {
     let match = false;
     for (const index in this.indices) {
       if (this.indices[index].name === this.indexName) {

--- a/src/components/TreeMenu.vue
+++ b/src/components/TreeMenu.vue
@@ -31,7 +31,7 @@ export default {
       blockClassName: 'ais-tree-menu',
     };
   },
-  mounted() {
+  created() {
     this.searchStore.addFacet(
       {
         name: this.attribute,

--- a/src/components/__tests__/__snapshots__/sort-by-selector.js.snap
+++ b/src/components/__tests__/__snapshots__/sort-by-selector.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders proper HTML 1`] = `
+
+<select class="ais-sort-by-selector">
+  <option value="index1">
+    label1
+  </option>
+  <option value="index2">
+    label2
+  </option>
+</select>
+
+`;

--- a/src/components/__tests__/clear.js
+++ b/src/components/__tests__/clear.js
@@ -7,6 +7,7 @@ describe('Clear component', () => {
   const stop = jest.fn();
   const start = jest.fn();
   const clearRefinements = jest.fn();
+  const refresh = jest.fn();
 
   const searchStore = {
     query: 'whatever',
@@ -14,12 +15,14 @@ describe('Clear component', () => {
     stop,
     start,
     clearRefinements,
+    refresh,
   };
 
   beforeEach(() => {
     stop.mockClear();
     start.mockClear();
     clearRefinements.mockClear();
+    refresh.mockClear();
     searchStore.query = 'whatever';
     searchStore.activeRefinements = ['whatever'];
   });
@@ -34,6 +37,7 @@ describe('Clear component', () => {
     expect(stop).toHaveBeenCalledTimes(1);
     expect(clearRefinements).toHaveBeenCalledTimes(1);
     expect(start).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
   });
 
   test('can disable query clearing', () => {
@@ -46,6 +50,7 @@ describe('Clear component', () => {
     expect(stop).toHaveBeenCalledTimes(1);
     expect(clearRefinements).toHaveBeenCalledTimes(1);
     expect(start).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
   });
 
   test('can disable facets clearing', () => {
@@ -58,6 +63,7 @@ describe('Clear component', () => {
     expect(stop).toHaveBeenCalledTimes(1);
     expect(clearRefinements).not.toHaveBeenCalled();
     expect(start).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
   });
 
   test('has proper HTML rendering', () => {

--- a/src/components/__tests__/menu-tree.js
+++ b/src/components/__tests__/menu-tree.js
@@ -55,15 +55,13 @@ test('should add a tree facet to the store when mounted', () => {
   const Component = Vue.extend(TreeMenu);
   const addFacetMock = jest.fn();
   const store = Object.assign({}, searchStore, { addFacet: addFacetMock });
-  const vm = new Component({
+  new Component({ // eslint-disable-line
     propsData: {
       attributes: ['category.lvl1', 'category.lvl2'],
       searchStore: store,
     },
   });
 
-  expect(addFacetMock).not.toBeCalled();
-  vm.$mount();
   expect(addFacetMock).toBeCalledWith(
     {
       name: 'tree-menu',

--- a/src/components/__tests__/refinement-list.js
+++ b/src/components/__tests__/refinement-list.js
@@ -32,7 +32,7 @@ test('renders proper HTML', () => {
   expect(vm.$el.outerHTML).toMatchSnapshot();
 });
 
-test('should add a facet to the store when mounted', () => {
+test('should add a facet to the store when created', () => {
   const Component = Vue.extend(RefinementList);
   const addFacetMock = jest.fn();
   const store = Object.assign({}, searchStore, { addFacet: addFacetMock });

--- a/src/components/__tests__/refinement-list.js
+++ b/src/components/__tests__/refinement-list.js
@@ -36,15 +36,12 @@ test('should add a facet to the store when mounted', () => {
   const Component = Vue.extend(RefinementList);
   const addFacetMock = jest.fn();
   const store = Object.assign({}, searchStore, { addFacet: addFacetMock });
-  const vm = new Component({
+  new Component({ // eslint-disable-line
     propsData: {
       attributeName: 'color',
       searchStore: store,
     },
   });
-
-  expect(addFacetMock).not.toBeCalled();
-  vm.$mount();
   expect(addFacetMock).toBeCalledWith('color', 'or');
 });
 

--- a/src/components/__tests__/sort-by-selector.js
+++ b/src/components/__tests__/sort-by-selector.js
@@ -1,0 +1,64 @@
+import Vue from 'vue';
+import SortBySelector from '../SortBySelector.vue';
+
+test('renders proper HTML', () => {
+  const searchStore = {};
+  const Component = Vue.extend(SortBySelector);
+  const vm = new Component({
+    propsData: {
+      searchStore,
+      indices: [
+        { name: 'index1', label: 'label1' },
+        { name: 'index2', label: 'label2' },
+      ],
+    },
+  });
+  vm.$mount();
+
+  expect(vm.$el.outerHTML).toMatchSnapshot();
+});
+
+test('should use current index name in search store if it is a valid option', () => {
+  const searchStore = {
+    indexName: 'index2',
+  };
+  const Component = Vue.extend(SortBySelector);
+  const vm = new Component({
+    propsData: {
+      searchStore,
+      indices: [
+        { name: 'index1', label: 'label1' },
+        { name: 'index2', label: 'label2' },
+      ],
+    },
+  });
+
+  expect(vm.searchStore.indexName).toEqual('index2');
+
+  vm.$mount();
+
+  expect(vm.$el.getElementsByTagName('option')[0].selected).toEqual(false);
+  expect(vm.$el.getElementsByTagName('option')[1].selected).toEqual(true);
+});
+
+test('should use first index if current index name is not a valid option', () => {
+  const searchStore = {
+    indexName: 'index3',
+  };
+  const Component = Vue.extend(SortBySelector);
+  const vm = new Component({
+    propsData: {
+      searchStore,
+      indices: [
+        { name: 'index1', label: 'label1' },
+        { name: 'index2', label: 'label2' },
+      ],
+    },
+  });
+
+  expect(vm.searchStore.indexName).toEqual('index1');
+
+  vm.$mount();
+
+  expect(vm.$el.getElementsByTagName('option')[0].selected).toEqual(true);
+});

--- a/src/store.js
+++ b/src/store.js
@@ -200,7 +200,9 @@ export class Store {
   }
 
   addFacet(attribute, type = FACET_AND) {
-    assertValidFacetType(type);
+    if (this.hasFacet(attribute, type)) {
+      return;
+    }
 
     this.stop();
 
@@ -242,6 +244,21 @@ export class Store {
     }
 
     this._helper.setState(state);
+  }
+
+  hasFacet(attribute, type = FACET_AND) {
+    assertValidFacetType(type);
+
+    switch (type) {
+      case FACET_AND:
+        return this._helper.state.isConjunctiveFacet(attribute);
+      case FACET_OR:
+        return this._helper.state.isDisjunctiveFacet(attribute);
+      case FACET_TREE:
+        return this._helper.state.isHierarchicalFacet(attribute);
+      default:
+        throw new TypeError(`${type} could not be handled.`);
+    }
   }
 
   addFacetRefinement(attribute, value) {

--- a/src/store.js
+++ b/src/store.js
@@ -131,10 +131,6 @@ export class Store {
     } else {
       this._stoppedCounter--;
     }
-
-    if (this._stoppedCounter === 0) {
-      this.refresh();
-    }
   }
 
   stop() {
@@ -228,6 +224,7 @@ export class Store {
       this._helper.setState(state);
     }
     this.start();
+    this.refresh();
   }
 
   removeFacet(attribute) {
@@ -343,6 +340,7 @@ export class Store {
       delete params.page;
     }
     this.start();
+    this.refresh();
   }
 
   get queryParameters() {
@@ -374,6 +372,9 @@ export class Store {
   }
 
   refresh() {
+    if (this._stoppedCounter !== 0) {
+      return;
+    }
     if (this._cacheEnabled === false) {
       this.clearCache();
     }
@@ -424,9 +425,7 @@ export const assertValidFacetType = function(type) {
 };
 
 const onHelperChange = function() {
-  if (this._stoppedCounter === 0) {
-    this.refresh();
-  }
+  this.refresh();
 };
 
 const onHelperResult = function(response) {


### PR DESCRIPTION
This PR removes all usage of the `$mounted` lifecycle hook.
Only `created` and `beforeCreated` are used on the server side.

Remaining `destroyed` and `mounted` still makes sense (unless I forgot some).