### PR TITLE
feat(MenuSelect): add widget

### DIFF
--- a/.github/V2_PROGRESS.md
+++ b/.github/V2_PROGRESS.md
@@ -32,7 +32,7 @@ x => done
 * [x] `ais-hits`
 * [x] `ais-index` (there's no connector for this today)
 * [~] `ais-infinite-hits` samouss
-* [~] `ais-menu-select` samouss
+* [x] `ais-menu-select`
 * [ ] `ais-menu`
 * [ ] `ais-numeric-menu`
 * [ ] `ais-numeric-selector`

--- a/docs/src/components/MenuSelect.md
+++ b/docs/src/components/MenuSelect.md
@@ -1,0 +1,40 @@
+---
+title: MenuSelect
+mainTitle: Components
+layout: main.pug
+category: Components
+withHeadings: true
+navWeight: 6
+editable: true
+githubSource: docs/src/components/MenuSelect.md
+---
+
+Create a menu based on a facet with a `select` element.
+
+<a class="btn btn-static-theme" href="stories/?selectedKind=MenuSelect">🕹 try out live</a>
+
+## Usage
+
+```html
+<ais-menu-select :attribute="facetName"></ais-menu-select>
+```
+
+## Props
+
+Name | Type | Default | Description | Required
+---|---|---|---|---
+attribute | `string` | | Name of the attribute for faceting. | yes
+limit | `number` | `10` | How many facets values to retrieve. | no
+sortBy | `string[]|function` | `['name:asc']` | How to sort refinements. Possible values: `count`, `isRefined`, `name:asc`, `name:desc`. You can also use a sort function that behaves like the standard JavaScript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax). | no
+
+## CSS classes
+
+Here's a list of CSS classes exposed by this widget. To better understand the underlying
+DOM structure, have a look at the generated DOM in your browser.
+
+Class name | Description
+---|---
+`ais-MenuSelect` | The root div of the widget
+`ais-MenuSelect--noRefinement	` | The root div of the widget with no refinement
+`ais-MenuSelect-select` | The select
+`ais-MenuSelect-option` | The select option

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -15,6 +15,7 @@ test('Should register all components when installed', () => {
     'ais-stats',
     'ais-pagination',
     'ais-menu',
+    'ais-menu-select',
     'ais-sort-by-selector',
     'ais-search-box',
     'ais-clear-refinements',

--- a/src/__tests__/suit.js
+++ b/src/__tests__/suit.js
@@ -1,0 +1,45 @@
+import suit from '../suit';
+
+it('expect to return "ais-Widget"', () => {
+  const name = 'Widget';
+
+  const expectation = 'ais-Widget';
+  const actual = suit(name);
+
+  expect(actual).toBe(expectation);
+});
+
+it('expect to return "ais-Widget--modifier"', () => {
+  const name = 'Widget';
+  const modifier = 'modifier';
+
+  const expectation = 'ais-Widget--modifier';
+  const actual = suit(name, '', modifier);
+
+  expect(actual).toBe(expectation);
+});
+
+it('expect to return "ais-Widget-element"', () => {
+  const name = 'Widget';
+  const element = 'element';
+
+  const expectation = 'ais-Widget-element';
+  const actual = suit(name, element);
+
+  expect(actual).toBe(expectation);
+});
+
+it('expect to return "ais-Widget-element--modifier"', () => {
+  const name = 'Widget';
+  const element = 'element';
+  const modifier = 'modifier';
+
+  const expectation = 'ais-Widget-element--modifier';
+  const actual = suit(name, element, modifier);
+
+  expect(actual).toBe(expectation);
+});
+
+it('expect to throw when widget is not provided', () => {
+  expect(() => suit()).toThrow('You need to provide `widgetName` in your data');
+});

--- a/src/components/MenuSelect.vue
+++ b/src/components/MenuSelect.vue
@@ -1,0 +1,82 @@
+<template>
+  <div
+    :class="[suit(''), !canRefine && suit('', 'noRefinement')]"
+    v-if="state"
+  >
+    <slot :items="items" :can-refine="canRefine" :refine="refine">
+      <select
+        :class="suit('select')"
+        @change="refine($event.currentTarget.value)"
+      >
+        <option :class="suit('option')" value="">
+          {{label}}
+        </option>
+        <option
+          v-for="item in items"
+          :key="item.value"
+          :class="suit('option')"
+          :value="item.value"
+          :selected="item.isRefined"
+        >
+          {{item.label}} ({{item.count}})
+        </option>
+      </select>
+    </slot>
+  </div>
+</template>
+
+<script>
+import algoliaComponent from '../component';
+import { connectMenu } from 'instantsearch.js/es/connectors';
+
+export default {
+  mixins: [algoliaComponent],
+  props: {
+    attribute: {
+      type: String,
+      required: true,
+    },
+    limit: {
+      type: Number,
+      required: false,
+    },
+    sortBy: {
+      // type: Array | Function
+      required: false,
+    },
+    label: {
+      type: String,
+      required: false,
+      default: 'See all',
+    },
+  },
+  data() {
+    return {
+      widgetName: 'MenuSelect',
+    };
+  },
+  beforeCreate() {
+    this.connector = connectMenu;
+  },
+  computed: {
+    widgetParams() {
+      return {
+        attributeName: this.attribute,
+        limit: this.limit,
+        sortBy: this.sortBy,
+      };
+    },
+    items() {
+      return this.state.items;
+    },
+    canRefine() {
+      return this.state.canRefine;
+    },
+  },
+  methods: {
+    refine(value) {
+      this.state.refine(value);
+    },
+  },
+};
+</script>

--- a/src/components/__tests__/MenuSelect.js
+++ b/src/components/__tests__/MenuSelect.js
@@ -1,0 +1,301 @@
+import { mount } from '@vue/test-utils';
+import MenuSelect from '../MenuSelect.vue';
+import { __setState } from '../../component';
+
+jest.mock('../../component');
+
+const defaultState = {
+  canRefine: true,
+  items: [
+    { label: 'Apple', value: 'Apple', isRefined: false, count: 50 },
+    { label: 'Samsung', value: 'Samsung', isRefined: false, count: 20 },
+    { label: 'Sony', value: 'Sony', isRefined: false, count: 15 },
+  ],
+};
+
+const defaultProps = {
+  attribute: 'brand',
+};
+
+it('accepts an attribute', () => {
+  __setState({
+    ...defaultState,
+  });
+
+  const props = {
+    ...defaultProps,
+  };
+
+  const wrapper = mount(MenuSelect, {
+    propsData: props,
+  });
+
+  expect(wrapper.vm.widgetParams.attributeName).toBe('brand');
+});
+
+it('accepts a limit', () => {
+  __setState({
+    ...defaultState,
+  });
+
+  const props = {
+    ...defaultProps,
+    limit: 5,
+  };
+
+  const wrapper = mount(MenuSelect, {
+    propsData: props,
+  });
+
+  expect(wrapper.vm.widgetParams.limit).toBe(5);
+});
+
+it('accepts a sortBy', () => {
+  __setState({
+    ...defaultState,
+  });
+
+  const props = {
+    ...defaultProps,
+    sortBy: ['name:desc'],
+  };
+
+  const wrapper = mount(MenuSelect, {
+    propsData: props,
+  });
+
+  expect(wrapper.vm.widgetParams.sortBy).toEqual(['name:desc']);
+});
+
+describe('default render', () => {
+  it('renders correctly', () => {
+    __setState({
+      ...defaultState,
+    });
+
+    const props = {
+      ...defaultProps,
+    };
+
+    const wrapper = mount(MenuSelect, {
+      propsData: props,
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with custom label', () => {
+    __setState({
+      ...defaultState,
+    });
+
+    const props = {
+      ...defaultProps,
+      label: 'None',
+    };
+
+    const wrapper = mount(MenuSelect, {
+      propsData: props,
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with a selected value', () => {
+    __setState({
+      ...defaultState,
+      items: [
+        { label: 'Apple', value: 'Apple', isRefined: false, count: 50 },
+        { label: 'Samsung', value: 'Samsung', isRefined: true, count: 20 },
+        { label: 'Sony', value: 'Sony', isRefined: false, count: 15 },
+      ],
+    });
+
+    const props = {
+      ...defaultProps,
+    };
+
+    const wrapper = mount(MenuSelect, {
+      propsData: props,
+    });
+
+    const selected = wrapper.find('[value="Samsung"]');
+    const options = wrapper.findAll('option:not([value="Samsung"])');
+
+    expect(selected.element.selected).toBe(true);
+
+    options.wrappers.forEach(option => {
+      expect(option.element.selected).toBe(false);
+    });
+  });
+
+  it('renders correctly without refinements', () => {
+    __setState({
+      ...defaultState,
+      canRefine: false,
+      items: [],
+    });
+
+    const props = {
+      ...defaultProps,
+    };
+
+    const wrapper = mount(MenuSelect, {
+      propsData: props,
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('calls refine on select change', () => {
+    const refine = jest.fn();
+
+    __setState({
+      ...defaultState,
+      refine,
+    });
+
+    const props = {
+      ...defaultProps,
+    };
+
+    const wrapper = mount(MenuSelect, {
+      propsData: props,
+    });
+
+    expect(refine).not.toHaveBeenCalled();
+
+    const select = wrapper.find('select');
+
+    // Simulate the change
+    select.element.value = 'Apple';
+
+    select.trigger('change');
+
+    expect(refine).toHaveBeenCalledTimes(1);
+    expect(refine).toHaveBeenCalledWith('Apple');
+  });
+});
+
+describe('custom default render', () => {
+  const defaultScopedSlots = `
+    <select
+      slot-scope="{ items, canRefine, refine }"
+      @change="refine($event.currentTarget.value)"
+      :disabled="!canRefine"
+    >
+      <option value="">All</option>
+      <option
+        v-for="item in items"
+        :key="item.value"
+        :value="item.value"
+        :selected="item.isRefined"
+      >
+        {{item.label}}
+      </option>
+    </select>
+  `;
+
+  it('renders correctly', () => {
+    __setState({
+      ...defaultState,
+    });
+
+    const props = {
+      ...defaultProps,
+    };
+
+    const wrapper = mount(MenuSelect, {
+      propsData: props,
+      scopedSlots: {
+        default: defaultScopedSlots,
+      },
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with a selected value', () => {
+    __setState({
+      ...defaultState,
+      items: [
+        { label: 'Apple', value: 'Apple', isRefined: false, count: 50 },
+        { label: 'Samsung', value: 'Samsung', isRefined: true, count: 20 },
+        { label: 'Sony', value: 'Sony', isRefined: false, count: 15 },
+      ],
+    });
+
+    const props = {
+      ...defaultProps,
+    };
+
+    const wrapper = mount(MenuSelect, {
+      propsData: props,
+      scopedSlots: {
+        default: defaultScopedSlots,
+      },
+    });
+
+    const selected = wrapper.find('[value="Samsung"]');
+    const options = wrapper.findAll('option:not([value="Samsung"])');
+
+    expect(selected.element.selected).toBe(true);
+
+    options.wrappers.forEach(option => {
+      expect(option.element.selected).toBe(false);
+    });
+  });
+
+  it('renders correctly without refinements', () => {
+    __setState({
+      ...defaultState,
+      canRefine: false,
+      items: [],
+    });
+
+    const props = {
+      ...defaultProps,
+    };
+
+    const wrapper = mount(MenuSelect, {
+      propsData: props,
+      scopedSlots: {
+        default: defaultScopedSlots,
+      },
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('calls refine on select change', () => {
+    const refine = jest.fn();
+
+    __setState({
+      ...defaultState,
+      refine,
+    });
+
+    const props = {
+      ...defaultProps,
+    };
+
+    const wrapper = mount(MenuSelect, {
+      propsData: props,
+      scopedSlots: {
+        default: defaultScopedSlots,
+      },
+    });
+
+    expect(refine).not.toHaveBeenCalled();
+
+    const select = wrapper.find('select');
+
+    // Simulate the change
+    select.element.value = 'Apple';
+
+    select.trigger('change');
+
+    expect(refine).toHaveBeenCalledTimes(1);
+    expect(refine).toHaveBeenCalledWith('Apple');
+  });
+});

--- a/src/components/__tests__/__snapshots__/MenuSelect.js.snap
+++ b/src/components/__tests__/__snapshots__/MenuSelect.js.snap
@@ -1,0 +1,106 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`custom default render renders correctly 1`] = `
+
+<div class="ais-MenuSelect">
+  <select>
+    <option value>
+      All
+    </option>
+    <option value="Apple">
+      Apple
+    </option>
+    <option value="Samsung">
+      Samsung
+    </option>
+    <option value="Sony">
+      Sony
+    </option>
+  </select>
+</div>
+
+`;
+
+exports[`custom default render renders correctly without refinements 1`] = `
+
+<div class="ais-MenuSelect ais-MenuSelect--noRefinement">
+  <select disabled="disabled">
+    <option value>
+      All
+    </option>
+  </select>
+</div>
+
+`;
+
+exports[`default render renders correctly 1`] = `
+
+<div class="ais-MenuSelect">
+  <select class="ais-MenuSelect-select">
+    <option value
+            class="ais-MenuSelect-option"
+    >
+      See all
+    </option>
+    <option class="ais-MenuSelect-option"
+            value="Apple"
+    >
+      Apple (50)
+    </option>
+    <option class="ais-MenuSelect-option"
+            value="Samsung"
+    >
+      Samsung (20)
+    </option>
+    <option class="ais-MenuSelect-option"
+            value="Sony"
+    >
+      Sony (15)
+    </option>
+  </select>
+</div>
+
+`;
+
+exports[`default render renders correctly with custom label 1`] = `
+
+<div class="ais-MenuSelect">
+  <select class="ais-MenuSelect-select">
+    <option value
+            class="ais-MenuSelect-option"
+    >
+      None
+    </option>
+    <option class="ais-MenuSelect-option"
+            value="Apple"
+    >
+      Apple (50)
+    </option>
+    <option class="ais-MenuSelect-option"
+            value="Samsung"
+    >
+      Samsung (20)
+    </option>
+    <option class="ais-MenuSelect-option"
+            value="Sony"
+    >
+      Sony (15)
+    </option>
+  </select>
+</div>
+
+`;
+
+exports[`default render renders correctly without refinements 1`] = `
+
+<div class="ais-MenuSelect ais-MenuSelect--noRefinement">
+  <select class="ais-MenuSelect-select">
+    <option value
+            class="ais-MenuSelect-option"
+    >
+      See all
+    </option>
+  </select>
+</div>
+
+`;

--- a/src/instantsearch.js
+++ b/src/instantsearch.js
@@ -9,6 +9,7 @@ import Stats from './components/Stats.vue';
 import Configure from './components/Configure.vue';
 import Pagination from './components/Pagination.vue';
 import Menu from './components/Menu.vue';
+import MenuSelect from './components/MenuSelect.vue';
 import SortBySelector from './components/SortBySelector.vue';
 import SearchBox from './components/SearchBox.vue';
 import ClearRefinements from './components/ClearRefinements.vue';
@@ -28,6 +29,7 @@ const InstantSearch = {
   Stats,
   Pagination,
   Menu,
+  MenuSelect,
   SortBySelector,
   SearchBox,
   ClearRefinements,
@@ -46,6 +48,7 @@ const InstantSearch = {
     Vue.component('ais-stats', Stats);
     Vue.component('ais-pagination', Pagination);
     Vue.component('ais-menu', Menu);
+    Vue.component('ais-menu-select', MenuSelect);
     Vue.component('ais-sort-by-selector', SortBySelector);
     Vue.component('ais-search-box', SearchBox);
     Vue.component('ais-clear-refinements', ClearRefinements);

--- a/src/suit.js
+++ b/src/suit.js
@@ -1,16 +1,17 @@
-export default function suit(widgetName, element, subElement) {
+export default function suit(widgetName, element, modifier) {
   if (!widgetName) {
     throw new Error('You need to provide `widgetName` in your data');
   }
 
+  const elements = [`ais-${widgetName}`];
+
   if (element) {
-    const scopedWidgetName = `ais-${widgetName}-${element}`;
-    // output `ais-Widget-xyz--abc`
-    if (subElement) return `${scopedWidgetName}--${subElement}`;
-    // output `ais-Widget-xyz`
-    return scopedWidgetName;
-  } else {
-    // output `ais-Widget`
-    return `ais-${widgetName}`;
+    elements.push(`-${element}`);
   }
+
+  if (modifier) {
+    elements.push(`--${modifier}`);
+  }
+
+  return elements.join('');
 }

--- a/stories/MenuSelect.stories.js
+++ b/stories/MenuSelect.stories.js
@@ -1,0 +1,55 @@
+import { previewWrapper } from './utils';
+import { storiesOf } from '@storybook/vue';
+
+storiesOf('MenuSelect', module)
+  .addDecorator(previewWrapper)
+  .add('simple usage', () => ({
+    template: '<ais-menu-select attribute="brand" />',
+  }))
+  .add('with a limit', () => ({
+    template: `
+      <ais-menu-select
+        attribute="brand"
+        :limit="5"
+      />
+    `,
+  }))
+  .add('custom sort', () => ({
+    template: `
+      <ais-menu-select
+        attribute="brand"
+        :sort-by="['name:desc']"
+      />
+    `,
+  }))
+  .add('custom label', () => ({
+    template: `
+      <ais-menu-select
+        attribute="brand"
+        label="None"
+      />
+    `,
+  }))
+  .add('custom rendering', () => ({
+    template: `
+      <ais-menu-select attribute="brand">
+        <select
+          slot-scope="{ items, canRefine, refine }"
+          @change="refine($event.currentTarget.value)"
+          :disabled="!canRefine"
+        >
+          <option value="">
+            All
+          </option>
+          <option
+            v-for="item in items"
+            :key="item.value"
+            :value="item.value"
+            :selected="item.isRefined"
+          >
+            {{item.label}}
+          </option>
+        </select>
+      </ais-menu-select>
+    `,
+  }));


### PR DESCRIPTION
**Summary**

In the implementation I used `:selected + @change`  rather than `v-model` because [computed setter](https://vuejs.org/v2/guide/computed.html#Computed-Setter) are not called when passed through the scope slots (I didn't find why but probably because the scope is different).

I also updated the `suit` function to be able to generate class like `ais-Widget--modifier`. With the previous implementation it was not possible. In order to have the `modifier` it was always needed to pass a valid `element`.