### PR TITLE
feat(Breadcrumb): implement widget

### DIFF
--- a/.github/V2_PROGRESS.md
+++ b/.github/V2_PROGRESS.md
@@ -22,7 +22,7 @@ A checklist for all of the components which are completely done.
 x => done
 ~ => in progress
 
-* [~] `ais-breadcrumb` Samuel
+* [x] `ais-breadcrumb`
 * [x] `ais-clear-refinements`
 * [x] `ais-configure`
 * [~] `ais-current-refinements` Haroenv

--- a/docs/src/components/Breadcrumb.md
+++ b/docs/src/components/Breadcrumb.md
@@ -9,9 +9,7 @@ editable: true
 githubSource: docs/src/components/Breadcrumb.md
 ---
 
-Breadcrumb connector provides the logic to build a custom widget that will give the user the ability to see the current path in a hierarchical facet.
-
-This is commonly used in websites that have a large amount of content organized in a hierarchical manner (usually e-commerce websites).
+The breadcrumb widget allows you to visualise which level of a hierarchical facet is currently selected.
 
 <a class="btn btn-static-theme" href="stories/?selectedKind=Breadcrumb">🕹 try out live</a>
 

--- a/docs/src/components/Breadcrumb.md
+++ b/docs/src/components/Breadcrumb.md
@@ -1,0 +1,57 @@
+---
+title: Breadcrumb
+mainTitle: Components
+layout: main.pug
+category: Components
+withHeadings: true
+navWeight: 6
+editable: true
+githubSource: docs/src/components/Breadcrumb.md
+---
+
+Breadcrumb connector provides the logic to build a custom widget that will give the user the ability to see the current path in a hierarchical facet.
+
+This is commonly used in websites that have a large amount of content organized in a hierarchical manner (usually e-commerce websites).
+
+<a class="btn btn-static-theme" href="stories/?selectedKind=Breadcrumb">🕹 try out live</a>
+
+## Usage
+
+```html
+<ais-breadcrumb
+  :attributes="[
+    'categories.lvl0',
+    'categories.lvl1',
+  ]"
+/>
+```
+
+## Props
+
+Name | Type | Default | Description | Required
+---|---|---|---|---
+attributes | `string[]` | - | Array of attributes to use to generate the breadcrumb | Yes
+separator | `string` | - | Separator used in the attributes to separate level values (mainly used to sync the options with a hierarchical menu) | -
+rootPath | `string` | - | Prefix path to use if the first level is not the root level (mainly used to sync the options with a hierarchical menu) | -
+
+## Slots
+
+Name | Scope | Description
+---|---|---
+default | `{ canRefine: boolean, refine: (value: string) => void, createURL: (value: string) => string }` | Slot to override the DOM output
+rootLabel | - | Slot to override the root label
+separator | - | Slot to override the separator
+
+## CSS classes
+
+Here's a list of CSS classes exposed by this widget. To better understand the underlying DOM structure, have a look at the generated DOM in your browser.
+
+Class name | Description
+---|---
+`ais-Breadcrumb` | The root div of the widget
+`ais-Breadcrumb--noRefinement` | The root div of the widget with no refinement
+`ais-Breadcrumb-list` | The list of all breadcrumb items
+`ais-Breadcrumb-item` | The breadcrumb navigation item
+`ais-Breadcrumb-item--selected` | The selected breadcrumb item
+`ais-Breadcrumb-separator` | The separator of each breadcrumb item
+`ais-Breadcrumb-link` | The clickable breadcrumb element

--- a/src/components/Breadcrumb.vue
+++ b/src/components/Breadcrumb.vue
@@ -1,34 +1,74 @@
 <template>
