### PR TITLE
feat(Menu): add widget

### DIFF
--- a/docs/src/components/menu.md
+++ b/docs/src/components/menu.md
@@ -23,28 +23,25 @@ Create a menu based on a facet. A menu displays a list of facet values and let t
 
 Name | Type | Default | Description | Required
 ---|---|---|---|---
-attribute | String | | The attribute | yes
-limit | Number | 10 | Number of items to show
-showMoreLimit | Number | 20 | Number of items to show when the user clicked on "show more items"
-showMore | Boolean | `false` | Whether or not to have the option to load more values
-sortBy | Array(string) or function | `['isRefined:desc', 'count:desc', 'name:asc']` | array or function to sort the results by
+attribute | string | - | The attribute | Yes
+limit | number | 10 | Number of items to show | -
+showMoreLimit | number | 20 | Number of items to show when the user clicked on "show more" | -
+showMore | boolean | `false` | Whether or not to have the option to load more values | -
+sortBy | string[] or function | `['name:asc', 'count:desc']` | Array or function to sort the results by | -
 
 ## CSS classes
 
-Here's a list of CSS classes exposed by this widget. To better understand the underlying
-DOM structure, have a look at the generated DOM in your browser.
+Here's a list of CSS classes exposed by this widget. To better understand the underlying DOM structure, have a look at the generated DOM in your browser.
 
 Class name | Description
 ---|---
 `.ais-Menu` | the root div of the widget
 `.ais-Menu--noRefinement` | the root div of the widget with no refinement
-`.ais-Menu-searchBox` | the search box of the widget
 `.ais-Menu-list` | the list of all menu items
 `.ais-Menu-item` | the menu list item
 `.ais-Menu-item--selected` | the selected menu list item
 `.ais-Menu-link` | the clickable menu element
 `.ais-Menu-label` | the label of each item
 `.ais-Menu-count` | the count of values for each item
-`.ais-Menu-noResults` | the div displayed when there are no results
 `.ais-Menu-showMore` | the button used to display more categories
 `.ais-Menu-showMore--disabled` | the disabled button used to display more categories

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -53,29 +53,29 @@ export default {
       type: Number,
       default: 10,
     },
+    showMoreLimit: {
+      type: Number,
+      default: 20,
+    },
     showMore: {
       type: Boolean,
       default: false,
     },
-    showMoreLimit: {
-      type: Number,
-    },
     sortBy: {
+      // type: Array || Function
       default() {
-        return ['isRefined:desc', 'count:desc', 'name:asc'];
+        return ['name:asc', 'count:desc'];
       },
     },
+
+    // How to implement those values?
     showMoreLabel: {
       type: String,
-      default() {
-        return 'Show more';
-      },
+      default: 'Show more',
     },
     showLessLabel: {
       type: String,
-      default() {
-        return 'Show less';
-      },
+      default: 'Show less',
     },
   },
   computed: {

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -102,5 +102,4 @@ export default {
       return this.state.canRefine && this.showMore;
     },
   },
-};
-</script>
+};</script>

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -1,20 +1,22 @@
 <template>
-  <div :class="suit()" v-if="state">
+  <div
+    v-if="state"
+    :class="[suit(''), !state.canRefine && suit('', 'noRefinement')]"
+  >
     <slot
-      :items="items"
-      :createURL="createURL"
-      :refine="refine"
-      :canRefine="canRefine"
-      :widgetParams="widgetParams"
-      :isShowingMore="isShowingMore"
-      :toggleShowMore="toggleShowMore"
-      :canToggleShowMore="canToggleShowMore"
+      :items="state.items"
+      :can-refine="state.canRefine"
+      :can-toggle-show-more="state.canToggleShowMore"
+      :is-showing-more="state.isShowingMore"
+      :refine="state.refine"
+      :create-URL="state.createURL"
+      :toggle-show-more="state.toggleShowMore"
     >
       <ul :class="suit('list')">
         <li
           v-for="item in state.items"
-          :class="item.isRefined ? suit('item', 'active') : suit('item')"
           :key="item.value"
+          :class="[suit('item'), item.isRefined && suit('item', 'selected')]"
         >
           <a
             :href="state.createURL(item.value)"
@@ -28,19 +30,23 @@
       </ul>
 
       <button
-        v-if="showMore && state.canToggleShowMore"
+        v-if="showShowMoreButton"
+        :class="[suit('showMore'), !state.canToggleShowMore && suit('showMore', 'disabled')]"
+        :disabled="!state.canToggleShowMore"
         @click.prevent="state.toggleShowMore()"
-        :class="state.canToggleShowMore ? suit('showMore') : suit('showMore', 'disabled')"
       >
-        {{state.isShowingMore ? showLessLabel : showMoreLabel}}
+        <slot name="showMoreLabel" :is-showing-more="state.isShowingMore">
+          {{state.isShowingMore ? 'Show less' : 'Show more'}}
+        </slot>
       </button>
     </slot>
   </div>
 </template>
 
 <script>
-import algoliaComponent from '../component';
+import isFunction from 'lodash/isFunction';
 import { connectMenu } from 'instantsearch.js/es/connectors';
+import algoliaComponent from '../component';
 
 export default {
   mixins: [algoliaComponent],
@@ -62,21 +68,21 @@ export default {
       default: false,
     },
     sortBy: {
-      // type: Array || Function
       default() {
         return ['name:asc', 'count:desc'];
       },
+      validator(value) {
+        return Array.isArray(value) || isFunction(value);
+      },
     },
-
-    // How to implement those values?
-    showMoreLabel: {
-      type: String,
-      default: 'Show more',
-    },
-    showLessLabel: {
-      type: String,
-      default: 'Show less',
-    },
+  },
+  beforeCreate() {
+    this.connector = connectMenu;
+  },
+  data() {
+    return {
+      widgetName: 'Menu',
+    };
   },
   computed: {
     widgetParams() {
@@ -87,13 +93,9 @@ export default {
         sortBy: this.sortBy,
       };
     },
+    showShowMoreButton() {
+      return this.state.canRefine && this.showMore;
+    },
   },
-  data() {
-    return {
-      widgetName: 'Menu',
-    };
-  },
-  beforeCreate() {
-    this.connector = connectMenu;
-  },
-};</script>
+};
+</script>

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -55,6 +55,11 @@ export default {
       type: String,
       required: true,
     },
