### PR TITLE
Fix/vue 2.5 compat

### DIFF
--- a/src/components/Results.vue
+++ b/src/components/Results.vue
@@ -3,7 +3,7 @@
 
     <slot name="header"></slot>
 
-    <slot v-for="result in results" :result="result" :key="result.objectID">
+    <slot v-for="result in results" :result="result">
       Result 'objectID': {{ result.objectID }}
     </slot>
 

--- a/src/components/__tests__/pagination.js
+++ b/src/components/__tests__/pagination.js
@@ -110,6 +110,9 @@ test('it should emit a "page-change" event when page changes', () => {
 
   expect(onPageChange).not.toHaveBeenCalled();
 
-  vm.$el.getElementsByTagName('li')[3].getElementsByTagName('a')[0].click();
+  vm.$el
+    .getElementsByTagName('li')[3]
+    .getElementsByTagName('a')[0]
+    .click();
   expect(onPageChange).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
cc @samouss 

It turns out that having a `key` binding on a slot now raises an error. Probably since 2.5.