### PR TITLE
Feat/add error on missing configuration

### DIFF
--- a/docs/src/components/highlight.md
+++ b/docs/src/components/highlight.md
@@ -15,10 +15,29 @@ but adds some sugar on top of it to prevent XSS attacks.
 
 ## Usage
 
-Basic usage:
+**Basic usage:**
 
 ```html
 <ais-highlight :result="result" attribute-name="description"></ais-highlight>
+```
+
+**Access a nested property:**
+
+Given an record like:
+
+```json
+{
+    "objectID": 1,
+    "meta": {
+        "title": "my title"
+    }
+}
+```
+
+You can access the highlighted version by specifying the path by separating levels with dots:
+
+```html
+<ais-highlight :result="result" attribute-name="meta.title"></ais-highlight>
 ```
 
 ## Props

--- a/docs/src/components/snippet.md
+++ b/docs/src/components/snippet.md
@@ -17,10 +17,29 @@ but adds some sugar on top of it to prevent XSS attacks.
 
 ## Usage
 
-Basic usage:
+**Basic usage:**
 
 ```html
 <ais-snippet :result="result" attribute-name="description"></ais-snippet>
+```
+
+**Access a nested property:**
+
+Given an record like:
+
+```json
+{
+    "objectID": 1,
+    "meta": {
+        "title": "my title"
+    }
+}
+```
+
+You can access the snippeted version by specifying the path by separating levels with dots:
+
+```html
+<ais-snippet :result="result" attribute-name="meta.title"></ais-snippet>
 ```
 
 ## Props

