### PR TITLE
fix(instantsearch): allow to treeshake es module

### DIFF
--- a/build/rollup.umd.config.js
+++ b/build/rollup.umd.config.js
@@ -8,7 +8,7 @@ import replace from 'rollup-plugin-replace';
 import json from 'rollup-plugin-json';
 
 export default {
-  entry: 'src/instantsearch.js',
+  entry: 'src/instantsearch.umd.js',
   moduleName: 'VueInstantSearch',
   exports: 'named',
   plugins: [

--- a/src/instantsearch.js
+++ b/src/instantsearch.js
@@ -68,11 +68,6 @@ const InstantSearch = {
   },
 };
 
-// Automatically register Algolia Search components if Vue is available globally
-if (typeof window !== 'undefined' && window.Vue) {
-  window.Vue.use(InstantSearch);
-}
-
 export default InstantSearch;
 
 export {

--- a/src/instantsearch.umd.js
+++ b/src/instantsearch.umd.js
@@ -1,0 +1,8 @@
+import InstantSearch from './instantsearch';
+
+// Automatically register Algolia Search components if Vue is available globally
+if (typeof window !== 'undefined' && window.Vue) {
+  window.Vue.use(InstantSearch);
+}
+
+export * from './instantsearch';


### PR DESCRIPTION
This PR makes sure that users using the ES module can tree shake unused code.
This PR removes the auto-registration of the Vue-InstantSearch plugin inside Vue in all builds but UMD.

Closes: #311 