### PR TITLE
feat: provide a loading indicator

### DIFF
--- a/docs/src/components/index.md
+++ b/docs/src/components/index.md
@@ -53,6 +53,7 @@ Provide search query parameters:
 | query-parameters | Object  | ``      | The search query parameters. Available options are [documented here](https://www.algolia.com/doc/api-client/javascript/search/#search-parameters). |
 | cache            | Boolean | `true`  | Whether to cache results or not. See: https://www.algolia.com/doc/tutorials/getting-started/quick-start-with-the-api-client/javascript/#cache       |
 | auto-search      | Boolean | `true`  | Whether to initiate a query to Algolia when this component is mounted                                                                               |
+| stalledSearchDelay | number | `200`  | Time before the search is considered unresponsive. Used to display a loading indicator. |
 
 ## Slots
 

--- a/src/components/Index.vue
+++ b/src/components/Index.vue
@@ -61,6 +61,10 @@ export default {
       type: Boolean,
       default: true,
     },
+    stalledSearchTimeout: {
+      type: Number,
+      default: 200,
+    },
   },
   data() {
     return {
@@ -71,7 +75,8 @@ export default {
     if (!this.searchStore) {
       this._localSearchStore = createFromAlgoliaCredentials(
         this.appId,
-        this.apiKey
+        this.apiKey,
+        this.stalledSearchTimeout,
       );
     } else {
       this._localSearchStore = this.searchStore;

--- a/src/components/Index.vue
+++ b/src/components/Index.vue
@@ -62,7 +62,7 @@ export default {
       type: Boolean,
       default: true,
     },
-    stalledSearchTimeout: {
+    stalledSearchDelay: {
       type: Number,
       default: 200,
     },
@@ -77,7 +77,7 @@ export default {
       this._localSearchStore = createFromAlgoliaCredentials(
         this.appId,
         this.apiKey,
-        this.stalledSearchTimeout
+        { stalledSearchDelay: this.stalledSearchDelay }
       );
     } else {
       this._localSearchStore = this.searchStore;

--- a/src/components/Index.vue
+++ b/src/components/Index.vue
@@ -76,7 +76,7 @@ export default {
       this._localSearchStore = createFromAlgoliaCredentials(
         this.appId,
         this.apiKey,
-        this.stalledSearchTimeout,
+        this.stalledSearchTimeout
       );
     } else {
       this._localSearchStore = this.searchStore;

--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -3,14 +3,14 @@
     <slot>
       <ais-input :search-store="searchStore" :placeholder="placeholder" :autofocus="autofocus"></ais-input>
       <button type="submit" :class="bem('submit')">
-        <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 40 40" v-if="!searchStore.isSearchStalled">
+        <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 40 40" v-if="!showLoadingIndicator || !searchStore.isSearchStalled">
           <title>{{ submitTitle }}</title>
           <path
             d="M26.804 29.01c-2.832 2.34-6.465 3.746-10.426 3.746C7.333 32.756 0 25.424 0 16.378 0 7.333 7.333 0 16.378 0c9.046 0 16.378 7.333 16.378 16.378 0 3.96-1.406 7.594-3.746 10.426l10.534 10.534c.607.607.61 1.59-.004 2.202-.61.61-1.597.61-2.202.004L26.804 29.01zm-10.426.627c7.323 0 13.26-5.936 13.26-13.26 0-7.32-5.937-13.257-13.26-13.257C9.056 3.12 3.12 9.056 3.12 16.378c0 7.323 5.936 13.26 13.258 13.26z"
             fillRule="evenodd"
           />
         </svg>
-        <svg width="1em" height="1em" viewBox="0 0 38 38" xmlns="http://www.w3.org/2000/svg" stroke="#000" v-if="searchStore.isSearchStalled">
+        <svg width="1em" height="1em" viewBox="0 0 38 38" xmlns="http://www.w3.org/2000/svg" stroke="#000" v-if="showLoadingIndicator && searchStore.isSearchStalled">
           <g fill="none" fill-rule="evenodd">
               <g transform="translate(1 1)" stroke-width="2">
                   <circle stroke-opacity=".5" cx="18" cy="18" r="18"/>
@@ -60,6 +60,10 @@ export default {
       default: 'clear',
     },
     autofocus: {
+      type: Boolean,
+      default: false,
+    },
+    showLoadingIndicator: {
       type: Boolean,
       default: false,
     },

--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -69,11 +69,6 @@ export default {
       blockClassName: 'ais-search-box',
     };
   },
-  computed: {
-    searchStalledClassName() {
-      return this.searchStore.isSearchStalled ? 'ais-search-box__stalled-search' : '';
-    },
-  },
   methods: {
     onFormSubmit() {
       const input = this.$el.querySelector('input[type=search]');

--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -2,7 +2,7 @@
   <form role="search" action="" @submit.prevent="onFormSubmit">
     <slot>
       <ais-input :search-store="searchStore" :placeholder="placeholder" :autofocus="autofocus"></ais-input>
-      <div v-if="showLoadingIndicator" :style="searchStore.isSearchStalled ? 'display:block;' : 'display:none;'" :class="bem('loading-indicator')" >
+      <div v-if="showLoadingIndicator" :hidden="!searchStore.isSearchStalled" :class="bem('loading-indicator')" >
         <slot name="loading-indicator" >
           <svg width="1em" height="1em" viewBox="0 0 38 38" xmlns="http://www.w3.org/2000/svg" stroke="#000">
             <g fill="none" fill-rule="evenodd">
@@ -22,7 +22,7 @@
           </svg>
         </slot>
       </div>
-      <button type="submit" :class="bem('submit')" :style="showLoadingIndicator && searchStore.isSearchStalled ? 'display:none;' : 'display:block;'">
+      <button type="submit" :class="bem('submit')" :hidden="showLoadingIndicator && searchStore.isSearchStalled">
         <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 40 40">
           <title>{{ submitTitle }}</title>
           <path

--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -3,13 +3,29 @@
     <slot>
       <ais-input :search-store="searchStore" :placeholder="placeholder" :autofocus="autofocus"></ais-input>
       <button type="submit" :class="bem('submit')">
-        <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 40 40">
+        <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 40 40" v-if="!searchStore.isSearchStalled">
           <title>{{ submitTitle }}</title>
           <path
             d="M26.804 29.01c-2.832 2.34-6.465 3.746-10.426 3.746C7.333 32.756 0 25.424 0 16.378 0 7.333 7.333 0 16.378 0c9.046 0 16.378 7.333 16.378 16.378 0 3.96-1.406 7.594-3.746 10.426l10.534 10.534c.607.607.61 1.59-.004 2.202-.61.61-1.597.61-2.202.004L26.804 29.01zm-10.426.627c7.323 0 13.26-5.936 13.26-13.26 0-7.32-5.937-13.257-13.26-13.257C9.056 3.12 3.12 9.056 3.12 16.378c0 7.323 5.936 13.26 13.258 13.26z"
             fillRule="evenodd"
           />
         </svg>
+        <svg width="1em" height="1em" viewBox="0 0 38 38" xmlns="http://www.w3.org/2000/svg" stroke="#000" v-if="searchStore.isSearchStalled">
+          <g fill="none" fill-rule="evenodd">
+              <g transform="translate(1 1)" stroke-width="2">
+                  <circle stroke-opacity=".5" cx="18" cy="18" r="18"/>
+                  <path d="M36 18c0-9.94-8.06-18-18-18">
+                      <animateTransform
+                          attributeName="transform"
+                          type="rotate"
+                          from="0 18 18"
+                          to="360 18 18"
+                          dur="1s"
+                          repeatCount="indefinite"/>
+                  </path>
+              </g>
+          </g>
+      </svg>
       </button>
       <ais-clear :search-store="searchStore">
         <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20">
@@ -52,6 +68,11 @@ export default {
     return {
       blockClassName: 'ais-search-box',
     };
+  },
+  computed: {
+    searchStalledClassName() {
+      return this.searchStore.isSearchStalled ? 'ais-search-box__stalled-search' : '';
+    },
   },
   methods: {
     onFormSubmit() {

--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -44,7 +44,8 @@
   </form>
 </template>
 
-<script>import algoliaComponent from '../component';
+<script>
+import algoliaComponent from '../component';
 import AisInput from './Input.vue';
 import AisClear from './Clear.vue';
 

--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -2,30 +2,34 @@
   <form role="search" action="" @submit.prevent="onFormSubmit">
     <slot>
       <ais-input :search-store="searchStore" :placeholder="placeholder" :autofocus="autofocus"></ais-input>
-      <button type="submit" :class="bem('submit')">
-        <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 40 40" v-if="!showLoadingIndicator || !searchStore.isSearchStalled">
+      <div v-if="showLoadingIndicator" :style="searchStore.isSearchStalled ? 'display:block;' : 'display:none;'" :class="bem('loading-indicator')" >
+        <slot name="loading-indicator" >
+          <svg width="1em" height="1em" viewBox="0 0 38 38" xmlns="http://www.w3.org/2000/svg" stroke="#000">
+            <g fill="none" fill-rule="evenodd">
+              <g transform="translate(1 1)" stroke-width="2">
+                <circle stroke-opacity=".5" cx="18" cy="18" r="18"/>
+                <path d="M36 18c0-9.94-8.06-18-18-18">
+                  <animateTransform
+                  attributeName="transform"
+                  type="rotate"
+                  from="0 18 18"
+                  to="360 18 18"
+                  dur="1s"
+                  repeatCount="indefinite"/>
+                </path>
+              </g>
+            </g>
+          </svg>
+        </slot>
+      </div>
+      <button type="submit" :class="bem('submit')" :style="showLoadingIndicator && searchStore.isSearchStalled ? 'display:none;' : 'display:block;'">
+        <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 40 40">
           <title>{{ submitTitle }}</title>
           <path
             d="M26.804 29.01c-2.832 2.34-6.465 3.746-10.426 3.746C7.333 32.756 0 25.424 0 16.378 0 7.333 7.333 0 16.378 0c9.046 0 16.378 7.333 16.378 16.378 0 3.96-1.406 7.594-3.746 10.426l10.534 10.534c.607.607.61 1.59-.004 2.202-.61.61-1.597.61-2.202.004L26.804 29.01zm-10.426.627c7.323 0 13.26-5.936 13.26-13.26 0-7.32-5.937-13.257-13.26-13.257C9.056 3.12 3.12 9.056 3.12 16.378c0 7.323 5.936 13.26 13.258 13.26z"
             fillRule="evenodd"
           />
         </svg>
-        <svg width="1em" height="1em" viewBox="0 0 38 38" xmlns="http://www.w3.org/2000/svg" stroke="#000" v-if="showLoadingIndicator && searchStore.isSearchStalled">
-          <g fill="none" fill-rule="evenodd">
-              <g transform="translate(1 1)" stroke-width="2">
-                  <circle stroke-opacity=".5" cx="18" cy="18" r="18"/>
-                  <path d="M36 18c0-9.94-8.06-18-18-18">
-                      <animateTransform
-                          attributeName="transform"
-                          type="rotate"
-                          from="0 18 18"
-                          to="360 18 18"
-                          dur="1s"
-                          repeatCount="indefinite"/>
-                  </path>
-              </g>
-          </g>
-      </svg>
       </button>
       <ais-clear :search-store="searchStore">
         <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20">
@@ -40,8 +44,7 @@
   </form>
 </template>
 
-<script>
-import algoliaComponent from '../component';
+<script>import algoliaComponent from '../component';
 import AisInput from './Input.vue';
 import AisClear from './Clear.vue';
 

--- a/src/components/__tests__/__snapshots__/search-box.js.snap
+++ b/src/components/__tests__/__snapshots__/search-box.js.snap
@@ -14,8 +14,188 @@ exports[`SearchBox component can be autofocused 1`] = `
          placeholder
          autofocus="autofocus"
   >
+  <!---->
   <button type="submit"
           class="ais-search-box__submit"
+          style="display: block;"
+  >
+    <svg xmlns="http://www.w3.org/2000/svg"
+         width="1em"
+         height="1em"
+         viewbox="0 0 40 40"
+    >
+      <title>
+        search
+      </title>
+      <path d="M26.804 29.01c-2.832 2.34-6.465 3.746-10.426 3.746C7.333 32.756 0 25.424 0 16.378 0 7.333 7.333 0 16.378 0c9.046 0 16.378 7.333 16.378 16.378 0 3.96-1.406 7.594-3.746 10.426l10.534 10.534c.607.607.61 1.59-.004 2.202-.61.61-1.597.61-2.202.004L26.804 29.01zm-10.426.627c7.323 0 13.26-5.936 13.26-13.26 0-7.32-5.937-13.257-13.26-13.257C9.056 3.12 3.12 9.056 3.12 16.378c0 7.323 5.936 13.26 13.258 13.26z"
+            fillrule="evenodd"
+      >
+      </path>
+    </svg>
+  </button>
+  <button type="reset"
+          disabled="disabled"
+          class="ais-clear ais-clear--disabled"
+  >
+    <svg xmlns="http://www.w3.org/2000/svg"
+         width="1em"
+         height="1em"
+         viewbox="0 0 20 20"
+    >
+      <title>
+        clear
+      </title>
+      <path d="M8.114 10L.944 2.83 0 1.885 1.886 0l.943.943L10 8.113l7.17-7.17.944-.943L20 1.886l-.943.943-7.17 7.17 7.17 7.17.943.944L18.114 20l-.943-.943-7.17-7.17-7.17 7.17-.944.943L0 18.114l.943-.943L8.113 10z"
+            fillrule="evenodd"
+      >
+      </path>
+    </svg>
+  </button>
+</form>
+
+`;
+
+exports[`SearchBox component if search is not stalled, show the submit and hide the loader 1`] = `
+
+<form role="search"
+      action
+>
+  <input type="search"
+         autocorrect="off"
+         autocapitalize="off"
+         autocomplete="off"
+         spellcheck="false"
+         class="ais-input"
+         placeholder
+         autofocus="autofocus"
+  >
+  <div class="ais-search-box__loading-indicator"
+       style="display: none;"
+  >
+    <svg width="1em"
+         height="1em"
+         viewbox="0 0 38 38"
+         xmlns="http://www.w3.org/2000/svg"
+         stroke="#000"
+    >
+      <g fill="none"
+         fill-rule="evenodd"
+      >
+        <g transform="translate(1 1)"
+           stroke-width="2"
+        >
+          <circle stroke-opacity=".5"
+                  cx="18"
+                  cy="18"
+                  r="18"
+          >
+          </circle>
+          <path d="M36 18c0-9.94-8.06-18-18-18">
+          </path>
+          <animatetransform attributename="transform"
+                            type="rotate"
+                            from="0 18 18"
+                            to="360 18 18"
+                            dur="1s"
+                            repeatcount="indefinite"
+          >
+          </animatetransform>
+        </g>
+      </g>
+    </svg>
+  </div>
+  <button type="submit"
+          class="ais-search-box__submit"
+          style="display: block;"
+  >
+    <svg xmlns="http://www.w3.org/2000/svg"
+         width="1em"
+         height="1em"
+         viewbox="0 0 40 40"
+    >
+      <title>
+        search
+      </title>
+      <path d="M26.804 29.01c-2.832 2.34-6.465 3.746-10.426 3.746C7.333 32.756 0 25.424 0 16.378 0 7.333 7.333 0 16.378 0c9.046 0 16.378 7.333 16.378 16.378 0 3.96-1.406 7.594-3.746 10.426l10.534 10.534c.607.607.61 1.59-.004 2.202-.61.61-1.597.61-2.202.004L26.804 29.01zm-10.426.627c7.323 0 13.26-5.936 13.26-13.26 0-7.32-5.937-13.257-13.26-13.257C9.056 3.12 3.12 9.056 3.12 16.378c0 7.323 5.936 13.26 13.258 13.26z"
+            fillrule="evenodd"
+      >
+      </path>
+    </svg>
+  </button>
+  <button type="reset"
+          disabled="disabled"
+          class="ais-clear ais-clear--disabled"
+  >
+    <svg xmlns="http://www.w3.org/2000/svg"
+         width="1em"
+         height="1em"
+         viewbox="0 0 20 20"
+    >
+      <title>
+        clear
+      </title>
+      <path d="M8.114 10L.944 2.83 0 1.885 1.886 0l.943.943L10 8.113l7.17-7.17.944-.943L20 1.886l-.943.943-7.17 7.17 7.17 7.17.943.944L18.114 20l-.943-.943-7.17-7.17-7.17 7.17-.944.943L0 18.114l.943-.943L8.113 10z"
+            fillrule="evenodd"
+      >
+      </path>
+    </svg>
+  </button>
+</form>
+
+`;
+
+exports[`SearchBox component if search is stalled, hide the submit and display the loader 1`] = `
+
+<form role="search"
+      action
+>
+  <input type="search"
+         autocorrect="off"
+         autocapitalize="off"
+         autocomplete="off"
+         spellcheck="false"
+         class="ais-input"
+         placeholder
+         autofocus="autofocus"
+  >
+  <div class="ais-search-box__loading-indicator"
+       style="display: block;"
+  >
+    <svg width="1em"
+         height="1em"
+         viewbox="0 0 38 38"
+         xmlns="http://www.w3.org/2000/svg"
+         stroke="#000"
+    >
+      <g fill="none"
+         fill-rule="evenodd"
+      >
+        <g transform="translate(1 1)"
+           stroke-width="2"
+        >
+          <circle stroke-opacity=".5"
+                  cx="18"
+                  cy="18"
+                  r="18"
+          >
+          </circle>
+          <path d="M36 18c0-9.94-8.06-18-18-18">
+          </path>
+          <animatetransform attributename="transform"
+                            type="rotate"
+                            from="0 18 18"
+                            to="360 18 18"
+                            dur="1s"
+                            repeatcount="indefinite"
+          >
+          </animatetransform>
+        </g>
+      </g>
+    </svg>
+  </div>
+  <button type="submit"
+          class="ais-search-box__submit"
+          style="display: none;"
   >
     <svg xmlns="http://www.w3.org/2000/svg"
          width="1em"
@@ -66,8 +246,10 @@ exports[`SearchBox component renders proper HTML 1`] = `
          class="ais-input"
          placeholder
   >
+  <!---->
   <button type="submit"
           class="ais-search-box__submit"
+          style="display: block;"
   >
     <svg xmlns="http://www.w3.org/2000/svg"
          width="1em"

--- a/src/components/__tests__/__snapshots__/search-box.js.snap
+++ b/src/components/__tests__/__snapshots__/search-box.js.snap
@@ -17,7 +17,6 @@ exports[`SearchBox component can be autofocused 1`] = `
   <!---->
   <button type="submit"
           class="ais-search-box__submit"
-          style="display: block;"
   >
     <svg xmlns="http://www.w3.org/2000/svg"
          width="1em"
@@ -69,8 +68,8 @@ exports[`SearchBox component if search is not stalled, show the submit and hide 
          placeholder
          autofocus="autofocus"
   >
-  <div class="ais-search-box__loading-indicator"
-       style="display: none;"
+  <div hidden="hidden"
+       class="ais-search-box__loading-indicator"
   >
     <svg width="1em"
          height="1em"
@@ -106,7 +105,6 @@ exports[`SearchBox component if search is not stalled, show the submit and hide 
   </div>
   <button type="submit"
           class="ais-search-box__submit"
-          style="display: block;"
   >
     <svg xmlns="http://www.w3.org/2000/svg"
          width="1em"
@@ -158,9 +156,7 @@ exports[`SearchBox component if search is stalled, hide the submit and display t
          placeholder
          autofocus="autofocus"
   >
-  <div class="ais-search-box__loading-indicator"
-       style="display: block;"
-  >
+  <div class="ais-search-box__loading-indicator">
     <svg width="1em"
          height="1em"
          viewbox="0 0 38 38"
@@ -194,8 +190,8 @@ exports[`SearchBox component if search is stalled, hide the submit and display t
     </svg>
   </div>
   <button type="submit"
+          hidden="hidden"
           class="ais-search-box__submit"
-          style="display: none;"
   >
     <svg xmlns="http://www.w3.org/2000/svg"
          width="1em"
@@ -249,7 +245,6 @@ exports[`SearchBox component renders proper HTML 1`] = `
   <!---->
   <button type="submit"
           class="ais-search-box__submit"
-          style="display: block;"
   >
     <svg xmlns="http://www.w3.org/2000/svg"
          width="1em"

--- a/src/components/__tests__/search-box.js
+++ b/src/components/__tests__/search-box.js
@@ -31,4 +31,36 @@ describe('SearchBox component', () => {
 
     expect(vm.$el.outerHTML).toMatchSnapshot();
   });
+
+  test('if search is stalled, hide the submit and display the loader', () => {
+    const searchStore = {
+      query: '',
+      activeRefinements: [], // needed for Clear component
+      isSearchStalled: true,
+    };
+    const Component = Vue.extend(SearchBox);
+    const vm = new Component({
+      propsData: { searchStore, autofocus: true, showLoadingIndicator: true },
+    });
+
+    vm.$mount();
+
+    expect(vm.$el.outerHTML).toMatchSnapshot();
+  });
+
+  test('if search is not stalled, show the submit and hide the loader', () => {
+    const searchStore = {
+      query: '',
+      activeRefinements: [], // needed for Clear component
+      isSearchStalled: false,
+    };
+    const Component = Vue.extend(SearchBox);
+    const vm = new Component({
+      propsData: { searchStore, autofocus: true, showLoadingIndicator: true },
+    });
+
+    vm.$mount();
+
+    expect(vm.$el.outerHTML).toMatchSnapshot();
+  });
 });

--- a/src/store.js
+++ b/src/store.js
@@ -15,11 +15,11 @@ export const FACET_TREE = 'tree';
 export const HIGHLIGHT_PRE_TAG = '__ais-highlight__';
 export const HIGHLIGHT_POST_TAG = '__/ais-highlight__';
 
-export const createFromAlgoliaCredentials = (appID, apiKey) => {
+export const createFromAlgoliaCredentials = (appID, apiKey, stalledSearchTimeout) => {
   const client = algolia(appID, apiKey);
   const helper = algoliaHelper(client);
 
-  return new Store(helper);
+  return new Store(helper, {stalledSearchTimeout});
 };
 
 export const createFromAlgoliaClient = client => {
@@ -39,7 +39,7 @@ export const createFromSerialized = data => {
 };
 
 export class Store {
-  constructor(helper) {
+  constructor(helper, {stalledSearchTimeout = 200} = {}) {
     if (!(helper instanceof algoliaHelper.AlgoliaSearchHelper)) {
       throw new TypeError(
         'Store should be constructed with an AlgoliaSearchHelper instance as first parameter.'
@@ -54,6 +54,8 @@ export class Store {
     this._highlightPostTag = '</em>';
 
     this._cacheEnabled = true;
+
+    this._stalledSearchTimeout = stalledSearchTimeout;
 
     this.algoliaHelper = helper;
   }
@@ -481,6 +483,6 @@ const onHelperSearch = function() {
   if(!this._stalledSearchTimer) {
     this._stalledSearchTimer = setTimeout(() => {
       this.isSearchStalled = true;
-    }, 200);
+    }, this._stalledSearchTimeout);
   }
 }

--- a/src/store.js
+++ b/src/store.js
@@ -15,27 +15,23 @@ export const FACET_TREE = 'tree';
 export const HIGHLIGHT_PRE_TAG = '__ais-highlight__';
 export const HIGHLIGHT_POST_TAG = '__/ais-highlight__';
 
-export const createFromAlgoliaCredentials = (
-  appID,
-  apiKey,
-  stalledSearchTimeout
-) => {
+export const createFromAlgoliaCredentials = (appID, apiKey, options) => {
   const client = algolia(appID, apiKey);
   const helper = algoliaHelper(client);
 
-  return new Store(helper, { stalledSearchTimeout });
+  return new Store(helper, options);
 };
 
-export const createFromAlgoliaClient = client => {
+export const createFromAlgoliaClient = (client, options) => {
   const helper = algoliaHelper(client);
 
-  return new Store(helper);
+  return new Store(helper, options);
 };
 
-export const createFromSerialized = data => {
+export const createFromSerialized = (data, options) => {
   const helper = deserializeHelper(data.helper);
 
-  const store = new Store(helper);
+  const store = new Store(helper, options);
   store.highlightPreTag = data.highlightPreTag;
   store.highlightPostTag = data.highlightPostTag;
 
@@ -43,7 +39,7 @@ export const createFromSerialized = data => {
 };
 
 export class Store {
-  constructor(helper, { stalledSearchTimeout = 200 } = {}) {
+  constructor(helper, { stalledSearchDelay = 200 } = {}) {
     if (!(helper instanceof algoliaHelper.AlgoliaSearchHelper)) {
       throw new TypeError(
         'Store should be constructed with an AlgoliaSearchHelper instance as first parameter.'
@@ -59,7 +55,7 @@ export class Store {
 
     this._cacheEnabled = true;
 
-    this._stalledSearchTimeout = stalledSearchTimeout;
+    this._stalledSearchDelay = stalledSearchDelay;
 
     this.algoliaHelper = helper;
   }
@@ -93,7 +89,7 @@ export class Store {
     this._helper.getClient().addAlgoliaAgent(`vue-instantsearch ${version}`);
 
     this._stalledSearchTimer = null;
-    this.isSearchStalled = false;
+    this.isSearchStalled = true;
   }
 
   get isSearchStalled() {
@@ -487,6 +483,6 @@ const onHelperSearch = function() {
   if (!this._stalledSearchTimer) {
     this._stalledSearchTimer = setTimeout(() => {
       this.isSearchStalled = true;
-    }, this._stalledSearchTimeout);
+    }, this._stalledSearchDelay);
   }
 };

--- a/src/store.js
+++ b/src/store.js
@@ -15,11 +15,15 @@ export const FACET_TREE = 'tree';
 export const HIGHLIGHT_PRE_TAG = '__ais-highlight__';
 export const HIGHLIGHT_POST_TAG = '__/ais-highlight__';
 
-export const createFromAlgoliaCredentials = (appID, apiKey, stalledSearchTimeout) => {
+export const createFromAlgoliaCredentials = (
+  appID,
+  apiKey,
+  stalledSearchTimeout
+) => {
   const client = algolia(appID, apiKey);
   const helper = algoliaHelper(client);
 
-  return new Store(helper, {stalledSearchTimeout});
+  return new Store(helper, { stalledSearchTimeout });
 };
 
 export const createFromAlgoliaClient = client => {
@@ -39,7 +43,7 @@ export const createFromSerialized = data => {
 };
 
 export class Store {
-  constructor(helper, {stalledSearchTimeout = 200} = {}) {
+  constructor(helper, { stalledSearchTimeout = 200 } = {}) {
     if (!(helper instanceof algoliaHelper.AlgoliaSearchHelper)) {
       throw new TypeError(
         'Store should be constructed with an AlgoliaSearchHelper instance as first parameter.'
@@ -472,7 +476,7 @@ const onHelperResult = function(response) {
     this.highlightPostTag
   );
 
-  if(!this._helper.hasPendingRequests()) {
+  if (!this._helper.hasPendingRequests()) {
     clearTimeout(this._stalledSearchTimer);
     this._stalledSearchTimer = null;
     this.isSearchStalled = false;
@@ -480,9 +484,9 @@ const onHelperResult = function(response) {
 };
 
 const onHelperSearch = function() {
-  if(!this._stalledSearchTimer) {
+  if (!this._stalledSearchTimer) {
     this._stalledSearchTimer = setTimeout(() => {
       this.isSearchStalled = true;
     }, this._stalledSearchTimeout);
   }
-}
+};

--- a/stories/SearchBox.stories.js
+++ b/stories/SearchBox.stories.js
@@ -6,6 +6,9 @@ storiesOf('SearchBox', module)
   .add('default', () => ({
     template: '<ais-search-box></ais-search-box>',
   }))
+  .add('with loading indicator', () => ({
+    template: '<ais-search-box showLoadingIndicator></ais-search-box>',
+  }))
   .add('with default query', () => ({
     template: '<ais-search-box ref="child"></ais-search-box>',
     mounted() {


### PR DESCRIPTION
This PR provides a way for the searchbox to display a spinner when the search is stalled.

The approach taken here is [similar to the one from react-instantsearch](https://github.com/algolia/react-instantsearch/pull/544): the mechanism that detects the stalled search is actually implemented at the top level. As in RIS this makes the implementation of this state update easier in multiple widgets, which seems like a good strategy.

On the UI implementation, because vue-IS doesn't implement any style, the magnifying glass svg is toggle with a spinner in the template. The effect is good as far as I can tell.

Missing elements:
 - [x] actual API to customize the parameters
 - [x] tests

Question: 
 - not sure about the implementation in store.js/waitUntilSync @rayrutjes 

Related to https://github.com/algolia/instantsearch.js/pull/2509