--- a/src/components/Highlight.js
+++ b/src/components/Highlight.js
@@ -17,6 +17,11 @@ export default {
     let attributeValue = '';
     if (result._highlightResult && result._highlightResult[attributeName]) {
       attributeValue = result._highlightResult[attributeName].value;
+    } else if (process.env.NODE_ENV !== 'production') {
+      throw new Error(
+        `The "${attributeName}" attribute is currently not configured to be highlighted in Algolia.
+        See https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight/.`
+      );
     }
 
     return h('span', {

--- a/src/components/Highlight.js
+++ b/src/components/Highlight.js
@@ -1,3 +1,6 @@
+const getProp = (obj, path) =>
+  path.split('.').reduce((acc, part) => acc && acc[part], obj);
+
 export default {
   functional: true,
   props: {
@@ -14,10 +17,10 @@ export default {
     const result = ctx.props.result;
     const attributeName = ctx.props.attributeName;
 
-    let attributeValue = '';
-    if (result._highlightResult && result._highlightResult[attributeName]) {
-      attributeValue = result._highlightResult[attributeName].value;
-    } else if (process.env.NODE_ENV !== 'production') {
+    const attributePath = `_highlightResult.${attributeName}.value`;
+    const attributeValue = getProp(result, attributePath);
+
+    if (process.env.NODE_ENV !== 'production' && attributeValue === undefined) {
       throw new Error(
         `The "${attributeName}" attribute is currently not configured to be highlighted in Algolia.
         See https://www.algolia.com/doc/api-reference/api-parameters/attributesToHighlight/.`

--- a/src/components/Highlight.js
+++ b/src/components/Highlight.js
@@ -1,5 +1,4 @@
-const getProp = (obj, path) =>
-  path.split('.').reduce((acc, part) => acc && acc[part], obj);
+import { getPropertyByPath } from '../util/object';
 
 export default {
   functional: true,
@@ -18,7 +17,7 @@ export default {
     const attributeName = ctx.props.attributeName;
 
     const attributePath = `_highlightResult.${attributeName}.value`;
-    const attributeValue = getProp(result, attributePath);
+    const attributeValue = getPropertyByPath(result, attributePath);
 
     if (process.env.NODE_ENV !== 'production' && attributeValue === undefined) {
       throw new Error(

--- a/src/components/Snippet.js
+++ b/src/components/Snippet.js
@@ -17,6 +17,11 @@ export default {
     let attributeValue = '';
     if (result._snippetResult && result._snippetResult[attributeName]) {
       attributeValue = result._snippetResult[attributeName].value;
+    } else if (process.env.NODE_ENV !== 'production') {
+      throw new Error(
+        `The "${attributeName}" attribute is currently not configured to be snippeted in Algolia.
+        See https://www.algolia.com/doc/api-reference/api-parameters/attributesToSnippet/.`
+      );
     }
 
     return h('span', {

--- a/src/components/Snippet.js
+++ b/src/components/Snippet.js
@@ -1,6 +1,4 @@
-const getProp = (obj, path) =>
-  path.split('.').reduce((acc, part) => acc && acc[part], obj);
-
+import { getPropertyByPath } from '../util/object';
 export default {
   functional: true,
   props: {
@@ -18,7 +16,7 @@ export default {
     const attributeName = ctx.props.attributeName;
 
     const attributePath = `_snippetResult.${attributeName}.value`;
-    const attributeValue = getProp(result, attributePath);
+    const attributeValue = getPropertyByPath(result, attributePath);
 
     if (process.env.NODE_ENV !== 'production' && attributeValue === undefined) {
       throw new Error(

--- a/src/components/Snippet.js
+++ b/src/components/Snippet.js
@@ -1,3 +1,6 @@
+const getProp = (obj, path) =>
+  path.split('.').reduce((acc, part) => acc && acc[part], obj);
+
 export default {
   functional: true,
   props: {
@@ -14,10 +17,10 @@ export default {
     const result = ctx.props.result;
     const attributeName = ctx.props.attributeName;
 
-    let attributeValue = '';
-    if (result._snippetResult && result._snippetResult[attributeName]) {
-      attributeValue = result._snippetResult[attributeName].value;
-    } else if (process.env.NODE_ENV !== 'production') {
+    const attributePath = `_snippetResult.${attributeName}.value`;
+    const attributeValue = getProp(result, attributePath);
+
+    if (process.env.NODE_ENV !== 'production' && attributeValue === undefined) {
       throw new Error(
         `The "${attributeName}" attribute is currently not configured to be snippeted in Algolia.
         See https://www.algolia.com/doc/api-reference/api-parameters/attributesToSnippet/.`

--- a/src/components/__tests__/__snapshots__/highlight.js.snap
+++ b/src/components/__tests__/__snapshots__/highlight.js.snap
@@ -12,7 +12,7 @@ exports[`renders proper HTML 1`] = `
 
 `;
 
-exports[`should render an empty string if attribute is not highlighted 1`] = `
+exports[`should render an empty string in production if attribute is not highlighted 1`] = `
 
 <span class="ais-highlight">
 </span>

--- a/src/components/__tests__/__snapshots__/highlight.js.snap
+++ b/src/components/__tests__/__snapshots__/highlight.js.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`allows usage of dot delimited path to access nested attribute 1`] = `
+
+<span class="ais-highlight">
+  nested
+  <em>
+    val
+  </em>
+</span>
+
+`;
+
 exports[`renders proper HTML 1`] = `
 
 <span class="ais-highlight">

--- a/src/components/__tests__/__snapshots__/snippet.js.snap
+++ b/src/components/__tests__/__snapshots__/snippet.js.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`allows usage of dot delimited path to access nested attribute 1`] = `
+
+<span class="ais-snippet">
+  nested
+  <em>
+    val
+  </em>
+</span>
+
+`;
+
 exports[`renders proper HTML 1`] = `
 
 <span class="ais-snippet">

--- a/src/components/__tests__/__snapshots__/snippet.js.snap
+++ b/src/components/__tests__/__snapshots__/snippet.js.snap
@@ -12,7 +12,7 @@ exports[`renders proper HTML 1`] = `
 
 `;
 
-exports[`should render an empty string if attribute is not snippeted 1`] = `
+exports[`should render an empty string in production if attribute is not snippeted 1`] = `
 
 <span class="ais-snippet">
 </span>

--- a/src/components/__tests__/highlight.js
+++ b/src/components/__tests__/highlight.js
@@ -1,6 +1,12 @@
 import Vue from 'vue';
 import Highlight from '../Highlight';
 
+function restoreTestProcessEnv() {
+  process.env.NODE_ENV = 'test';
+}
+
+afterEach(restoreTestProcessEnv);
+
 test('renders proper HTML', () => {
   const result = {
     _highlightResult: {
@@ -28,7 +34,8 @@ test('renders proper HTML', () => {
   expect(vm.$el.outerHTML).toMatchSnapshot();
 });
 
-test('should render an empty string if attribute is not highlighted', () => {
+test('should render an empty string in production if attribute is not highlighted', () => {
+  process.env.NODE_ENV = 'production';
   const result = {
     _highlightResult: {},
   };
@@ -49,4 +56,29 @@ test('should render an empty string if attribute is not highlighted', () => {
   }).$mount();
 
   expect(vm.$el.outerHTML).toMatchSnapshot();
+});
+
+test('should throw an error when not in production if attribute is not highlighted', () => {
+  global.console = { error: jest.fn() };
+
+  const result = {
+    _highlightResult: {},
+  };
+
+  new Vue({
+    template: '<highlight attributeName="attr" :result="result">',
+    render(h) {
+      return h('highlight', {
+        props: {
+          attributeName: 'attr',
+          result,
+        },
+      });
+    },
+    components: {
+      Highlight,
+    },
+  }).$mount();
+
+  expect(global.console.error).toHaveBeenCalled();
 });

--- a/src/components/__tests__/highlight.js
+++ b/src/components/__tests__/highlight.js
@@ -17,7 +17,6 @@ test('renders proper HTML', () => {
   };
 
   const vm = new Vue({
-    template: '<highlight attributeName="attr" :result="result">',
     render(h) {
       return h('highlight', {
         props: {
@@ -41,7 +40,6 @@ test('should render an empty string in production if attribute is not highlighte
   };
 
   const vm = new Vue({
-    template: '<highlight attributeName="attr" :result="result">',
     render(h) {
       return h('highlight', {
         props: {
@@ -66,7 +64,6 @@ test('should throw an error when not in production if attribute is not highlight
   };
 
   new Vue({
-    template: '<highlight attributeName="attr" :result="result">',
     render(h) {
       return h('highlight', {
         props: {
@@ -81,4 +78,32 @@ test('should throw an error when not in production if attribute is not highlight
   }).$mount();
 
   expect(global.console.error).toHaveBeenCalled();
+});
+
+test('allows usage of dot delimited path to access nested attribute', () => {
+  const result = {
+    _highlightResult: {
+      attr: {
+        nested: {
+          value: `nested <em>val</em>`,
+        },
+      },
+    },
+  };
+
+  const vm = new Vue({
+    render(h) {
+      return h('highlight', {
+        props: {
+          attributeName: 'attr.nested',
+          result,
+        },
+      });
+    },
+    components: {
+      Highlight,
+    },
+  }).$mount();
+
+  expect(vm.$el.outerHTML).toMatchSnapshot();
 });

--- a/src/components/__tests__/snippet.js
+++ b/src/components/__tests__/snippet.js
@@ -1,6 +1,13 @@
 import Vue from 'vue';
 import Snippet from '../Snippet';
 
+function restoreTestProcessEnv() {
+  process.env.NODE_ENV = 'test';
+}
+
+afterEach(restoreTestProcessEnv);
+
+
 test('renders proper HTML', () => {
   const result = {
     _snippetResult: {
@@ -28,7 +35,8 @@ test('renders proper HTML', () => {
   expect(vm.$el.outerHTML).toMatchSnapshot();
 });
 
-test('should render an empty string if attribute is not snippeted', () => {
+test('should render an empty string in production if attribute is not snippeted', () => {
+  process.env.NODE_ENV = 'production';
   const result = {
     _snippetResult: {},
   };
@@ -49,4 +57,29 @@ test('should render an empty string if attribute is not snippeted', () => {
   }).$mount();
 
   expect(vm.$el.outerHTML).toMatchSnapshot();
+});
+
+test('should throw an error when not in production if attribute is not snippeted', () => {
+  global.console = { error: jest.fn() };
+
+  const result = {
+    _snippetResult: {},
+  };
+
+  new Vue({
+    template: '<snippet attributeName="attr" :result="result">',
+    render(h) {
+      return h('snippet', {
+        props: {
+          attributeName: 'attr',
+          result,
+        },
+      });
+    },
+    components: {
+      Snippet,
+    },
+  }).$mount();
+
+  expect(global.console.error).toHaveBeenCalled();
 });

--- a/src/components/__tests__/snippet.js
+++ b/src/components/__tests__/snippet.js
@@ -17,7 +17,6 @@ test('renders proper HTML', () => {
   };
 
   const vm = new Vue({
-    template: '<snippet attributeName="attr" :result="result">',
     render(h) {
       return h('snippet', {
         props: {
@@ -41,7 +40,6 @@ test('should render an empty string in production if attribute is not snippeted'
   };
 
   const vm = new Vue({
-    template: '<snippet attributeName="attr" :result="result">',
     render(h) {
       return h('snippet', {
         props: {
@@ -59,14 +57,13 @@ test('should render an empty string in production if attribute is not snippeted'
 });
 
 test('should throw an error when not in production if attribute is not snippeted', () => {
-  global.console = { error: jest.fn() };
+  global.console.error = jest.fn();
 
   const result = {
     _snippetResult: {},
   };
 
   new Vue({
-    template: '<snippet attributeName="attr" :result="result">',
     render(h) {
       return h('snippet', {
         props: {
@@ -81,4 +78,32 @@ test('should throw an error when not in production if attribute is not snippeted
   }).$mount();
 
   expect(global.console.error).toHaveBeenCalled();
+});
+
+test('allows usage of dot delimited path to access nested attribute', () => {
+  const result = {
+    _snippetResult: {
+      attr: {
+        nested: {
+          value: `nested <em>val</em>`,
+        },
+      },
+    },
+  };
+
+  const vm = new Vue({
+    render(h) {
+      return h('snippet', {
+        props: {
+          attributeName: 'attr.nested',
+          result,
+        },
+      });
+    },
+    components: {
+      Snippet,
+    },
+  }).$mount();
+
+  expect(vm.$el.outerHTML).toMatchSnapshot();
 });

--- a/src/components/__tests__/snippet.js
+++ b/src/components/__tests__/snippet.js
@@ -7,7 +7,6 @@ function restoreTestProcessEnv() {
 
 afterEach(restoreTestProcessEnv);
 
-
 test('renders proper HTML', () => {
   const result = {
     _snippetResult: {

--- a/src/util/object.js
+++ b/src/util/object.js
@@ -1,0 +1,5 @@
+export const getPropertyByPath = function(object, path) {
+  const parts = path.split('.');
+
+  return parts.reduce((current, key) => current && current[key], object);
+};


### PR DESCRIPTION
This gets nicely caught by Vue:
![image](https://user-images.githubusercontent.com/5570853/29318880-204c3eea-81d2-11e7-80d8-5fc0129a4b80.png)

This is disabled in production and will get removed in minified build.

Will try to add couple of tests.