### PR TITLE
docs(index): correct documentation links

### DIFF
--- a/docs/src/components/index.md
+++ b/docs/src/components/index.md
@@ -50,8 +50,8 @@ Provide search query parameters:
 | app-id           | String  | ``      | The application ID                                                                                                                                 |
 | index-name       | String  | ``      | The index name                                                                                                                                     |
 | query            | String  | ``      | The search query                                                                                                                                   |
-| query-parameters | Object  | ``      | The search query parameters. Available options are [documented here](https://www.algolia.com/doc/api-client/javascript/search/#search-parameters). |
-| cache            | Boolean | `true`  | Whether to cache results or not. See: https://www.algolia.com/doc/tutorials/getting-started/quick-start-with-the-api-client/javascript/#cache       |
+| query-parameters | Object  | ``      | The search query parameters. Available options are [documented here](https://www.algolia.com/doc/api-reference/search-api-parameters/). |
+| cache            | Boolean | `true`  | Whether to cache results or not. See [the documentation](https://www.algolia.com/doc/tutorials/getting-started/quick-start-with-the-api-client/javascript/#cache)       |
 | auto-search      | Boolean | `true`  | Whether to initiate a query to Algolia when this component is mounted                                                                               |
 
 ## Slots


### PR DESCRIPTION
1. cache: make into a shortened link
2. api parameters: use the correct link, cc @kfirba