### PR TITLE
feat: Update client and helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "changelog:unreleased": "conventional-changelog --preset angular --output-unreleased"
   },
   "dependencies": {
-    "algoliasearch": "^3.18.1",
-    "algoliasearch-helper": "^2.21.1",
+    "algoliasearch": "^3.27.0",
+    "algoliasearch-helper": "^2.25.1",
     "escape-html": "^1.0.3"
   },
   "peerDependencies": {

--- a/src/__tests__/store.js
+++ b/src/__tests__/store.js
@@ -544,7 +544,6 @@ describe('Store', () => {
 
       expect(client.search).toHaveBeenCalledTimes(1);
       // first results from Algolia
-      client.searchResultsResolvers[0]();
       return client.searchResultsPromises[0]
         .then(() => {
           expect(store.isSearchStalled).toBe(false);
@@ -555,7 +554,6 @@ describe('Store', () => {
 
           expect(store.isSearchStalled).toBe(true);
 
-          client.searchResultsResolvers[1]();
           return client.searchResultsPromises[1];
         })
         .then(() => {
@@ -566,20 +564,15 @@ describe('Store', () => {
 });
 
 function makeManagedClient() {
-  const searchResultsResolvers = [];
   const searchResultsPromises = [];
   const fakeClient = {
-    search: jest.fn((qs, cb) => {
-      const p = new Promise(resolve =>
-        searchResultsResolvers.push(resolve)
-      ).then(() => {
-        cb(null, defaultResponse());
-      });
-      searchResultsPromises.push(p);
+    search: jest.fn(() => {
+      const results = Promise.resolve(defaultResponse());
+      searchResultsPromises.push(results);
+      return results;
     }),
     addAlgoliaAgent: () => {},
     searchResultsPromises,
-    searchResultsResolvers,
   };
 
   return fakeClient;

--- a/yarn.lock
+++ b/yarn.lock
@@ -250,18 +250,18 @@ ajv@^5.0.0, ajv@^5.1.0, ajv@^5.1.5, ajv@^5.2.0:
     json-schema-traverse "^0.3.0"
     json-stable-stringify "^1.0.1"
 
-algoliasearch-helper@^2.21.1:
-  version "2.22.0"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-2.22.0.tgz#6904abf15cd9b65a32fc3d9eb9dfe50f53b27001"
+algoliasearch-helper@^2.25.1:
+  version "2.25.1"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-2.25.1.tgz#89828b83257df7e6cd0a9e42cfb4ab5dd35a7f4e"
   dependencies:
     events "^1.1.0"
     lodash "^4.13.1"
     qs "^6.2.1"
     util "^0.10.3"
 
-algoliasearch@^3.18.1:
-  version "3.24.5"
-  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.24.5.tgz#15d1e6c6a059b8b357d7d40122d9841829acfd20"
+algoliasearch@^3.27.0:
+  version "3.27.0"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.27.0.tgz#675b7f2d186e5785a1553369b15d47b53d4efb31"
   dependencies:
     agentkeepalive "^2.2.0"
     debug "^2.6.8"


### PR DESCRIPTION
This PR updates to `algoliasearch@3.27.0` and `algoliasearch-helper@2.25.1`, using the promisified version of `client.search()`.