### PR TITLE
Fix typo on `extend` instruction

### DIFF
--- a/docs/src/getting-started/styling.md
+++ b/docs/src/getting-started/styling.md
@@ -127,7 +127,7 @@ Here is how you could implement a `TableResults.vue` component that would displa
 import { Results } from 'vue-instantsearch';
 
 export default {
-  extend: Results,
+  extends: Results,
 }
 </script>
 ```


### PR DESCRIPTION
As define in doc: https://vuejs.org/v2/api/#extends

Otherwise in raise: **Property or method "results" is not defined on the instance but referenced during render**