### PR TITLE
fix(SearchBox): propagate the classname overrides to children

### DIFF
--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -1,7 +1,18 @@
 <template>
-  <form role="search" action="" @submit.prevent="onFormSubmit">
+  <form
+    role="search"
+    action=""
+    @submit.prevent="onFormSubmit"
+    :class="bem('form')"
+  >
     <slot>
-      <ais-input :search-store="searchStore" :placeholder="placeholder" :autofocus="autofocus"></ais-input>
+      <ais-input
+        :search-store="searchStore"
+        :placeholder="placeholder"
+        :autofocus="autofocus"
+        :class-names="classNames"
+      >
+      </ais-input>
       <div v-if="showLoadingIndicator" :hidden="!searchStore.isSearchStalled" :class="bem('loading-indicator')" >
         <slot name="loading-indicator" >
           <svg width="1em" height="1em" viewBox="0 0 38 38" xmlns="http://www.w3.org/2000/svg" stroke="#000">
@@ -31,7 +42,7 @@
           />
         </svg>
       </button>
-      <ais-clear :search-store="searchStore">
+      <ais-clear :search-store="searchStore" :class-names="classNames">
         <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 20 20">
           <title>{{ clearTitle }}</title>
           <path

--- a/src/components/__tests__/__snapshots__/search-box.js.snap
+++ b/src/components/__tests__/__snapshots__/search-box.js.snap
@@ -4,6 +4,7 @@ exports[`SearchBox component can be autofocused 1`] = `
 
 <form role="search"
       action
+      class="ais-search-box__form"
 >
   <input type="search"
          autocorrect="off"
@@ -58,6 +59,7 @@ exports[`SearchBox component if search is not stalled, show the submit and hide 
 
 <form role="search"
       action
+      class="ais-search-box__form"
 >
   <input type="search"
          autocorrect="off"
@@ -146,6 +148,7 @@ exports[`SearchBox component if search is stalled, hide the submit and display t
 
 <form role="search"
       action
+      class="ais-search-box__form"
 >
   <input type="search"
          autocorrect="off"
@@ -233,6 +236,7 @@ exports[`SearchBox component renders proper HTML 1`] = `
 
 <form role="search"
       action
+      class="ais-search-box__form"
 >
   <input type="search"
          autocorrect="off"


### PR DESCRIPTION
We never noticed it because this wasn't a very popular API, but if you use vanilla ais-search-box, you can not override the class names of the input or the clear which are nested within the component.

This is not an issue we have in v2, since we removed this API and no longer nest components in eachother, so it doesn't need to be passed around.

Using the `:class-names` API to pretend v1 is using InstantSearch.css with @francoischalifour made me realise that this is a useful API to keep, so it should be replicated in v2 as well.

(this change was tested in @francoischalifour's node_modules)