### PR TITLE
chore(Storybook): add styles

### DIFF
--- a/.storybook/styles.css
+++ b/.storybook/styles.css
@@ -1,41 +1,79 @@
 body {
   font-family: 'Raleway', Helvetica Neue, helvetica;
   font-size: 14px;
+  margin: 25px;
 }
 
-.result {
-  font-size: 16px;
+.container {
+  position: relative;
+  padding: 50px 40px 40px;
 }
 
-.result:after {
-  content: '';
-  display: block;
-  clear: both;
+.container::after {
+  font-size: 13px;
+  top: 0;
+  left: 0;
+  color: #999999;
+  padding: 4px 6px;
+  line-height: 1em;
+  position: absolute;
+  background-color: #f3f3f3;
+  border: solid 1px #e4e4e4;
+  border-width: 0 1px 1px 0;
 }
 
-.result-picture {
-  float: left;
-  margin-right: 10px;
+.container-preview {
+  border: solid 1px #e4e4e4;
+  border-radius: 5px 5px 0px 0px;
 }
 
-.result-content {
-  overflow: hidden;
+.container-preview::after {
+  content: 'Preview';
+  border-radius: 4px 0 0;
 }
 
-.result-content em {
-  font-style: normal;
-  background: #ccefff;
+.container-playground {
+  border-left: solid 1px #e4e4e4;
+  border-right: solid 1px #e4e4e4;
+  border-bottom: solid 1px #e4e4e4;
 }
 
-.result-name {
-  padding-top: 20px;
+.container-playground::after {
+  content: 'Playground';
 }
 
-.result-type {
-  color: #9d9dbd; /* East bay */
+.playground-hits {
+  list-style: none;
+  padding: 0;
+  margin: 25px 0;
 }
 
-.result-description {
-  padding-top: 10px;
-  max-width: 400px;
+.playground-hits-item {
+  display: flex;
+  align-items: center;
+  margin-bottom: 25px;
+}
+
+.playground-hits-item:last-child {
+  margin-bottom: 0;
+}
+
+.playground-hits-image {
+  width: 100px;
+  height: 100px;
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: 50% 50%;
+}
+
+.playground-hits-desc {
+  margin-left: 25px;
+}
+
+.playground-hits-desc > p {
+  margin: 0 0 10px;
+}
+
+.playground-hits-desc > p:last-child {
+  margin: 0;
 }

--- a/.storybook/styles.css
+++ b/.storybook/styles.css
@@ -1,6 +1,12 @@
+body {
+  font-family: 'Raleway', Helvetica Neue, helvetica;
+  font-size: 14px;
+}
+
 .result {
   font-size: 16px;
 }
+
 .result:after {
   content: '';
   display: block;
@@ -24,6 +30,7 @@
 .result-name {
   padding-top: 20px;
 }
+
 .result-type {
   color: #9d9dbd; /* East bay */
 }

--- a/.storybook/styles.css
+++ b/.storybook/styles.css
@@ -1,5 +1,6 @@
 body {
-  font-family: 'Raleway', Helvetica Neue, helvetica;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+    Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   font-size: 14px;
   margin: 25px;
 }

--- a/stories/Breadcrumb.stories.js
+++ b/stories/Breadcrumb.stories.js
@@ -1,8 +1,8 @@
-import { previewWrapper } from './utils';
 import { storiesOf } from '@storybook/vue';
+import { previewWrapper } from './utils';
 
 storiesOf('Breadcrumb', module)
-  .addDecorator(previewWrapper)
+  .addDecorator(previewWrapper())
   .add('default', () => ({
     template: `<div>hello</div>`,
   }));

--- a/stories/ClearRefinements.stories.js
+++ b/stories/ClearRefinements.stories.js
@@ -1,8 +1,8 @@
-import { previewWrapper } from './utils';
 import { storiesOf } from '@storybook/vue';
+import { previewWrapper } from './utils';
 
 storiesOf('ClearRefinements', module)
-  .addDecorator(previewWrapper)
+  .addDecorator(previewWrapper())
   .add('default', () => ({
     template: '<ais-clear-refinements></ais-clear-refinements>',
   }))

--- a/stories/Configure.stories.js
+++ b/stories/Configure.stories.js
@@ -1,8 +1,8 @@
-import { previewWrapper } from './utils';
 import { storiesOf } from '@storybook/vue';
+import { previewWrapper } from './utils';
 
 storiesOf('Configure', module)
-  .addDecorator(previewWrapper)
+  .addDecorator(previewWrapper())
   .add('default', () => ({
     template: '<ais-configure></ais-configure>',
   }))

--- a/stories/CurrentRefinements.stories.js
+++ b/stories/CurrentRefinements.stories.js
@@ -1,8 +1,8 @@
-import { previewWrapper } from './utils';
 import { storiesOf } from '@storybook/vue';
+import { previewWrapper } from './utils';
 
 storiesOf('CurrentRefinements', module)
-  .addDecorator(previewWrapper)
+  .addDecorator(previewWrapper())
   .add('default', () => ({
     template: '<ais-current-refinements></ais-current-refinements>',
   }))

--- a/stories/HierarchicalMenu.stories.js
+++ b/stories/HierarchicalMenu.stories.js
@@ -1,8 +1,8 @@
-import { previewWrapper } from './utils';
 import { storiesOf } from '@storybook/vue';
+import { previewWrapper } from './utils';
 
 storiesOf('HierarchicalMenu', module)
-  .addDecorator(previewWrapper)
+  .addDecorator(previewWrapper())
   .add('default', () => ({
     template: `<ais-hierarchical-menu :attributes="[
         'hierarchicalCategories.lvl0',

--- a/stories/Hits.stories.js
+++ b/stories/Hits.stories.js
@@ -1,8 +1,8 @@
-import { previewWrapper } from './utils';
 import { storiesOf } from '@storybook/vue';
+import { previewWrapper } from './utils';
 
 storiesOf('Hits', module)
-  .addDecorator(previewWrapper)
+  .addDecorator(previewWrapper())
   .add('simple usage', () => ({
     template: `<ais-hits></ais-hits>`,
   }))

--- a/stories/HitsPerPage.stories.js
+++ b/stories/HitsPerPage.stories.js
@@ -1,8 +1,8 @@
-import { previewWrapper } from './utils';
 import { storiesOf } from '@storybook/vue';
+import { previewWrapper } from './utils';
 
 storiesOf('HitsPerPage', module)
-  .addDecorator(previewWrapper)
+  .addDecorator(previewWrapper())
   .add('simple usage', () => ({
     template: `<ais-hits-per-page :items="[{
         label: '10 results', value: 10, default: true,

--- a/stories/InfiniteHits.stories.js
+++ b/stories/InfiniteHits.stories.js
@@ -1,8 +1,8 @@
-import { previewWrapper } from './utils';
 import { storiesOf } from '@storybook/vue';
+import { previewWrapper } from './utils';
 
 storiesOf('InfiniteHits', module)
-  .addDecorator(previewWrapper)
+  .addDecorator(previewWrapper())
   .add('simple usage', () => ({
     template: `<ais-infinite-hits />`,
   }))

--- a/stories/Menu.stories.js
+++ b/stories/Menu.stories.js
@@ -1,8 +1,8 @@
-import { previewWrapper } from './utils';
 import { storiesOf } from '@storybook/vue';
+import { previewWrapper } from './utils';
 
 storiesOf('Menu', module)
-  .addDecorator(previewWrapper)
+  .addDecorator(previewWrapper())
   .add('default', () => ({
     template: `
       <ais-menu attribute="brand" />

--- a/stories/MenuSelect.stories.js
+++ b/stories/MenuSelect.stories.js
@@ -1,8 +1,8 @@
-import { previewWrapper } from './utils';
 import { storiesOf } from '@storybook/vue';
+import { previewWrapper } from './utils';
 
 storiesOf('MenuSelect', module)
-  .addDecorator(previewWrapper)
+  .addDecorator(previewWrapper())
   .add('simple usage', () => ({
     template: '<ais-menu-select attribute="brand" />',
   }))

--- a/stories/NoResults.stories.js
+++ b/stories/NoResults.stories.js
@@ -1,8 +1,8 @@
-import { previewWrapper } from './utils';
 import { storiesOf } from '@storybook/vue';
+import { previewWrapper } from './utils';
 
 storiesOf('NoResults', module)
-  .addDecorator(previewWrapper)
+  .addDecorator(previewWrapper())
   .add('default', () => ({
     template: `<ais-no-results ref="child"></ais-no-results>`,
     mounted() {

--- a/stories/Pagination.stories.js
+++ b/stories/Pagination.stories.js
@@ -1,8 +1,8 @@
-import { previewWrapper } from './utils';
 import { storiesOf } from '@storybook/vue';
+import { previewWrapper } from './utils';
 
 storiesOf('Pagination', module)
-  .addDecorator(previewWrapper)
+  .addDecorator(previewWrapper())
   .add('default', () => ({
     template: '<ais-pagination></ais-pagination>',
   }))

--- a/stories/PoweredBy.stories.js
+++ b/stories/PoweredBy.stories.js
@@ -1,8 +1,8 @@
-import { previewWrapper } from './utils';
 import { storiesOf } from '@storybook/vue';
+import { previewWrapper } from './utils';
 
 storiesOf('PoweredBy', module)
-  .addDecorator(previewWrapper)
+  .addDecorator(previewWrapper())
   .add('default', () => ({
     template: '<ais-powered-by></ais-powered-by>',
   }))

--- a/stories/RatingMenu.stories.js
+++ b/stories/RatingMenu.stories.js
@@ -1,15 +1,16 @@
-import { customPreviewWrapper } from './utils';
 import { storiesOf } from '@storybook/vue';
+import { previewWrapper } from './utils';
 
 storiesOf('RatingMenu', module)
   .addDecorator(
-    customPreviewWrapper({
+    previewWrapper({
+      indexName: 'instant_search_rating_asc',
       hits: `
         <div slot="item" slot-scope="{ item }">
           <h2>rating: {{item.rating}}</h2>
           <p>{{item.name}}</p>
-        </div>`,
-      indexName: 'instant_search_rating_asc',
+        </div>
+      `,
     })
   )
   .add('default', () => ({

--- a/stories/RatingMenu.stories.js
+++ b/stories/RatingMenu.stories.js
@@ -5,12 +5,6 @@ storiesOf('RatingMenu', module)
   .addDecorator(
     previewWrapper({
       indexName: 'instant_search_rating_asc',
-      hits: `
-        <div slot="item" slot-scope="{ item }">
-          <h2>rating: {{item.rating}}</h2>
-          <p>{{item.name}}</p>
-        </div>
-      `,
     })
   )
   .add('default', () => ({

--- a/stories/RefinementList.stories.js
+++ b/stories/RefinementList.stories.js
@@ -1,8 +1,8 @@
-import { previewWrapper } from './utils';
 import { storiesOf } from '@storybook/vue';
+import { previewWrapper } from './utils';
 
 storiesOf('RefinementList', module)
-  .addDecorator(previewWrapper)
+  .addDecorator(previewWrapper())
   .add('default', () => ({
     template: `<ais-refinement-list attribute-name="materials"></ais-refinement-list>`,
   }))

--- a/stories/SearchBox.stories.js
+++ b/stories/SearchBox.stories.js
@@ -1,8 +1,8 @@
-import { previewWrapper } from './utils';
 import { storiesOf } from '@storybook/vue';
+import { previewWrapper } from './utils';
 
 storiesOf('SearchBox', module)
-  .addDecorator(previewWrapper)
+  .addDecorator(previewWrapper())
   .add('default', () => ({
     template: '<ais-search-box></ais-search-box>',
   }))

--- a/stories/SortBy.stories.js
+++ b/stories/SortBy.stories.js
@@ -1,31 +1,35 @@
-import { previewWrapper } from './utils';
 import { storiesOf } from '@storybook/vue';
+import { previewWrapper } from './utils';
 
 storiesOf('SortBy', module)
-  .addDecorator(previewWrapper)
+  .addDecorator(previewWrapper())
   .add('default', () => ({
-    template: `<ais-sort-by :items="[
-      { name: 'instant_search', label: 'Featured' },
-      { name: 'instant_search_price_asc', label: 'Price asc.' },
-      { name: 'instant_search_price_desc', label: 'Price desc.' },
-    ]">
-    </ais-sort-by>
+    template: `
+      <ais-sort-by
+        :items="[
+          { name: 'instant_search', label: 'Featured' },
+          { name: 'instant_search_price_asc', label: 'Price asc.' },
+          { name: 'instant_search_price_desc', label: 'Price desc.' },
+        ]"
+      />
     `,
   }))
   .add('custom display', () => ({
-    template: `<ais-sort-by :items="[
-      { name: 'instant_search', label: 'Featured' },
-      { name: 'instant_search_price_asc', label: 'Price asc.' },
-      { name: 'instant_search_price_desc', label: 'Price desc.' },
-    ]">
-    
-      <ul slot-scope="{ items, refine, currentRefinement}">
-        <li v-for="item in items" :key="item.value">
-          <button @click="refine(item.value)">
-            {{item.label}} {{currentRefinement === item.value ? '✔️' : ''}}
-          </button>
-        </li>
-      </ul>
-    </ais-sort-by>
+    template: `
+      <ais-sort-by
+        :items="[
+          { name: 'instant_search', label: 'Featured' },
+          { name: 'instant_search_price_asc', label: 'Price asc.' },
+          { name: 'instant_search_price_desc', label: 'Price desc.' },
+        ]"
+      >
+        <ul slot-scope="{ items, refine, currentRefinement}">
+          <li v-for="item in items" :key="item.value">
+            <button @click="refine(item.value)">
+              {{item.label}} {{currentRefinement === item.value ? '✔️' : ''}}
+            </button>
+          </li>
+        </ul>
+      </ais-sort-by>
     `,
   }));

--- a/stories/Stats.stories.js
+++ b/stories/Stats.stories.js
@@ -1,8 +1,8 @@
-import { previewWrapper } from './utils';
 import { storiesOf } from '@storybook/vue';
+import { previewWrapper } from './utils';
 
 storiesOf('Stats', module)
-  .addDecorator(previewWrapper)
+  .addDecorator(previewWrapper())
   .add('default', () => ({
     template: `<ais-stats></ais-stats>`,
   }))

--- a/stories/TreeMenu.stories.js
+++ b/stories/TreeMenu.stories.js
@@ -1,8 +1,8 @@
-import { previewWrapper } from './utils';
 import { storiesOf } from '@storybook/vue';
+import { previewWrapper } from './utils';
 
 storiesOf('TreeMenu', module)
-  .addDecorator(previewWrapper)
+  .addDecorator(previewWrapper())
   .add('default', () => ({
     template: `<ais-tree-menu :attributes="['category', 'sub_category']"></ais-tree-menu>'`,
   }));

--- a/stories/utils.js
+++ b/stories/utils.js
@@ -1,21 +1,21 @@
-const makeTemplate = ({ hits = '', indexName = 'instant_search' } = {}) => `
-  <ais-index
-    appId="latency"
-    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
-    indexName="${indexName}"
-  >
-    <h2>Display</h2>
-    <story/>
-    <h2>Hits</h2>
-    <ais-search-box></ais-search-box>
-    <ais-hits>${hits}</ais-hits>
-  </ais-index>
-`;
+export const previewWrapper = ({
+  indexName = 'instant_search',
+  hits = '',
+} = {}) => () => ({
+  template: `
+    <ais-index
+      appId="latency"
+      apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+      indexName="${indexName}"
+    >
+      <h2>Display</h2>
+      <story />
 
-export const previewWrapper = () => ({
-  template: makeTemplate(),
-});
-
-export const customPreviewWrapper = ({ hits, indexName }) => () => ({
-  template: makeTemplate({ hits, indexName }),
+      <h2>Hits</h2>
+      <ais-search-box />
+      <ais-hits>
+        ${hits}
+      </ais-hits>
+    </ais-index>
+  `,
 });

--- a/stories/utils.js
+++ b/stories/utils.js
@@ -1,6 +1,27 @@
 export const previewWrapper = ({
   indexName = 'instant_search',
-  hits = '',
+  hits = `
+    <ol
+      slot-scope="{ items }"
+      class="playground-hits"
+    >
+      <li
+        v-for="item in items"
+        :key="item.objectID"
+        class="playground-hits-item"
+      >
+        <div
+          class="playground-hits-image"
+          :style="{ backgroundImage: 'url(' + item.image + ')' }"
+        />
+        <div class="playground-hits-desc">
+          <p>{{ item.name }}</p>
+          <p>Rating: {{ item.rating }}✭</p>
+          <p>Price: {{ item.price }}$</p>
+        </div>
+      </li>
+    </ol>
+  `,
 } = {}) => () => ({
   template: `
     <ais-index
@@ -8,14 +29,18 @@ export const previewWrapper = ({
       apiKey="6be0576ff61c053d5f9a3225e2a90f76"
       indexName="${indexName}"
     >
-      <h2>Display</h2>
-      <story />
+      <ais-configure :hitsPerPage="3" />
+      <div class="container container-preview">
+        <story />
+      </div>
 
-      <h2>Hits</h2>
-      <ais-search-box />
-      <ais-hits>
-        ${hits}
-      </ais-hits>
+      <div class="container container-playground">
+        <ais-search-box />
+        <ais-hits>
+          ${hits}
+        </ais-hits>
+        <ais-pagination />
+      </div>
     </ais-index>
   `,
 });


### PR DESCRIPTION
## Summary

This PR adds some styles to Storybook, it's pretty basic feel free to update it. I took almost the same style as the one implemented in React InstantSearch. As soon as we have the `ClearRefinements` widget we should add it with a two column layout along with a `RefinementList`. It will allow us to play with almost all the widget easily.

**Before**

![localhost_9001__selectedkind menuselect selectedstory simple 20usage full 0 addons 1 stories 1 panelright 0 1](https://user-images.githubusercontent.com/6513513/43894085-57350ef4-9bd1-11e8-877e-cc6b2e31cc24.png)

**After**

![localhost_9001__selectedkind menuselect selectedstory simple 20usage full 0 addons 1 stories 1 panelright 0](https://user-images.githubusercontent.com/6513513/43894089-5b719e42-9bd1-11e8-91a0-2e6136de0a26.png)

You play with the live example on [Storybook](url).