-  <div>
-    <slot v-bind="state">
-      <json-tree :level="2" :data="state"></json-tree>
+  <div
+    v-if="state"
+    :class="[suit(''), !state.canRefine && suit('', 'noRefinement')]"
+  >
+    <slot
+      :items="state.items"
+      :can-refine="state.canRefine"
+      :refine="state.refine"
+      :create-URL="state.createURL"
+    >
+      <ul :class="suit('list')">
+        <li :class="[suit('item'), !state.items.length && suit('item', 'selected')]">
+          <a
+            v-if="Boolean(state.items.length)"
+            :href="state.createURL()"
+            :class="suit('link')"
+            @click.prevent="state.refine()"
+          >
+            <slot name="rootLabel">Home</slot>
+          </a>
+          <span v-else>
+            <slot name="rootLabel">Home</slot>
+          </span>
+        </li>
+        <li
+          v-for="(item, index) in state.items"
+          :key="item.name"
+          :class="[suit('item'), isLastItem(index) && suit('item', 'selected')]"
+        >
+          <span :class="suit('separator')" aria-hidden="true">
+            <slot name="separator">></slot>
+          </span>
+          <a
+            v-if="!isLastItem(index)"
+            :href="state.createURL(item.value)"
+            :class="suit('link')"
+            @click.prevent="state.refine(item.value)"
+          >
+            {{ item.name }}
+          </a>
+          <span v-else>
+            {{ item.name }}
+          </span>
+        </li>
+      </ul>
     </slot>
   </div>
 </template>
 
 <script>
-import JsonTree from 'vue-json-tree'; // todo: remove
-import algoliaComponent from '../component';
 import { connectBreadcrumb } from 'instantsearch.js/es/connectors';
