### PR TITLE
fix(doc): `queryParameters` is not a function

### DIFF
--- a/docs/src/getting-started/search-store.md
+++ b/docs/src/getting-started/search-store.md
@@ -132,7 +132,7 @@ store.stop();
 
 store.indexName = 'new_index';
 store.query = '';
-store.queryParameters({'distinct': true});
+store.queryParameters = { distinct: true };
 
 store.start();
 store.refresh();


### PR DESCRIPTION
`queryParameters` actually has a setter that merges assigned params to the full params list