### PR TITLE
feat(Stats): add more info to slot

### DIFF
--- a/src/components/Stats.vue
+++ b/src/components/Stats.vue
@@ -1,7 +1,8 @@
 <template>
   <div :class="bem()" v-if="totalResults > 0">
-    <slot :totalResults="totalResults" :processingTime="processingTime" :query="query">
-      {{ totalResults.toLocaleString() }} results found in {{ processingTime.toLocaleString() }}ms
+    <slot :totalResults="totalResults" :processingTime="processingTime" :query="query" :resultStart="resultStart" :resultEnd="resultEnd">
+      Showing {{ resultStart.toLocaleString() }} - {{ resultEnd.toLocaleString() }} of {{ totalResults.toLocaleString() }},
+      took {{ processingTime.toLocaleString() }}ms
     </slot>
   </div>
 </template>

--- a/src/components/Stats.vue
+++ b/src/components/Stats.vue
@@ -1,8 +1,7 @@
 <template>
   <div :class="bem()" v-if="totalResults > 0">
     <slot :totalResults="totalResults" :processingTime="processingTime" :query="query" :resultStart="resultStart" :resultEnd="resultEnd">
-      Showing {{ resultStart.toLocaleString() }} - {{ resultEnd.toLocaleString() }} of {{ totalResults.toLocaleString() }},
-      took {{ processingTime.toLocaleString() }}ms
+      {{ totalResults.toLocaleString() }} results found in {{ processingTime.toLocaleString() }}ms
     </slot>
   </div>
 </template>

--- a/src/components/Stats.vue
+++ b/src/components/Stats.vue
@@ -26,6 +26,12 @@ export default {
     processingTime() {
       return this.searchStore.processingTimeMS;
     },
+    resultStart() {
+      return (this.searchStore.page - 1) * this.searchStore.resultsPerPage + 1;
+    },
+    resultEnd() {
+      return this.resultsStart + this.searchStore.results.length - 1;
+    },
   },
 };
 </script>

--- a/src/components/Stats.vue
+++ b/src/components/Stats.vue
@@ -27,9 +27,13 @@ export default {
       return this.searchStore.processingTimeMS;
     },
     resultStart() {
+      if(!this.searchStore || !this.searchStore.page || !this.searchStore.resultsPerPage) return undefined
+      
       return (this.searchStore.page - 1) * this.searchStore.resultsPerPage + 1;
     },
     resultEnd() {
+      if(!this.resultStart || !this.searchStore || !this.searchStore.results) return undefined
+      
       return this.resultStart + this.searchStore.results.length - 1;
     },
   },

--- a/src/components/Stats.vue
+++ b/src/components/Stats.vue
@@ -30,7 +30,7 @@ export default {
       return (this.searchStore.page - 1) * this.searchStore.resultsPerPage + 1;
     },
     resultEnd() {
-      return this.resultsStart + this.searchStore.results.length - 1;
+      return this.resultStart + this.searchStore.results.length - 1;
     },
   },
 };

--- a/src/components/Stats.vue
+++ b/src/components/Stats.vue
@@ -27,12 +27,14 @@ export default {
       return this.searchStore.processingTimeMS;
     },
     resultStart() {
-      if(!this.searchStore || !this.searchStore.page || !this.searchStore.resultsPerPage) return undefined
+      if(!this.searchStore || !this.searchStore.page || !this.searchStore.resultsPerPage)
+        return undefined
       
       return (this.searchStore.page - 1) * this.searchStore.resultsPerPage + 1;
     },
     resultEnd() {
-      if(!this.resultStart || !this.searchStore || !this.searchStore.results) return undefined
+      if(!this.resultStart || !this.searchStore || !this.searchStore.results)
+        return undefined
       
       return this.resultStart + this.searchStore.results.length - 1;
     },


### PR DESCRIPTION
Adding resultStart and resultEnd gives you "Amazon Like" stats.  For example "Showing {{ resultStart }} - {{ resultEnd }} of {{ totalResults }}" would show "Showing 31 - 60 of 123" when you are on page 2 with 30 / page.

Adding just these 2 things makes this comp much more usable in production.