### PR TITLE
Stop false positives in No Results Comp!

### DIFF
--- a/src/components/NoResults.vue
+++ b/src/components/NoResults.vue
@@ -20,7 +20,7 @@ export default {
     totalResults() {
       return this.searchStore.totalResults;
     },
-    processingTime(){
+    processingTime() {
       return this.searchStore.processingTimeMS;
     },
     query() {

--- a/src/components/NoResults.vue
+++ b/src/components/NoResults.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="bem()" v-if="totalResults <= 0">
+  <div :class="bem()" v-if="totalResults <= 0 && processingTime > 0">
     <slot :query="query">
       No results matched your query <strong :class="bem('query')">{{query}}</strong>
     </slot>
@@ -19,6 +19,9 @@ export default {
   computed: {
     totalResults() {
       return this.searchStore.totalResults;
+    },
+    processingTime(){
+      return this.searchStore.processingTimeMS
     },
     query() {
       return this.searchStore.query;

--- a/src/components/NoResults.vue
+++ b/src/components/NoResults.vue
@@ -21,7 +21,7 @@ export default {
       return this.searchStore.totalResults;
     },
     processingTime(){
-      return this.searchStore.processingTimeMS
+      return this.searchStore.processingTimeMS;
     },
     query() {
       return this.searchStore.query;


### PR DESCRIPTION
This comp misfires a lot when loading legit results (flashes on/off), just watch searchStore.results.length to find out.  This tweak at least makes it so it will only show when you actually launched a query. 