### PR TITLE
fix(menu): avoid error when no facet values are retrieved

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -46,7 +46,7 @@ export default {
 
   computed: {
     facetValues() {
-      const { data = [] } = this.searchStore.getFacetValues(
+      const { data } = this.searchStore.getFacetValues(
         this.attribute,
         this.sortBy
       );

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -51,7 +51,11 @@ export default {
         this.sortBy
       );
 
-      return data;
+      if (Array.isArray(data)) {
+        return data;
+      }
+
+      return [];
     },
     show() {
       return this.facetValues.length > 0;

--- a/src/components/__tests__/__snapshots__/menu.js.snap
+++ b/src/components/__tests__/__snapshots__/menu.js.snap
@@ -46,3 +46,5 @@ exports[`Menu should render correctly 1`] = `
 </div>
 
 `;
+
+exports[`Menu should render nothing if no menu entries are available 1`] = `undefined`;

--- a/src/components/__tests__/menu.js
+++ b/src/components/__tests__/menu.js
@@ -62,6 +62,22 @@ describe('Menu', () => {
     expect(vm.$el.outerHTML).toMatchSnapshot();
   });
 
+  it('should render nothing if no menu entries are available', () => {
+    const Component = Vue.extend(Menu);
+
+    const store = Object.assign({}, searchStore, {
+      getFacetValues: () => ({ data: null }),
+    });
+    const vm = new Component({
+      propsData: {
+        attribute: 'category',
+        searchStore: store,
+      },
+    });
+    vm.$mount();
+    expect(vm.$el.outerHTML).toMatchSnapshot();
+  });
+
   it('should add a facet to the store when created', () => {
     const Component = Vue.extend(Menu);
     const addFacetMock = jest.fn();


### PR DESCRIPTION
Works around a bug in the Menu component implementation:
![image](https://user-images.githubusercontent.com/5570853/36897785-40cfe7ce-1e18-11e8-84e7-e69cecf1162c.png)

cc @Shipow 