+import algoliaComponent from '../component';
 
 export default {
-  components: { 'json-tree': JsonTree },
   mixins: [algoliaComponent],
   props: {
     attributes: {
       type: Array,
       required: true,
     },
-    rootPath: {
+    separator: {
       type: String,
     },
-    separator: {
+    rootPath: {
       type: String,
     },
   },
   data() {
     return {
-      widgetName: 'ais-breadcrumb',
+      widgetName: 'Breadcrumb',
     };
   },
   beforeCreate() {
@@ -38,9 +78,14 @@ export default {
     widgetParams() {
       return {
         attributes: this.attributes,
-        rootPath: this.rootPath,
         separator: this.separator,
+        rootPath: this.rootPath,
       };
+    },
+  },
+  methods: {
+    isLastItem(index) {
+      return this.state.items.length - 1 === index;
     },
   },
 };</script>

--- a/src/components/__tests__/Breadcrumb.js
+++ b/src/components/__tests__/Breadcrumb.js
@@ -1,0 +1,317 @@
+import { mount } from '@vue/test-utils';
+import { __setState } from '../../component';
+import Breadcrumb from '../Breadcrumb.vue';
+
+jest.mock('../../component');
+
+const defaultItems = [
+  {
+    name: 'TV & Home Theater',
+    value: 'TV & Home Theater',
+  },
+  {
+    name: 'Streaming Media Players',
+    value: 'TV & Home Theater > Streaming Media Players',
+  },
+];
+
+const defaultState = {
+  items: defaultItems,
+  canRefine: true,
+  refine: () => {},
+  createURL: () => {},
+};
+
+const defaultProps = {
+  attributes: ['categories.lvl0', 'categories.lvl1'],
+};
+
+it('accepts an attribute prop', () => {
+  __setState({
+    ...defaultState,
+  });
+
+  const wrapper = mount(Breadcrumb, {
+    propsData: defaultProps,
+  });
+
+  expect(wrapper.vm.widgetParams.attributes).toEqual([
+    'categories.lvl0',
+    'categories.lvl1',
+  ]);
+});
+
+it('accepts a separator prop', () => {
+  __setState({
+    ...defaultState,
+  });
+
+  const wrapper = mount(Breadcrumb, {
+    propsData: {
+      ...defaultProps,
+      separator: ' ~ ',
+    },
+  });
+
+  expect(wrapper.vm.widgetParams.separator).toBe(' ~ ');
+});
+
+it('accepts a rootPath prop', () => {
+  __setState({
+    ...defaultState,
+  });
+
+  const wrapper = mount(Breadcrumb, {
+    propsData: {
+      ...defaultProps,
+      rootPath: 'TV & Home Theater',
+    },
+  });
+
+  expect(wrapper.vm.widgetParams.rootPath).toBe('TV & Home Theater');
+});
+
+describe('default render', () => {
+  it('renders correctly', () => {
+    __setState({ ...defaultState });
+
+    const wrapper = mount(Breadcrumb, {
+      propsData: defaultProps,
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly without refinement', () => {
+    __setState({
+      ...defaultState,
+      items: [],
+      canRefine: false,
+    });
+
+    const wrapper = mount(Breadcrumb, {
+      propsData: defaultProps,
+    });
+
+    const selected = wrapper.find('.ais-Breadcrumb-item--selected');
+
+    expect(selected.text()).toContain('Home');
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with a selected item', () => {
+    __setState({
+      ...defaultState,
+    });
+
+    const wrapper = mount(Breadcrumb, {
+      propsData: defaultProps,
+    });
+
+    const selected = wrapper.find('.ais-Breadcrumb-item--selected');
+
+    expect(selected.text()).toContain('Streaming Media Players');
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with an URL for the href', () => {
+    __setState({
+      ...defaultState,
+      createURL: value => `/${value}`,
+    });
+
+    const wrapper = mount(Breadcrumb, {
+      propsData: defaultProps,
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('calls refine on root click', () => {
+    const refine = jest.fn();
+
+    __setState({
+      ...defaultState,
+      refine,
+    });
+
+    const wrapper = mount(Breadcrumb, {
+      propsData: defaultProps,
+    });
+
+    wrapper
+      .findAll('a')
+      .at(0)
+      .trigger('click');
+
+    expect(refine).toHaveBeenCalledTimes(1);
+    expect(refine).toHaveBeenCalledWith();
+  });
+
+  it('calls refine on item click', () => {
+    const refine = jest.fn();
+
+    __setState({
+      ...defaultState,
+      refine,
+    });
+
+    const wrapper = mount(Breadcrumb, {
+      propsData: defaultProps,
+    });
+
+    wrapper
+      .findAll('a')
+      .at(1)
+      .trigger('click');
+
+    expect(refine).toHaveBeenCalledTimes(1);
+    expect(refine).toHaveBeenCalledWith('TV & Home Theater');
+  });
+});
+
+describe('custom default render', () => {
+  const defaultScopedSlot = `
+    <ul
+      slot-scope="{ items, canRefine, refine, createURL }"
+      :class="[!canRefine && 'noRefinement']"
+    >
+      <li
+        v-for="(item, index) in items"
+        :key="item.name"
+      >
+        <a
+          :href="createURL(item.value)"
+          @click.prevent="refine(item.value)"
+        >
+          {{ item.name }}
+        </a>
+      </li>
+    </ul>
+  `;
+
+  it('renders correctly', () => {
+    __setState({ ...defaultState });
+
+    const wrapper = mount(Breadcrumb, {
+      propsData: defaultProps,
+      scopedSlots: {
+        default: defaultScopedSlot,
+      },
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly without refinement', () => {
+    __setState({
+      ...defaultState,
+      items: [],
+      canRefine: false,
+    });
+
+    const wrapper = mount(Breadcrumb, {
+      propsData: defaultProps,
+      scopedSlots: {
+        default: defaultScopedSlot,
+      },
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with an URL for the href', () => {
+    __setState({
+      ...defaultState,
+      createURL: value => `/${value}`,
+    });
+
+    const wrapper = mount(Breadcrumb, {
+      propsData: defaultProps,
+      scopedSlots: {
+        default: defaultScopedSlot,
+      },
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('calls refine on link click', () => {
+    const refine = jest.fn();
+
+    __setState({
+      ...defaultState,
+      refine,
+    });
+
+    const wrapper = mount(Breadcrumb, {
+      propsData: defaultProps,
+      scopedSlots: {
+        default: defaultScopedSlot,
+      },
+    });
+
+    wrapper
+      .findAll('a')
+      .at(0)
+      .trigger('click');
+
+    expect(refine).toHaveBeenCalledTimes(1);
+    expect(refine).toHaveBeenCalledWith('TV & Home Theater');
+  });
+});
+
+describe('custom rootLabel render', () => {
+  const roolLabelSlot = `
+    <template>Home page</template>
+  `;
+
+  it('renders correctly', () => {
+    __setState({ ...defaultState });
+
+    const wrapper = mount(Breadcrumb, {
+      propsData: defaultProps,
+      scopedSlots: {
+        rootLabel: roolLabelSlot,
+      },
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly without refinement', () => {
+    __setState({
+      ...defaultState,
+      items: [],
+      canRefine: false,
+    });
+
+    const wrapper = mount(Breadcrumb, {
+      propsData: defaultProps,
+      scopedSlots: {
+        rootLabel: roolLabelSlot,
+      },
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+});
+
+describe('custom separator render', () => {
+  const separatorSlot = `
+    <template>~~</template>
+  `;
+
+  it('renders correctly', () => {
+    __setState({ ...defaultState });
+
+    const wrapper = mount(Breadcrumb, {
+      propsData: defaultProps,
+      scopedSlots: {
+        separator: separatorSlot,
+      },
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+});

--- a/src/components/__tests__/__snapshots__/Breadcrumb.js.snap
+++ b/src/components/__tests__/__snapshots__/Breadcrumb.js.snap
@@ -1,0 +1,250 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`custom default render renders correctly 1`] = `
+
+<div class="ais-Breadcrumb">
+  <ul class>
+    <li>
+      <a>
+        TV &amp; Home Theater
+      </a>
+    </li>
+    <li>
+      <a>
+        Streaming Media Players
+      </a>
+    </li>
+  </ul>
+</div>
+
+`;
+
+exports[`custom default render renders correctly with an URL for the href 1`] = `
+
+<div class="ais-Breadcrumb">
+  <ul class>
+    <li>
+      <a href="/TV &amp; Home Theater">
+        TV &amp; Home Theater
+      </a>
+    </li>
+    <li>
+      <a href="/TV &amp; Home Theater > Streaming Media Players">
+        Streaming Media Players
+      </a>
+    </li>
+  </ul>
+</div>
+
+`;
+
+exports[`custom default render renders correctly without refinement 1`] = `
+
+<div class="ais-Breadcrumb ais-Breadcrumb--noRefinement">
+  <ul class="noRefinement">
+  </ul>
+</div>
+
+`;
+
+exports[`custom rootLabel render renders correctly 1`] = `
+
+<div class="ais-Breadcrumb">
+  <ul class="ais-Breadcrumb-list">
+    <li class="ais-Breadcrumb-item">
+      <a class="ais-Breadcrumb-link">
+        Home page
+      </a>
+    </li>
+    <li class="ais-Breadcrumb-item">
+      <span aria-hidden="true"
+            class="ais-Breadcrumb-separator"
+      >
+        &gt;
+      </span>
+      <a class="ais-Breadcrumb-link">
+        TV &amp; Home Theater
+      </a>
+    </li>
+    <li class="ais-Breadcrumb-item ais-Breadcrumb-item--selected">
+      <span aria-hidden="true"
+            class="ais-Breadcrumb-separator"
+      >
+        &gt;
+      </span>
+      <span>
+        Streaming Media Players
+      </span>
+    </li>
+  </ul>
+</div>
+
+`;
+
+exports[`custom rootLabel render renders correctly without refinement 1`] = `
+
+<div class="ais-Breadcrumb ais-Breadcrumb--noRefinement">
+  <ul class="ais-Breadcrumb-list">
+    <li class="ais-Breadcrumb-item ais-Breadcrumb-item--selected">
+      <span>
+        Home page
+      </span>
+    </li>
+  </ul>
+</div>
+
+`;
+
+exports[`custom separator render renders correctly 1`] = `
+
+<div class="ais-Breadcrumb">
+  <ul class="ais-Breadcrumb-list">
+    <li class="ais-Breadcrumb-item">
+      <a class="ais-Breadcrumb-link">
+        Home
+      </a>
+    </li>
+    <li class="ais-Breadcrumb-item">
+      <span aria-hidden="true"
+            class="ais-Breadcrumb-separator"
+      >
+        ~~
+      </span>
+      <a class="ais-Breadcrumb-link">
+        TV &amp; Home Theater
+      </a>
+    </li>
+    <li class="ais-Breadcrumb-item ais-Breadcrumb-item--selected">
+      <span aria-hidden="true"
+            class="ais-Breadcrumb-separator"
+      >
+        ~~
+      </span>
+      <span>
+        Streaming Media Players
+      </span>
+    </li>
+  </ul>
+</div>
+
+`;
+
+exports[`default render renders correctly 1`] = `
+
+<div class="ais-Breadcrumb">
+  <ul class="ais-Breadcrumb-list">
+    <li class="ais-Breadcrumb-item">
+      <a class="ais-Breadcrumb-link">
+        Home
+      </a>
+    </li>
+    <li class="ais-Breadcrumb-item">
+      <span aria-hidden="true"
+            class="ais-Breadcrumb-separator"
+      >
+        &gt;
+      </span>
+      <a class="ais-Breadcrumb-link">
+        TV &amp; Home Theater
+      </a>
+    </li>
+    <li class="ais-Breadcrumb-item ais-Breadcrumb-item--selected">
+      <span aria-hidden="true"
+            class="ais-Breadcrumb-separator"
+      >
+        &gt;
+      </span>
+      <span>
+        Streaming Media Players
+      </span>
+    </li>
+  </ul>
+</div>
+
+`;
+
+exports[`default render renders correctly with a selected item 1`] = `
+
+<div class="ais-Breadcrumb">
+  <ul class="ais-Breadcrumb-list">
+    <li class="ais-Breadcrumb-item">
+      <a class="ais-Breadcrumb-link">
+        Home
+      </a>
+    </li>
+    <li class="ais-Breadcrumb-item">
+      <span aria-hidden="true"
+            class="ais-Breadcrumb-separator"
+      >
+        &gt;
+      </span>
+      <a class="ais-Breadcrumb-link">
+        TV &amp; Home Theater
+      </a>
+    </li>
+    <li class="ais-Breadcrumb-item ais-Breadcrumb-item--selected">
+      <span aria-hidden="true"
+            class="ais-Breadcrumb-separator"
+      >
+        &gt;
+      </span>
+      <span>
+        Streaming Media Players
+      </span>
+    </li>
+  </ul>
+</div>
+
+`;
+
+exports[`default render renders correctly with an URL for the href 1`] = `
+
+<div class="ais-Breadcrumb">
+  <ul class="ais-Breadcrumb-list">
+    <li class="ais-Breadcrumb-item">
+      <a href="/undefined"
+         class="ais-Breadcrumb-link"
+      >
+        Home
+      </a>
+    </li>
+    <li class="ais-Breadcrumb-item">
+      <span aria-hidden="true"
+            class="ais-Breadcrumb-separator"
+      >
+        &gt;
+      </span>
+      <a href="/TV &amp; Home Theater"
+         class="ais-Breadcrumb-link"
+      >
+        TV &amp; Home Theater
+      </a>
+    </li>
+    <li class="ais-Breadcrumb-item ais-Breadcrumb-item--selected">
+      <span aria-hidden="true"
+            class="ais-Breadcrumb-separator"
+      >
+        &gt;
+      </span>
+      <span>
+        Streaming Media Players
+      </span>
+    </li>
+  </ul>
+</div>
+
+`;
+
+exports[`default render renders correctly without refinement 1`] = `
+
+<div class="ais-Breadcrumb ais-Breadcrumb--noRefinement">
+  <ul class="ais-Breadcrumb-list">
+    <li class="ais-Breadcrumb-item ais-Breadcrumb-item--selected">
+      <span>
+        Home
+      </span>
+    </li>
+  </ul>
+</div>
+
+`;

--- a/stories/Breadcrumb.stories.js
+++ b/stories/Breadcrumb.stories.js
@@ -1,8 +1,111 @@
 import { storiesOf } from '@storybook/vue';
 import { previewWrapper } from './utils';
 
+const attributes = [
+  'hierarchicalCategories.lvl0',
+  'hierarchicalCategories.lvl1',
+];
+
+const hierarchicalFacets = [
+  {
+    name: 'hierarchicalCategories.lvl0',
+    attributes,
+    separator: ' > ',
+  },
+];
+
+const hierarchicalFacetsRefinements = {
+  'hierarchicalCategories.lvl0': [
+    'TV & Home Theater > Streaming Media Players',
+  ],
+};
+
 storiesOf('Breadcrumb', module)
   .addDecorator(previewWrapper())
   .add('default', () => ({
-    template: `<div>hello</div>`,
+    template: `
+      <div>
+        <ais-configure
+          :hierarchicalFacets="hierarchicalFacets"
+          :hierarchicalFacetsRefinements="hierarchicalFacetsRefinements"
+        />
+
+        <ais-breadcrumb :attributes="attributes" />
+      </div>
+    `,
+    data: () => ({
+      attributes,
+      hierarchicalFacets,
+      hierarchicalFacetsRefinements,
+    }),
+  }))
+  .add('with a custom root label', () => ({
+    template: `
+      <div>
+        <ais-configure
+          :hierarchicalFacets="hierarchicalFacets"
+          :hierarchicalFacetsRefinements="hierarchicalFacetsRefinements"
+        />
+
+        <ais-breadcrumb :attributes="attributes">
+          <template slot="rootLabel">Home Page</template>
+        </ais-breadcrumb>
+      </div>
+    `,
+    data: () => ({
+      attributes,
+      hierarchicalFacets,
+      hierarchicalFacetsRefinements,
+    }),
+  }))
+  .add('with a custom separator', () => ({
+    template: `
+      <div>
+        <ais-configure
+          :hierarchicalFacets="hierarchicalFacets"
+          :hierarchicalFacetsRefinements="hierarchicalFacetsRefinements"
+        />
+
+        <ais-breadcrumb :attributes="attributes">
+          <template slot="separator" slot-scope="_">~</template>
+        </ais-breadcrumb>
+      </div>
+    `,
+    data: () => ({
+      attributes,
+      hierarchicalFacets,
+      hierarchicalFacetsRefinements,
+    }),
+  }))
+  .add('with a custom render', () => ({
+    template: `
+      <div>
+        <ais-configure
+          :hierarchicalFacets="hierarchicalFacets"
+          :hierarchicalFacetsRefinements="hierarchicalFacetsRefinements"
+        />
+
+        <ais-breadcrumb :attributes="attributes">
+          <ul slot-scope="{ items, refine, createURL }">
+            <li
+              v-for="(item, index) in items"
+              :key="item.name"
+              :style="{ fontWeight: index === items.length -1 ? 600 : 400 }"
+            >
+              <a
+                :href="createURL(item.value)"
+                @click.prevent="refine(item.value)"
+              >
+                {{ item.name }}
+              </a>
+            </li>
+          </ul>
+        </ais-breadcrumb>
+      </div>
+    `,
+    data: () => ({
+      attributes,
+      hierarchicalFacets,
+      hierarchicalFacetsRefinements,
+    }),
   }));


### PR DESCRIPTION
**Summary**

This PR implements the `Breadcrumb` widget. Note that the story use the `Configure` widget to test the `Breadcrumb`. We need to change it to the `HierarchicalMenu` once it's implemented.

![screen shot 2018-08-17 at 12 24 06](https://user-images.githubusercontent.com/6513513/44261616-7c1d2600-a218-11e8-84d4-005dea004e71.png)

You can use the widget on [Storybook](https://deploy-preview-493--vue-instantsearch.netlify.com/stories/?selectedKind=Breadcrumb&selectedStory=default&full=0&addons=1&stories=1&panelRight=0).