### PR TITLE
Update scoped slot docs

### DIFF
--- a/docs/src/advanced/integrate-with-nuxt.md
+++ b/docs/src/advanced/integrate-with-nuxt.md
@@ -83,7 +83,7 @@ You can go ahead and create a search page by creating a new file called `pages/s
   <ais-index app-id="latency" api-key="3d9875e51fbd20c7754e65422f7ce5e1" index-name="bestbuy">
     <ais-search-box></ais-search-box>
     <ais-results>
-      <template scope="{ result }">
+      <template slot-scope="{ result }">
         <h2>{{ result.name }}</h2>
       </template>
     </ais-results>
@@ -111,7 +111,7 @@ Here is what you need to do to enable your server to pre-render results:
   <ais-index :search-store="searchStore" >
     <ais-search-box></ais-search-box>
     <ais-results>
-      <template scope="{ result }">
+      <template slot-scope="{ result }">
         <h2>{{ result.name }}</h2>
       </template>
     </ais-results>

--- a/docs/src/components/highlight.md
+++ b/docs/src/components/highlight.md
@@ -46,7 +46,7 @@ For more complex data structures, it will be necessary to leverage the [_highlig
 
 ```html
 <ais-results>
-  <template scope="{ result }">
+  <template slot-scope="{ result }">
     <p v-for="keyword in result._highlightResult.keywords" v-html="keyword.value"></p>
   </template>
 </ais-results>

--- a/docs/src/components/no-results.md
+++ b/docs/src/components/no-results.md
@@ -25,7 +25,7 @@ Overriding the default content:
 
  ```html
 <ais-no-results>
-	<template scope="props">
+	<template slot-scope="props">
 		No products found for <i>{{ props.query }}</i>.
 	</template>
 </ais-no-results>

--- a/docs/src/components/results.md
+++ b/docs/src/components/results.md
@@ -17,7 +17,7 @@ Basic usage:
 
 ```html
 <ais-results>
-  <template scope="{ result }">
+  <template slot-scope="{ result }">
     <h2>
       <a :href="result.url">
         {{ result.title }}

--- a/docs/src/components/sort-by-selector.md
+++ b/docs/src/components/sort-by-selector.md
@@ -43,7 +43,7 @@ Customize the option rendering:
       {name: 'products_total_sales', label: 'Popularity'}
     ]"
 >
-  <template scope="{ indexName, label }">
+  <template slot-scope="{ indexName, label }">
     <option :value="indexName">Sort by: {{ label }}</option>
   </template>
 </ais-sort-by-selector>

--- a/docs/src/components/stats.md
+++ b/docs/src/components/stats.md
@@ -25,7 +25,7 @@ Custom text:
 
 ```html
 <ais-stats>
-  <template scope="{ totalResults, processingTime, query }">
+  <template slot-scope="{ totalResults, processingTime, query }">
     There are {{ totalResults }} matching your query: <b>{{ query }}</b>
     - <small>{{ processingTime }}ms</small>
   </template>

--- a/docs/src/getting-started/getting-started.md
+++ b/docs/src/getting-started/getting-started.md
@@ -92,7 +92,7 @@ Open the `src/App.vue` component. Then replace the whole beginning of the file, 
   >
     <ais-search-box></ais-search-box>
     <ais-results>
-      <template scope="{ result }">
+      <template slot-scope="{ result }">
         <h2>
           <ais-highlight :result="result" attribute-name="name"></ais-highlight>
         </h2>
@@ -166,7 +166,7 @@ A scoped slot means that the template can access data passed to the slot.
 This is illustrated by this snippet:
 
 ```html
-<template scope="parameters">
+<template slot-scope="parameters">
   <h1>{{ parameters.result.name }}</h1>
 </template>
 ```
@@ -174,7 +174,7 @@ This is illustrated by this snippet:
 or with an ES6 syntax:
 
 ```html
-<template scope="{ result }">
+<template slot-scope="{ result }">
   <h1>{{ result.name }}</h1>
 </template>
 ```

--- a/docs/src/getting-started/styling.md
+++ b/docs/src/getting-started/styling.md
@@ -67,7 +67,7 @@ When you use a `scoped slot`, you need to tell your template to get the scope.
 
 ```html
 <ais-results>
-  <template scope="{ result }">
+  <template slot-scope="{ result }">
     <h2>{{ result.name }}</h2>
   </template>
 </ais-results>


### PR DESCRIPTION
The "scope" attribute for scoped slots have been deprecated and replaced by "slot-scope" since Vue 2.5.