+    // @TODO
+    // searchable: {
+    //   type: Boolean,
+    //   default: false,
+    // },
     limit: {
       type: Number,
       default: 10,

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    v-if="state"
-    :class="[suit(''), !state.canRefine && suit('', 'noRefinement')]"
-  >
+  <div v-if="state">
     <slot
       :items="state.items"
       :can-refine="state.canRefine"
@@ -12,33 +9,35 @@
       :create-URL="state.createURL"
       :toggle-show-more="state.toggleShowMore"
     >
-      <ul :class="suit('list')">
-        <li
-          v-for="item in state.items"
-          :key="item.value"
-          :class="[suit('item'), item.isRefined && suit('item', 'selected')]"
-        >
-          <a
-            :href="state.createURL(item.value)"
-            :class="suit('link')"
-            @click.prevent="state.refine(item.value)"
+      <div :class="[suit(''), !state.canRefine && suit('', 'noRefinement')]">
+        <ul :class="suit('list')">
+          <li
+            v-for="item in state.items"
+            :key="item.value"
+            :class="[suit('item'), item.isRefined && suit('item', 'selected')]"
           >
-            <span :class="suit('label')">{{item.label}}</span>
-            <span :class="suit('count')">{{item.count}}</span>
-          </a>
-        </li>
-      </ul>
+            <a
+              :href="state.createURL(item.value)"
+              :class="suit('link')"
+              @click.prevent="state.refine(item.value)"
+            >
+              <span :class="suit('label')">{{item.label}}</span>
+              <span :class="suit('count')">{{item.count}}</span>
+            </a>
+          </li>
+        </ul>
 
-      <button
-        v-if="showShowMoreButton"
-        :class="[suit('showMore'), !state.canToggleShowMore && suit('showMore', 'disabled')]"
-        :disabled="!state.canToggleShowMore"
-        @click.prevent="state.toggleShowMore()"
-      >
-        <slot name="showMoreLabel" :is-showing-more="state.isShowingMore">
-          {{state.isShowingMore ? 'Show less' : 'Show more'}}
-        </slot>
-      </button>
+        <button
+          v-if="showShowMoreButton"
+          :class="[suit('showMore'), !state.canToggleShowMore && suit('showMore', 'disabled')]"
+          :disabled="!state.canToggleShowMore"
+          @click.prevent="state.toggleShowMore()"
+        >
+          <slot name="showMoreLabel" :is-showing-more="state.isShowingMore">
+            {{state.isShowingMore ? 'Show less' : 'Show more'}}
+          </slot>
+        </button>
+      </div>
     </slot>
   </div>
 </template>

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -1,5 +1,8 @@
 <template>
-  <div v-if="state">
+  <div
+    v-if="state"
+    :class="[suit(''), !state.canRefine && suit('', 'noRefinement')]"
+  >
     <slot
       :items="state.items"
       :can-refine="state.canRefine"
@@ -9,35 +12,33 @@
       :create-URL="state.createURL"
       :toggle-show-more="state.toggleShowMore"
     >
-      <div :class="[suit(''), !state.canRefine && suit('', 'noRefinement')]">
-        <ul :class="suit('list')">
-          <li
-            v-for="item in state.items"
-            :key="item.value"
-            :class="[suit('item'), item.isRefined && suit('item', 'selected')]"
-          >
-            <a
-              :href="state.createURL(item.value)"
-              :class="suit('link')"
-              @click.prevent="state.refine(item.value)"
-            >
-              <span :class="suit('label')">{{item.label}}</span>
-              <span :class="suit('count')">{{item.count}}</span>
-            </a>
-          </li>
-        </ul>
-
-        <button
-          v-if="showShowMoreButton"
-          :class="[suit('showMore'), !state.canToggleShowMore && suit('showMore', 'disabled')]"
-          :disabled="!state.canToggleShowMore"
-          @click.prevent="state.toggleShowMore()"
+      <ul :class="suit('list')">
+        <li
+          v-for="item in state.items"
+          :key="item.value"
+          :class="[suit('item'), item.isRefined && suit('item', 'selected')]"
         >
-          <slot name="showMoreLabel" :is-showing-more="state.isShowingMore">
-            {{state.isShowingMore ? 'Show less' : 'Show more'}}
-          </slot>
-        </button>
-      </div>
+          <a
+            :href="state.createURL(item.value)"
+            :class="suit('link')"
+            @click.prevent="state.refine(item.value)"
+          >
+            <span :class="suit('label')">{{item.label}}</span>
+            <span :class="suit('count')">{{item.count}}</span>
+          </a>
+        </li>
+      </ul>
+
+      <button
+        v-if="showShowMoreButton"
+        :class="[suit('showMore'), !state.canToggleShowMore && suit('showMore', 'disabled')]"
+        :disabled="!state.canToggleShowMore"
+        @click.prevent="state.toggleShowMore()"
+      >
+        <slot name="showMoreLabel" :is-showing-more="state.isShowingMore">
+          {{state.isShowingMore ? 'Show less' : 'Show more'}}
+        </slot>
+      </button>
     </slot>
   </div>
 </template>

--- a/src/components/__tests__/__snapshots__/menu.js.snap
+++ b/src/components/__tests__/__snapshots__/menu.js.snap
@@ -1,82 +1,557 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly 1`] = `
+exports[`custom default render renders correctly 1`] = `
 
-<div class="ais-Menu">
-  <ul class="ais-Menu-list">
-    <li class="ais-Menu-item--active">
-      <a class="ais-Menu-link">
-        <span class="ais-Menu-label">
-          foo
-        </span>
-        <span class="ais-Menu-count">
-          2
-        </span>
-      </a>
-    </li>
-    <li class="ais-Menu-item">
-      <a class="ais-Menu-link">
-        <span class="ais-Menu-label">
-          bar
-        </span>
-        <span class="ais-Menu-count">
-          3
-        </span>
-      </a>
-    </li>
-    <li class="ais-Menu-item">
-      <a class="ais-Menu-link">
-        <span class="ais-Menu-label">
-          foobar
-        </span>
-        <span class="ais-Menu-count">
-          4
-        </span>
-      </a>
-    </li>
-  </ul>
+<div>
+  <div class>
+    <ol>
+      <li>
+        <a>
+          Apple - 50
+        </a>
+      </li>
+      <li>
+        <a>
+          Samsung - 25
+        </a>
+      </li>
+      <li>
+        <a>
+          Microsoft - 12
+        </a>
+      </li>
+    </ol>
+    <button disabled="disabled">
+      Show more
+    </button>
+  </div>
 </div>
 
 `;
 
-exports[`renders correctly with showMore 1`] = `
+exports[`custom default render renders correctly with a disabled show more button 1`] = `
 
-<div class="ais-Menu">
-  <ul class="ais-Menu-list">
-    <li class="ais-Menu-item--active">
-      <a class="ais-Menu-link">
-        <span class="ais-Menu-label">
-          foo
-        </span>
-        <span class="ais-Menu-count">
-          2
-        </span>
-      </a>
-    </li>
-    <li class="ais-Menu-item">
-      <a class="ais-Menu-link">
-        <span class="ais-Menu-label">
-          bar
-        </span>
-        <span class="ais-Menu-count">
-          3
-        </span>
-      </a>
-    </li>
-    <li class="ais-Menu-item">
-      <a class="ais-Menu-link">
-        <span class="ais-Menu-label">
-          foobar
-        </span>
-        <span class="ais-Menu-count">
-          4
-        </span>
-      </a>
-    </li>
-  </ul>
-  <button class="ais-Menu-showMore">
-    Show more
-  </button>
+<div>
+  <div class>
+    <ol>
+      <li>
+        <a>
+          Apple - 50
+        </a>
+      </li>
+      <li>
+        <a>
+          Samsung - 25
+        </a>
+      </li>
+      <li>
+        <a>
+          Microsoft - 12
+        </a>
+      </li>
+    </ol>
+    <button disabled="disabled">
+      Show more
+    </button>
+  </div>
+</div>
+
+`;
+
+exports[`custom default render renders correctly with a show more button toggled 1`] = `
+
+<div>
+  <div class>
+    <ol>
+      <li>
+        <a>
+          Apple - 50
+        </a>
+      </li>
+      <li>
+        <a>
+          Samsung - 25
+        </a>
+      </li>
+      <li>
+        <a>
+          Microsoft - 12
+        </a>
+      </li>
+    </ol>
+    <button disabled="disabled">
+      Show less
+    </button>
+  </div>
+</div>
+
+`;
+
+exports[`custom default render renders correctly with an URL for the href 1`] = `
+
+<div>
+  <div class>
+    <ol>
+      <li>
+        <a href="/brand/Apple">
+          Apple - 50
+        </a>
+      </li>
+      <li>
+        <a href="/brand/Samsung">
+          Samsung - 25
+        </a>
+      </li>
+      <li>
+        <a href="/brand/Microsoft">
+          Microsoft - 12
+        </a>
+      </li>
+    </ol>
+    <button disabled="disabled">
+      Show more
+    </button>
+  </div>
+</div>
+
+`;
+
+exports[`custom default render renders correctly without refinement 1`] = `
+
+<div>
+  <div class="no-refinement">
+    <ol>
+    </ol>
+    <button disabled="disabled">
+      Show more
+    </button>
+  </div>
+</div>
+
+`;
+
+exports[`custom showMoreLabel render renders correctly with a custom show more label 1`] = `
+
+<div>
+  <div class="ais-Menu">
+    <ul class="ais-Menu-list">
+      <li class="ais-Menu-item">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Apple
+          </span>
+          <span class="ais-Menu-count">
+            50
+          </span>
+        </a>
+      </li>
+      <li class="ais-Menu-item">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Samsung
+          </span>
+          <span class="ais-Menu-count">
+            25
+          </span>
+        </a>
+      </li>
+      <li class="ais-Menu-item">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Microsoft
+          </span>
+          <span class="ais-Menu-count">
+            12
+          </span>
+        </a>
+      </li>
+    </ul>
+    <button disabled="disabled"
+            class="ais-Menu-showMore ais-Menu-showMore--disabled"
+    >
+      <span>
+        Voir plus
+      </span>
+    </button>
+  </div>
+</div>
+
+`;
+
+exports[`custom showMoreLabel render renders correctly with a custom show more label toggled 1`] = `
+
+<div>
+  <div class="ais-Menu">
+    <ul class="ais-Menu-list">
+      <li class="ais-Menu-item">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Apple
+          </span>
+          <span class="ais-Menu-count">
+            50
+          </span>
+        </a>
+      </li>
+      <li class="ais-Menu-item">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Samsung
+          </span>
+          <span class="ais-Menu-count">
+            25
+          </span>
+        </a>
+      </li>
+      <li class="ais-Menu-item">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Microsoft
+          </span>
+          <span class="ais-Menu-count">
+            12
+          </span>
+        </a>
+      </li>
+    </ul>
+    <button disabled="disabled"
+            class="ais-Menu-showMore ais-Menu-showMore--disabled"
+    >
+      <span>
+        Voir moins
+      </span>
+    </button>
+  </div>
+</div>
+
+`;
+
+exports[`default render renders correctly 1`] = `
+
+<div>
+  <div class="ais-Menu">
+    <ul class="ais-Menu-list">
+      <li class="ais-Menu-item">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Apple
+          </span>
+          <span class="ais-Menu-count">
+            50
+          </span>
+        </a>
+      </li>
+      <li class="ais-Menu-item">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Samsung
+          </span>
+          <span class="ais-Menu-count">
+            25
+          </span>
+        </a>
+      </li>
+      <li class="ais-Menu-item">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Microsoft
+          </span>
+          <span class="ais-Menu-count">
+            12
+          </span>
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>
+
+`;
+
+exports[`default render renders correctly with a URL for the href 1`] = `
+
+<div>
+  <div class="ais-Menu">
+    <ul class="ais-Menu-list">
+      <li class="ais-Menu-item">
+        <a href="/brand/Apple"
+           class="ais-Menu-link"
+        >
+          <span class="ais-Menu-label">
+            Apple
+          </span>
+          <span class="ais-Menu-count">
+            50
+          </span>
+        </a>
+      </li>
+      <li class="ais-Menu-item">
+        <a href="/brand/Samsung"
+           class="ais-Menu-link"
+        >
+          <span class="ais-Menu-label">
+            Samsung
+          </span>
+          <span class="ais-Menu-count">
+            25
+          </span>
+        </a>
+      </li>
+      <li class="ais-Menu-item">
+        <a href="/brand/Microsoft"
+           class="ais-Menu-link"
+        >
+          <span class="ais-Menu-label">
+            Microsoft
+          </span>
+          <span class="ais-Menu-count">
+            12
+          </span>
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>
+
+`;
+
+exports[`default render renders correctly with a disabled show more button 1`] = `
+
+<div>
+  <div class="ais-Menu">
+    <ul class="ais-Menu-list">
+      <li class="ais-Menu-item">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Apple
+          </span>
+          <span class="ais-Menu-count">
+            50
+          </span>
+        </a>
+      </li>
+      <li class="ais-Menu-item">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Samsung
+          </span>
+          <span class="ais-Menu-count">
+            25
+          </span>
+        </a>
+      </li>
+      <li class="ais-Menu-item">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Microsoft
+          </span>
+          <span class="ais-Menu-count">
+            12
+          </span>
+        </a>
+      </li>
+    </ul>
+    <button disabled="disabled"
+            class="ais-Menu-showMore ais-Menu-showMore--disabled"
+    >
+      Show more
+    </button>
+  </div>
+</div>
+
+`;
+
+exports[`default render renders correctly with a selected item 1`] = `
+
+<div>
+  <div class="ais-Menu">
+    <ul class="ais-Menu-list">
+      <li class="ais-Menu-item">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Apple
+          </span>
+          <span class="ais-Menu-count">
+            50
+          </span>
+        </a>
+      </li>
+      <li class="ais-Menu-item ais-Menu-item--selected">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Samsung
+          </span>
+          <span class="ais-Menu-count">
+            25
+          </span>
+        </a>
+      </li>
+      <li class="ais-Menu-item">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Microsoft
+          </span>
+          <span class="ais-Menu-count">
+            12
+          </span>
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>
+
+`;
+
+exports[`default render renders correctly with show more button 1`] = `
+
+<div>
+  <div class="ais-Menu">
+    <ul class="ais-Menu-list">
+      <li class="ais-Menu-item">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Apple
+          </span>
+          <span class="ais-Menu-count">
+            50
+          </span>
+        </a>
+      </li>
+      <li class="ais-Menu-item">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Samsung
+          </span>
+          <span class="ais-Menu-count">
+            25
+          </span>
+        </a>
+      </li>
+      <li class="ais-Menu-item">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Microsoft
+          </span>
+          <span class="ais-Menu-count">
+            12
+          </span>
+        </a>
+      </li>
+    </ul>
+    <button disabled="disabled"
+            class="ais-Menu-showMore ais-Menu-showMore--disabled"
+    >
+      Show more
+    </button>
+  </div>
+</div>
+
+`;
+
+exports[`default render renders correctly with show more button toggled 1`] = `
+
+<div>
+  <div class="ais-Menu">
+    <ul class="ais-Menu-list">
+      <li class="ais-Menu-item">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Apple
+          </span>
+          <span class="ais-Menu-count">
+            50
+          </span>
+        </a>
+      </li>
+      <li class="ais-Menu-item">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Samsung
+          </span>
+          <span class="ais-Menu-count">
+            25
+          </span>
+        </a>
+      </li>
+      <li class="ais-Menu-item">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Microsoft
+          </span>
+          <span class="ais-Menu-count">
+            12
+          </span>
+        </a>
+      </li>
+    </ul>
+    <button disabled="disabled"
+            class="ais-Menu-showMore ais-Menu-showMore--disabled"
+    >
+      Show less
+    </button>
+  </div>
+</div>
+
+`;
+
+exports[`default render renders correctly without a show more button (canRefine) 1`] = `
+
+<div>
+  <div class="ais-Menu ais-Menu--noRefinement">
+    <ul class="ais-Menu-list">
+    </ul>
+  </div>
+</div>
+
+`;
+
+exports[`default render renders correctly without a show more button (showMore) 1`] = `
+
+<div>
+  <div class="ais-Menu">
+    <ul class="ais-Menu-list">
+      <li class="ais-Menu-item">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Apple
+          </span>
+          <span class="ais-Menu-count">
+            50
+          </span>
+        </a>
+      </li>
+      <li class="ais-Menu-item">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Samsung
+          </span>
+          <span class="ais-Menu-count">
+            25
+          </span>
+        </a>
+      </li>
+      <li class="ais-Menu-item">
+        <a class="ais-Menu-link">
+          <span class="ais-Menu-label">
+            Microsoft
+          </span>
+          <span class="ais-Menu-count">
+            12
+          </span>
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>
+
+`;
+
+exports[`default render renders correctly without refinement 1`] = `
+
+<div>
+  <div class="ais-Menu ais-Menu--noRefinement">
+    <ul class="ais-Menu-list">
+    </ul>
+  </div>
 </div>
 
 `;

--- a/src/components/__tests__/__snapshots__/menu.js.snap
+++ b/src/components/__tests__/__snapshots__/menu.js.snap
@@ -2,7 +2,7 @@
 
 exports[`custom default render renders correctly 1`] = `
 
-<div>
+<div class="ais-Menu">
   <div class>
     <ol>
       <li>
@@ -31,7 +31,7 @@ exports[`custom default render renders correctly 1`] = `
 
 exports[`custom default render renders correctly with a disabled show more button 1`] = `
 
-<div>
+<div class="ais-Menu">
   <div class>
     <ol>
       <li>
@@ -60,7 +60,7 @@ exports[`custom default render renders correctly with a disabled show more butto
 
 exports[`custom default render renders correctly with a show more button toggled 1`] = `
 
-<div>
+<div class="ais-Menu">
   <div class>
     <ol>
       <li>
@@ -89,7 +89,7 @@ exports[`custom default render renders correctly with a show more button toggled
 
 exports[`custom default render renders correctly with an URL for the href 1`] = `
 
-<div>
+<div class="ais-Menu">
   <div class>
     <ol>
       <li>
@@ -118,7 +118,7 @@ exports[`custom default render renders correctly with an URL for the href 1`] = 
 
 exports[`custom default render renders correctly without refinement 1`] = `
 
-<div>
+<div class="ais-Menu ais-Menu--noRefinement">
   <div class="no-refinement">
     <ol>
     </ol>
@@ -132,426 +132,404 @@ exports[`custom default render renders correctly without refinement 1`] = `
 
 exports[`custom showMoreLabel render renders correctly with a custom show more label 1`] = `
 
-<div>
-  <div class="ais-Menu">
-    <ul class="ais-Menu-list">
-      <li class="ais-Menu-item">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Apple
-          </span>
-          <span class="ais-Menu-count">
-            50
-          </span>
-        </a>
-      </li>
-      <li class="ais-Menu-item">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Samsung
-          </span>
-          <span class="ais-Menu-count">
-            25
-          </span>
-        </a>
-      </li>
-      <li class="ais-Menu-item">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Microsoft
-          </span>
-          <span class="ais-Menu-count">
-            12
-          </span>
-        </a>
-      </li>
-    </ul>
-    <button disabled="disabled"
-            class="ais-Menu-showMore ais-Menu-showMore--disabled"
-    >
-      <span>
-        Voir plus
-      </span>
-    </button>
-  </div>
+<div class="ais-Menu">
+  <ul class="ais-Menu-list">
+    <li class="ais-Menu-item">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Apple
+        </span>
+        <span class="ais-Menu-count">
+          50
+        </span>
+      </a>
+    </li>
+    <li class="ais-Menu-item">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Samsung
+        </span>
+        <span class="ais-Menu-count">
+          25
+        </span>
+      </a>
+    </li>
+    <li class="ais-Menu-item">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Microsoft
+        </span>
+        <span class="ais-Menu-count">
+          12
+        </span>
+      </a>
+    </li>
+  </ul>
+  <button disabled="disabled"
+          class="ais-Menu-showMore ais-Menu-showMore--disabled"
+  >
+    <span>
+      Voir plus
+    </span>
+  </button>
 </div>
 
 `;
 
 exports[`custom showMoreLabel render renders correctly with a custom show more label toggled 1`] = `
 
-<div>
-  <div class="ais-Menu">
-    <ul class="ais-Menu-list">
-      <li class="ais-Menu-item">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Apple
-          </span>
-          <span class="ais-Menu-count">
-            50
-          </span>
-        </a>
-      </li>
-      <li class="ais-Menu-item">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Samsung
-          </span>
-          <span class="ais-Menu-count">
-            25
-          </span>
-        </a>
-      </li>
-      <li class="ais-Menu-item">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Microsoft
-          </span>
-          <span class="ais-Menu-count">
-            12
-          </span>
-        </a>
-      </li>
-    </ul>
-    <button disabled="disabled"
-            class="ais-Menu-showMore ais-Menu-showMore--disabled"
-    >
-      <span>
-        Voir moins
-      </span>
-    </button>
-  </div>
+<div class="ais-Menu">
+  <ul class="ais-Menu-list">
+    <li class="ais-Menu-item">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Apple
+        </span>
+        <span class="ais-Menu-count">
+          50
+        </span>
+      </a>
+    </li>
+    <li class="ais-Menu-item">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Samsung
+        </span>
+        <span class="ais-Menu-count">
+          25
+        </span>
+      </a>
+    </li>
+    <li class="ais-Menu-item">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Microsoft
+        </span>
+        <span class="ais-Menu-count">
+          12
+        </span>
+      </a>
+    </li>
+  </ul>
+  <button disabled="disabled"
+          class="ais-Menu-showMore ais-Menu-showMore--disabled"
+  >
+    <span>
+      Voir moins
+    </span>
+  </button>
 </div>
 
 `;
 
 exports[`default render renders correctly 1`] = `
 
-<div>
-  <div class="ais-Menu">
-    <ul class="ais-Menu-list">
-      <li class="ais-Menu-item">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Apple
-          </span>
-          <span class="ais-Menu-count">
-            50
-          </span>
-        </a>
-      </li>
-      <li class="ais-Menu-item">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Samsung
-          </span>
-          <span class="ais-Menu-count">
-            25
-          </span>
-        </a>
-      </li>
-      <li class="ais-Menu-item">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Microsoft
-          </span>
-          <span class="ais-Menu-count">
-            12
-          </span>
-        </a>
-      </li>
-    </ul>
-  </div>
+<div class="ais-Menu">
+  <ul class="ais-Menu-list">
+    <li class="ais-Menu-item">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Apple
+        </span>
+        <span class="ais-Menu-count">
+          50
+        </span>
+      </a>
+    </li>
+    <li class="ais-Menu-item">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Samsung
+        </span>
+        <span class="ais-Menu-count">
+          25
+        </span>
+      </a>
+    </li>
+    <li class="ais-Menu-item">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Microsoft
+        </span>
+        <span class="ais-Menu-count">
+          12
+        </span>
+      </a>
+    </li>
+  </ul>
 </div>
 
 `;
 
 exports[`default render renders correctly with a URL for the href 1`] = `
 
-<div>
-  <div class="ais-Menu">
-    <ul class="ais-Menu-list">
-      <li class="ais-Menu-item">
-        <a href="/brand/Apple"
-           class="ais-Menu-link"
-        >
-          <span class="ais-Menu-label">
-            Apple
-          </span>
-          <span class="ais-Menu-count">
-            50
-          </span>
-        </a>
-      </li>
-      <li class="ais-Menu-item">
-        <a href="/brand/Samsung"
-           class="ais-Menu-link"
-        >
-          <span class="ais-Menu-label">
-            Samsung
-          </span>
-          <span class="ais-Menu-count">
-            25
-          </span>
-        </a>
-      </li>
-      <li class="ais-Menu-item">
-        <a href="/brand/Microsoft"
-           class="ais-Menu-link"
-        >
-          <span class="ais-Menu-label">
-            Microsoft
-          </span>
-          <span class="ais-Menu-count">
-            12
-          </span>
-        </a>
-      </li>
-    </ul>
-  </div>
+<div class="ais-Menu">
+  <ul class="ais-Menu-list">
+    <li class="ais-Menu-item">
+      <a href="/brand/Apple"
+         class="ais-Menu-link"
+      >
+        <span class="ais-Menu-label">
+          Apple
+        </span>
+        <span class="ais-Menu-count">
+          50
+        </span>
+      </a>
+    </li>
+    <li class="ais-Menu-item">
+      <a href="/brand/Samsung"
+         class="ais-Menu-link"
+      >
+        <span class="ais-Menu-label">
+          Samsung
+        </span>
+        <span class="ais-Menu-count">
+          25
+        </span>
+      </a>
+    </li>
+    <li class="ais-Menu-item">
+      <a href="/brand/Microsoft"
+         class="ais-Menu-link"
+      >
+        <span class="ais-Menu-label">
+          Microsoft
+        </span>
+        <span class="ais-Menu-count">
+          12
+        </span>
+      </a>
+    </li>
+  </ul>
 </div>
 
 `;
 
 exports[`default render renders correctly with a disabled show more button 1`] = `
 
-<div>
-  <div class="ais-Menu">
-    <ul class="ais-Menu-list">
-      <li class="ais-Menu-item">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Apple
-          </span>
-          <span class="ais-Menu-count">
-            50
-          </span>
-        </a>
-      </li>
-      <li class="ais-Menu-item">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Samsung
-          </span>
-          <span class="ais-Menu-count">
-            25
-          </span>
-        </a>
-      </li>
-      <li class="ais-Menu-item">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Microsoft
-          </span>
-          <span class="ais-Menu-count">
-            12
-          </span>
-        </a>
-      </li>
-    </ul>
-    <button disabled="disabled"
-            class="ais-Menu-showMore ais-Menu-showMore--disabled"
-    >
-      Show more
-    </button>
-  </div>
+<div class="ais-Menu">
+  <ul class="ais-Menu-list">
+    <li class="ais-Menu-item">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Apple
+        </span>
+        <span class="ais-Menu-count">
+          50
+        </span>
+      </a>
+    </li>
+    <li class="ais-Menu-item">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Samsung
+        </span>
+        <span class="ais-Menu-count">
+          25
+        </span>
+      </a>
+    </li>
+    <li class="ais-Menu-item">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Microsoft
+        </span>
+        <span class="ais-Menu-count">
+          12
+        </span>
+      </a>
+    </li>
+  </ul>
+  <button disabled="disabled"
+          class="ais-Menu-showMore ais-Menu-showMore--disabled"
+  >
+    Show more
+  </button>
 </div>
 
 `;
 
 exports[`default render renders correctly with a selected item 1`] = `
 
-<div>
-  <div class="ais-Menu">
-    <ul class="ais-Menu-list">
-      <li class="ais-Menu-item">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Apple
-          </span>
-          <span class="ais-Menu-count">
-            50
-          </span>
-        </a>
-      </li>
-      <li class="ais-Menu-item ais-Menu-item--selected">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Samsung
-          </span>
-          <span class="ais-Menu-count">
-            25
-          </span>
-        </a>
-      </li>
-      <li class="ais-Menu-item">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Microsoft
-          </span>
-          <span class="ais-Menu-count">
-            12
-          </span>
-        </a>
-      </li>
-    </ul>
-  </div>
+<div class="ais-Menu">
+  <ul class="ais-Menu-list">
+    <li class="ais-Menu-item">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Apple
+        </span>
+        <span class="ais-Menu-count">
+          50
+        </span>
+      </a>
+    </li>
+    <li class="ais-Menu-item ais-Menu-item--selected">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Samsung
+        </span>
+        <span class="ais-Menu-count">
+          25
+        </span>
+      </a>
+    </li>
+    <li class="ais-Menu-item">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Microsoft
+        </span>
+        <span class="ais-Menu-count">
+          12
+        </span>
+      </a>
+    </li>
+  </ul>
 </div>
 
 `;
 
 exports[`default render renders correctly with show more button 1`] = `
 
-<div>
-  <div class="ais-Menu">
-    <ul class="ais-Menu-list">
-      <li class="ais-Menu-item">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Apple
-          </span>
-          <span class="ais-Menu-count">
-            50
-          </span>
-        </a>
-      </li>
-      <li class="ais-Menu-item">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Samsung
-          </span>
-          <span class="ais-Menu-count">
-            25
-          </span>
-        </a>
-      </li>
-      <li class="ais-Menu-item">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Microsoft
-          </span>
-          <span class="ais-Menu-count">
-            12
-          </span>
-        </a>
-      </li>
-    </ul>
-    <button disabled="disabled"
-            class="ais-Menu-showMore ais-Menu-showMore--disabled"
-    >
-      Show more
-    </button>
-  </div>
+<div class="ais-Menu">
+  <ul class="ais-Menu-list">
+    <li class="ais-Menu-item">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Apple
+        </span>
+        <span class="ais-Menu-count">
+          50
+        </span>
+      </a>
+    </li>
+    <li class="ais-Menu-item">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Samsung
+        </span>
+        <span class="ais-Menu-count">
+          25
+        </span>
+      </a>
+    </li>
+    <li class="ais-Menu-item">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Microsoft
+        </span>
+        <span class="ais-Menu-count">
+          12
+        </span>
+      </a>
+    </li>
+  </ul>
+  <button disabled="disabled"
+          class="ais-Menu-showMore ais-Menu-showMore--disabled"
+  >
+    Show more
+  </button>
 </div>
 
 `;
 
 exports[`default render renders correctly with show more button toggled 1`] = `
 
-<div>
-  <div class="ais-Menu">
-    <ul class="ais-Menu-list">
-      <li class="ais-Menu-item">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Apple
-          </span>
-          <span class="ais-Menu-count">
-            50
-          </span>
-        </a>
-      </li>
-      <li class="ais-Menu-item">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Samsung
-          </span>
-          <span class="ais-Menu-count">
-            25
-          </span>
-        </a>
-      </li>
-      <li class="ais-Menu-item">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Microsoft
-          </span>
-          <span class="ais-Menu-count">
-            12
-          </span>
-        </a>
-      </li>
-    </ul>
-    <button disabled="disabled"
-            class="ais-Menu-showMore ais-Menu-showMore--disabled"
-    >
-      Show less
-    </button>
-  </div>
+<div class="ais-Menu">
+  <ul class="ais-Menu-list">
+    <li class="ais-Menu-item">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Apple
+        </span>
+        <span class="ais-Menu-count">
+          50
+        </span>
+      </a>
+    </li>
+    <li class="ais-Menu-item">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Samsung
+        </span>
+        <span class="ais-Menu-count">
+          25
+        </span>
+      </a>
+    </li>
+    <li class="ais-Menu-item">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Microsoft
+        </span>
+        <span class="ais-Menu-count">
+          12
+        </span>
+      </a>
+    </li>
+  </ul>
+  <button disabled="disabled"
+          class="ais-Menu-showMore ais-Menu-showMore--disabled"
+  >
+    Show less
+  </button>
 </div>
 
 `;
 
 exports[`default render renders correctly without a show more button (canRefine) 1`] = `
 
-<div>
-  <div class="ais-Menu ais-Menu--noRefinement">
-    <ul class="ais-Menu-list">
-    </ul>
-  </div>
+<div class="ais-Menu ais-Menu--noRefinement">
+  <ul class="ais-Menu-list">
+  </ul>
 </div>
 
 `;
 
 exports[`default render renders correctly without a show more button (showMore) 1`] = `
 
-<div>
-  <div class="ais-Menu">
-    <ul class="ais-Menu-list">
-      <li class="ais-Menu-item">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Apple
-          </span>
-          <span class="ais-Menu-count">
-            50
-          </span>
-        </a>
-      </li>
-      <li class="ais-Menu-item">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Samsung
-          </span>
-          <span class="ais-Menu-count">
-            25
-          </span>
-        </a>
-      </li>
-      <li class="ais-Menu-item">
-        <a class="ais-Menu-link">
-          <span class="ais-Menu-label">
-            Microsoft
-          </span>
-          <span class="ais-Menu-count">
-            12
-          </span>
-        </a>
-      </li>
-    </ul>
-  </div>
+<div class="ais-Menu">
+  <ul class="ais-Menu-list">
+    <li class="ais-Menu-item">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Apple
+        </span>
+        <span class="ais-Menu-count">
+          50
+        </span>
+      </a>
+    </li>
+    <li class="ais-Menu-item">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Samsung
+        </span>
+        <span class="ais-Menu-count">
+          25
+        </span>
+      </a>
+    </li>
+    <li class="ais-Menu-item">
+      <a class="ais-Menu-link">
+        <span class="ais-Menu-label">
+          Microsoft
+        </span>
+        <span class="ais-Menu-count">
+          12
+        </span>
+      </a>
+    </li>
+  </ul>
 </div>
 
 `;
 
 exports[`default render renders correctly without refinement 1`] = `
 
-<div>
-  <div class="ais-Menu ais-Menu--noRefinement">
-    <ul class="ais-Menu-list">
-    </ul>
-  </div>
+<div class="ais-Menu ais-Menu--noRefinement">
+  <ul class="ais-Menu-list">
+  </ul>
 </div>
 
 `;

--- a/src/components/__tests__/menu.js
+++ b/src/components/__tests__/menu.js
@@ -1,57 +1,500 @@
 import { mount } from '@vue/test-utils';
-
-import Menu from '../Menu.vue';
 import { __setState } from '../../component';
+import Menu from '../Menu.vue';
 
 jest.mock('../../component');
 
+const apple = {
+  value: 'Apple',
+  label: 'Apple',
+  count: 50,
+  isRefined: false,
+};
+
+const samsung = {
+  value: 'Samsung',
+  label: 'Samsung',
+  count: 25,
+  isRefined: false,
+};
+
+const microsoft = {
+  value: 'Microsoft',
+  label: 'Microsoft',
+  count: 12,
+  isRefined: false,
+};
+
 const defaultState = {
+  items: [apple, samsung, microsoft],
   canRefine: true,
   canToggleShowMore: false,
-  createURL: jest.fn(),
   isShowingMore: false,
-  items: [
-    { value: 'foo', label: 'foo', count: 2, isRefined: true },
-    { value: 'bar', label: 'bar', count: 3 },
-    { value: 'foobar', label: 'foobar', count: 4 },
-  ],
-  refine: jest.fn(),
-  toggleShowMore: jest.fn(),
+  refine: () => {},
+  createURL: () => {},
+  toggleShowMore: () => {},
 };
-//
-it('renders correctly', () => {
-  __setState(defaultState);
 
-  const wrapper = mount(Menu, { propsData: { attribute: 'foo' } });
-  expect(wrapper.html()).toMatchSnapshot();
-});
+const defaultProps = {
+  attribute: 'brand',
+};
 
-it('renders correctly with showMore', () => {
-  __setState({ ...defaultState, canToggleShowMore: true });
+it('accepts an attribute prop', () => {
+  __setState({
+    ...defaultState,
+  });
+
+  const props = {
+    ...defaultProps,
+  };
 
   const wrapper = mount(Menu, {
-    propsData: { attribute: 'foo', showMore: true },
+    propsData: props,
   });
-  expect(wrapper.html()).toMatchSnapshot();
+
+  expect(wrapper.vm.widgetParams.attributeName).toBe('brand');
 });
 
-it('calls `refine()` when click on an element', () => {
-  __setState(defaultState);
+it('accepts a limit prop', () => {
+  __setState({
+    ...defaultState,
+  });
 
-  const wrapper = mount(Menu, { propsData: { attribute: 'foo' } });
-  wrapper.find('.ais-Menu-link').trigger('click');
-
-  expect(defaultState.refine).toHaveBeenCalled();
-  expect(defaultState.refine).toHaveBeenCalledWith(defaultState.items[0].value);
-});
-
-it('calls `toggleShowMore()` when possible', () => {
-  __setState({ ...defaultState, canToggleShowMore: true });
+  const props = {
+    ...defaultProps,
+    limit: 5,
+  };
 
   const wrapper = mount(Menu, {
-    propsData: { attribute: 'foo', showMore: true },
+    propsData: props,
   });
-  wrapper.find('button').trigger('click');
 
-  expect(defaultState.toggleShowMore).toHaveBeenCalled();
+  expect(wrapper.vm.widgetParams.limit).toBe(5);
+});
+
+it('accepts a showMoreLimit prop', () => {
+  __setState({
+    ...defaultState,
+  });
+
+  const props = {
+    ...defaultProps,
+    showMoreLimit: 10,
+  };
+
+  const wrapper = mount(Menu, {
+    propsData: props,
+  });
+
+  expect(wrapper.vm.widgetParams.showMoreLimit).toBe(10);
+});
+
+it('accepts a sortBy prop', () => {
+  __setState({
+    ...defaultState,
+  });
+
+  const props = {
+    ...defaultProps,
+    sortBy: ['name:desc'],
+  };
+
+  const wrapper = mount(Menu, {
+    propsData: props,
+  });
+
+  expect(wrapper.vm.widgetParams.sortBy).toEqual(['name:desc']);
+});
+
+describe('default render', () => {
+  it('renders correctly', () => {
+    __setState(defaultState);
+
+    const wrapper = mount(Menu, {
+      propsData: defaultProps,
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly without refinement', () => {
+    __setState({
+      ...defaultState,
+      items: [],
+      canRefine: false,
+    });
+
+    const wrapper = mount(Menu, {
+      propsData: defaultProps,
+    });
+
+    expect(wrapper.findAll('.ais-Menu--noRefinement')).toHaveLength(1);
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with a selected item', () => {
+    __setState({
+      ...defaultState,
+      items: [
+        apple,
+        {
+          ...samsung,
+          isRefined: true,
+        },
+        microsoft,
+      ],
+    });
+
+    const wrapper = mount(Menu, {
+      propsData: defaultProps,
+    });
+
+    expect(wrapper.findAll('.ais-Menu-item--selected')).toHaveLength(1);
+    expect(wrapper.find('.ais-Menu-item--selected').text()).toBe('Samsung 25');
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with a URL for the href', () => {
+    __setState({
+      ...defaultState,
+      createURL: value => `/brand/${value}`,
+    });
+
+    const wrapper = mount(Menu, {
+      propsData: defaultProps,
+    });
+
+    expect(wrapper.find('.ais-Menu-link').attributes().href).toBe(
+      '/brand/Apple'
+    );
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with show more button', () => {
+    __setState(defaultState);
+
+    const wrapper = mount(Menu, {
+      propsData: {
+        ...defaultProps,
+        showMore: true,
+      },
+    });
+
+    expect(wrapper.findAll('.ais-Menu-showMore')).toHaveLength(1);
+    expect(wrapper.find('.ais-Menu-showMore').text()).toBe('Show more');
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with show more button toggled', () => {
+    __setState({
+      ...defaultState,
+      isShowingMore: true,
+    });
+
+    const wrapper = mount(Menu, {
+      propsData: {
+        ...defaultProps,
+        showMore: true,
+      },
+    });
+
+    expect(wrapper.find('.ais-Menu-showMore').text()).toBe('Show less');
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with a disabled show more button', () => {
+    __setState({
+      ...defaultState,
+      canToggleShowMore: false,
+    });
+
+    const wrapper = mount(Menu, {
+      propsData: {
+        ...defaultProps,
+        showMore: true,
+      },
+    });
+
+    const showMoreWrapper = wrapper.find('.ais-Menu-showMore');
+
+    expect(wrapper.findAll('.ais-Menu-showMore')).toHaveLength(1);
+    expect(showMoreWrapper.classes()).toContain('ais-Menu-showMore--disabled');
+    expect(showMoreWrapper.attributes().disabled).toBe('disabled');
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly without a show more button (canRefine)', () => {
+    __setState({
+      ...defaultState,
+      items: [],
+      canRefine: false,
+    });
+
+    const wrapper = mount(Menu, {
+      propsData: {
+        ...defaultProps,
+        showMore: true,
+      },
+    });
+
+    expect(wrapper.findAll('.ais-Menu-showMore')).toHaveLength(0);
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly without a show more button (showMore)', () => {
+    __setState(defaultState);
+
+    const wrapper = mount(Menu, {
+      propsData: {
+        ...defaultProps,
+        showMore: false,
+      },
+    });
+
+    expect(wrapper.findAll('.ais-Menu-showMore')).toHaveLength(0);
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('calls refine on link click', () => {
+    const refine = jest.fn();
+
+    __setState({
+      ...defaultState,
+      refine,
+    });
+
+    const wrapper = mount(Menu, {
+      propsData: defaultProps,
+    });
+
+    wrapper.find('.ais-Menu-link').trigger('click');
+
+    expect(refine).toHaveBeenCalledTimes(1);
+    expect(refine).toHaveBeenCalledWith('Apple');
+  });
+
+  it('calls toggleShowMore on button click', () => {
+    const toggleShowMore = jest.fn();
+
+    __setState({
+      ...defaultState,
+      canToggleShowMore: true,
+      toggleShowMore,
+    });
+
+    const wrapper = mount(Menu, {
+      propsData: {
+        ...defaultProps,
+        showMore: true,
+      },
+    });
+
+    wrapper.find('.ais-Menu-showMore').trigger('click');
+
+    expect(toggleShowMore).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('custom default render', () => {
+  const defaultScopedSlot = `
+    <div
+      slot-scope="{
+        items,
+        canRefine,
+        canToggleShowMore,
+        isShowingMore,
+        refine,
+        createURL,
+        toggleShowMore,
+      }"
+      :class="[!canRefine && 'no-refinement']"
+    >
+      <ol>
+        <li
+          v-for="item in items"
+          :key="item.value"
+        >
+          <a
+            :href="createURL(item.value)"
+            @click.prevent="refine(item.value)"
+          >
+            {{item.label}} - {{item.count}}
+          </a>
+        </li>
+      </ol>
+      <button
+        :disabled="!canToggleShowMore"
+        @click.prevent="toggleShowMore"
+      >
+        {{ isShowingMore ? 'Show less' : 'Show more' }}
+      </button>
+    </div>
+  `;
+
+  it('renders correctly', () => {
+    __setState(defaultState);
+
+    const wrapper = mount(Menu, {
+      propsData: defaultProps,
+      scopedSlots: {
+        default: defaultScopedSlot,
+      },
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly without refinement', () => {
+    __setState({
+      ...defaultState,
+      items: [],
+      canRefine: false,
+    });
+
+    const wrapper = mount(Menu, {
+      propsData: defaultProps,
+      scopedSlots: {
+        default: defaultScopedSlot,
+      },
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with an URL for the href', () => {
+    __setState({
+      ...defaultState,
+      createURL: value => `/brand/${value}`,
+    });
+
+    const wrapper = mount(Menu, {
+      propsData: defaultProps,
+      scopedSlots: {
+        default: defaultScopedSlot,
+      },
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with a show more button toggled', () => {
+    __setState({
+      ...defaultState,
+      isShowingMore: true,
+    });
+
+    const wrapper = mount(Menu, {
+      propsData: defaultProps,
+      scopedSlots: {
+        default: defaultScopedSlot,
+      },
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with a disabled show more button', () => {
+    __setState({
+      ...defaultState,
+      canToggleShowMore: false,
+    });
+
+    const wrapper = mount(Menu, {
+      propsData: defaultProps,
+      scopedSlots: {
+        default: defaultScopedSlot,
+      },
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('calls refine on link click', () => {
+    const refine = jest.fn();
+
+    __setState({
+      ...defaultState,
+      refine,
+    });
+
+    const wrapper = mount(Menu, {
+      propsData: defaultProps,
+      scopedSlots: {
+        default: defaultScopedSlot,
+      },
+    });
+
+    wrapper.find('a').trigger('click');
+
+    expect(refine).toHaveBeenCalledTimes(1);
+    expect(refine).toHaveBeenCalledWith('Apple');
+  });
+
+  it('calls toggleShowMore on button click', () => {
+    const toggleShowMore = jest.fn();
+
+    __setState({
+      ...defaultState,
+      canToggleShowMore: true,
+      toggleShowMore,
+    });
+
+    const wrapper = mount(Menu, {
+      propsData: {
+        ...defaultProps,
+      },
+      scopedSlots: {
+        default: defaultScopedSlot,
+      },
+    });
+
+    wrapper.find('button').trigger('click');
+
+    expect(toggleShowMore).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('custom showMoreLabel render', () => {
+  const showMoreLabelScopedSlot = `
+    <span slot-scope="{ isShowingMore }">
+      {{ isShowingMore ? 'Voir moins' : 'Voir plus' }}
+    </span>
+  `;
+
+  it('renders correctly with a custom show more label', () => {
+    __setState(defaultState);
+
+    const wrapper = mount(Menu, {
+      propsData: {
+        ...defaultProps,
+        showMore: true,
+      },
+      scopedSlots: {
+        showMoreLabel: showMoreLabelScopedSlot,
+      },
+    });
+
+    expect(wrapper.find('.ais-Menu-showMore').text()).toBe('Voir plus');
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with a custom show more label toggled', () => {
+    __setState({
+      ...defaultState,
+      isShowingMore: true,
+    });
+
+    const wrapper = mount(Menu, {
+      propsData: {
+        ...defaultProps,
+        showMore: true,
+      },
+      scopedSlots: {
+        showMoreLabel: showMoreLabelScopedSlot,
+      },
+    });
+
+    expect(wrapper.find('.ais-Menu-showMore').text()).toBe('Voir moins');
+    expect(wrapper.html()).toMatchSnapshot();
+  });
 });

--- a/stories/Menu.stories.js
+++ b/stories/Menu.stories.js
@@ -4,14 +4,46 @@ import { storiesOf } from '@storybook/vue';
 storiesOf('Menu', module)
   .addDecorator(previewWrapper)
   .add('default', () => ({
-    template: '<ais-menu attribute="brand"></ais-menu>',
+    template: `
+      <ais-menu attribute="brand" />
+    `,
   }))
-  .add('limit the facet values', () => ({
-    template: '<ais-menu attribute="brand" :limit="3"></ais-menu>',
+  .add('with show more', () => ({
+    template: `
+      <ais-menu attribute="brand" :limit="2" :showMoreLimit="5" :show-more="true" />
+    `,
   }))
-  .add('custom rendering', () => ({
-    template: `<ais-menu attribute="brand" :limit="3">
-      <h3 slot="header">Materials</h3>
-      <hr slot="footer" />
-    </ais-menu>`,
+  .add('with custom label', () => ({
+    template: `
+      <ais-menu attribute="brand" :limit="2" :showMoreLimit="5" :show-more="true">
+        <template slot="showMoreLabel" slot-scope="{ isShowingMore }">
+          {{isShowingMore ? 'View less' : 'View more'}}
+        </template>
+      </ais-menu>
+    `,
+  }))
+  .add('with a different sort', () => ({
+    template: `
+      <ais-menu attribute="brand" :sort-by="['isRefined:desc', 'name:asc']" />
+    `,
+  }))
+  .add('with a custom render', () => ({
+    template: `
+      <ais-menu attribute="brand">
+        <ol slot-scope="{ items, createURL, refine }">
+          <li
+            v-for="item in items"
+            :key="item.value"
+            :style="{ fontWeight: item.isRefined ? 600 : 400 }"
+          >
+            <a
+              :href="createURL(item.value)"
+              @click.prevent="refine(item.value)"
+            >
+              {{item.label}} - {{item.count}}
+            </a>
+          </li>
+        </ol>
+      </ais-menu>
+    `,
   }));


### PR DESCRIPTION
## Summary

This PR implements the `Menu` widget.

![screen shot 2018-08-09 at 11 00 17](https://user-images.githubusercontent.com/6513513/43889033-6cd7e136-9bc3-11e8-9705-15829550adf7.png)

You can try the widget on [Storybook](https://deploy-preview-478--vue-instantsearch.netlify.com/stories/?selectedKind=Menu&full=0&addons=1&stories=1&panelRight=0).

## Questions

One thing to note is that I scoped the top level `div` of the widget under the `slot`. It avoids to still have the top level className when you completely rewrite the widget. But it introduce a top level `div` on top of the widget (see picture below). It can be removed when Vue will support a ["Fragment"](https://github.com/vuejs/vue/issues/7088) like component. Do we want to implement this behaviour on all the widgets?

**With default render**

![screen shot 2018-08-09 at 10 56 49 1](https://user-images.githubusercontent.com/6513513/43888910-1b67dd9c-9bc3-11e8-83f6-439a91737499.png)

**With custom render**

![screen shot 2018-08-09 at 10 57 35](https://user-images.githubusercontent.com/6513513/43888913-1df45bb2-9bc3-11e8-9a1b-81c6d434ff90.png)