### PR TITLE
docs(index): fix parameter used in example

### DIFF
--- a/docs/src/components/index.md
+++ b/docs/src/components/index.md
@@ -33,8 +33,7 @@ Provide search query parameters:
            app-id="YourAppID"
            api-key="YourSearchAPIKey"
            :query-parameters="{
-             distinct: true,
-             attributeForDistinct: 'product_id'
+             distinct: true
            }"
 >
   <!-- Add your InstantSearch components here. -->


### PR DESCRIPTION
The `attributeForDistinct` parameter isn't a search parameter, so it can't be used with the `query-parameters` prop.

This follows up on a HelpScout ticket: https://secure.helpscout.net/conversation/617944989/74808?folderId=1106372