### PR TITLE
feat(HierarchicalMenu): implement widget

### DIFF
--- a/.github/V2_PROGRESS.md
+++ b/.github/V2_PROGRESS.md
@@ -26,7 +26,7 @@ x => done
 * [x] `ais-clear-refinements`
 * [x] `ais-configure`
 * [~] `ais-current-refinements` Haroenv
-* [~] `ais-hierarchical-menu` Samuel
+* [x] `ais-hierarchical-menu`
 * [~] `ais-highlight` Haroenv
   * Just a getter for \_highlightResult, doesn't set any parameters
 * [x] `ais-hits-per-page`

--- a/docs/src/components/HierarchicalMenu.md
+++ b/docs/src/components/HierarchicalMenu.md
@@ -1,0 +1,67 @@
+---
+title: HierarchicalMenu
+mainTitle: Components
+layout: main.pug
+category: Components
+withHeadings: true
+navWeight: 6
+editable: true
+githubSource: docs/src/components/HierarchicalMenu.md
+---
+
+The hierarchical menu lets the user browse attributes using a tree-like structure. This is commonly used for multi-level categorization of products on e-commerce websites. From a UX point of view, we suggest not displaying more than two levels deep.
+
+<a class="btn btn-static-theme" href="stories/?selectedKind=HierarchicalMenu">🕹 try out live</a>
+
+## Usage
+
+```html
+<ais-hierarchical-menu
+  :attributes="[
+    'categories.lvl0',
+    'categories.lvl1',
+    'categories.lvl2',
+  ]"
+/>
+```
+
+## Props
+
+Name | Type | Default | Description | Required
+---|---|---|---|---
+attributes | `string[]` | - | Array of attributes to use to generate the hierarchical menu | Yes
+limit | `number` | `10` | Number of items to show | -
+showMoreLimit | `number` | `20` | Number of items to show when the user clicked on "show more" | -
+showMore | `boolean` | `false` | Whether or not to have the option to load more values | -
+separator | `string` | - | Separator used in the attributes to separate level values | -
+rootPath | `string` | - | Prefix path to use if the first level is not the root level | -
+showParentLevel | `boolean` | `true` | Show the siblings of the selected parent level of the current refined value. This does not impact the root level | -
+sortBy | `string[] | function` | `['name:asc']` | Array or function to sort the results by | -
+
+## Slots
+
+Name | Scope | Description
+---|---|---
+default | `{ items: object[], canRefine: boolean, canToggleShowMore: boolean, isShowingMore: boolean, refine: (value: string) => void, createURL: (value: string) => string, toggleShowMore: () => void }` | Slot to override the DOM output
+showMoreLabel | `{ isShowingMore: boolean }` | Slot to override the show more label
+
+## CSS classes
+
+Here's a list of CSS classes exposed by this widget. To better understand the underlying DOM structure, have a look at the generated DOM in your browser.
+
+Class name | Description
+---|---
+`ais-HierarchicalMenu` | The root div of the widget
+`ais-HierarchicalMenu--noRefinement` | The root div of the widget with no refinement
+`ais-HierarchicalMenu-list` | The list of menu items
+`ais-HierarchicalMenu-list--child` | The child list of menu items
+`ais-HierarchicalMenu-list--lvl0` | The level 0 list of menu items
+`ais-HierarchicalMenu-list--lvl1` | The level 1 list of menu items (and so on)
+`ais-HierarchicalMenu-item` | The menu list item
+`ais-HierarchicalMenu-item--selected` | The selected menu list item
+`ais-HierarchicalMenu-item--parent` | The menu list item containing children
+`ais-HierarchicalMenu-link` | The clickable menu element
+`ais-HierarchicalMenu-label` | The label of each item
+`ais-HierarchicalMenu-count` | The count of each item
+`ais-HierarchicalMenu-showMore` | The button used to display more categories
+`ais-HierarchicalMenu-showMore--disabled` | The disabled button used to display more categories

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "rollup-plugin-vue": "^3.0.0",
     "rollup-watch": "^4.3.1",
     "vue": "^2.5.17",
+    "vue-jest": "^2.6.0",
     "vue-json-tree": "^0.3.3",
     "vue-loader": "^14.2.2",
     "vue-template-compiler": "^2.5.17"
@@ -101,8 +102,8 @@
       "node_modules/(?!(instantsearch\\.js|vue-json-tree))"
     ],
     "transform": {
-      "^.+\\.js$": "<rootDir>/node_modules/babel-jest",
-      ".*\\.(vue)$": "<rootDir>/node_modules/jest-vue-preprocessor"
+      "^.+\\.js$": "babel-jest",
+      "^.+\\.vue$": "vue-jest"
     },
     "testURL": "https://example.com",
     "watchPlugins": [

--- a/src/components/HierarchicalMenu.vue
+++ b/src/components/HierarchicalMenu.vue
@@ -1,19 +1,49 @@
 <template>
-  <div>
-    <slot v-bind="state">
-      <json-tree :level="2" :data="state"></json-tree>
+  <div
+    v-if="state"
+    :class="[suit(''), !canRefine && suit('', 'noRefinement')]"
+  >
+    <slot
+      :items="items"
+      :can-refine="canRefine"
+      :can-toggle-show-more="canToggleShowMore"
+      :is-showing-more="isShowingMore"
+      :refine="state.refine"
+      :create-URL="state.createURL"
+      :toggle-show-more="toggleShowMore"
+    >
+      <ais-hierarchical-menu-list
+        :items="items"
+        :level="0"
+        :suit="suit"
+        :refine="state.refine"
+        :createURL="state.createURL"
+      />
+
+      <button
+        v-if="showMore"
+        :class="[suit('showMore'), !canToggleShowMore && suit('showMore', 'disabled')]"
+        :disabled="!canToggleShowMore"
+        @click.prevent="toggleShowMore"
+      >
+        <slot name="showMoreLabel" :is-showing-more="isShowingMore">
+          {{ isShowingMore ? 'Show less' : 'Show more' }}
+        </slot>
+      </button>
     </slot>
   </div>
 </template>
 
 <script>
-import JsonTree from 'vue-json-tree'; // todo: remove
-import algoliaComponent from '../component';
 import { connectHierarchicalMenu } from 'instantsearch.js/es/connectors';
+import algoliaComponent from '../component';
+import HierarchicalMenuList from './HierarchicalMenuList.vue';
 
 export default {
-  components: { 'json-tree': JsonTree },
   mixins: [algoliaComponent],
+  components: {
+    'ais-hierarchical-menu-list': HierarchicalMenuList,
+  },
   props: {
     attributes: {
       type: Array,
@@ -21,35 +51,35 @@ export default {
     },
     limit: {
       type: Number,
-      required: false,
-    },
-    showMore: {
-      type: Boolean,
-      required: false,
-      default: false,
+      default: 10,
     },
     showMoreLimit: {
       type: Number,
-      required: false,
       default: 20,
+    },
+    showMore: {
+      type: Boolean,
+      default: false,
+    },
+    sortBy: {
+      type: [Array, Function],
     },
     separator: {
       type: String,
-      required: false,
     },
     rootPath: {
       type: String,
-      required: false,
     },
     showParentLevel: {
       type: Boolean,
-      required: false,
-      default: true,
+      // explicit otherwise Vue coerces the default value
+      // to false because of the `Boolean` prop type
+      default: undefined,
     },
   },
   data() {
     return {
-      widgetName: 'ais-hierarchical-menu',
+      widgetName: 'HierarchicalMenu',
       isShowingMore: false,
     };
   },
@@ -60,17 +90,41 @@ export default {
     widgetParams() {
       return {
         attributes: this.attributes,
-        limit:
-          this.showMore && this.isShowingMore ? this.showMoreLimit : this.limit,
+        limit: this.showMore ? this.showMoreLimit : this.limit,
         separator: this.separator,
         rootPath: this.rootPath,
         showParentLevel: this.showParentLevel,
+        sortBy: this.sortBy,
       };
+    },
+    items() {
+      return this.truncate(this.state.items);
+    },
+    canRefine() {
+      return this.state.items.length > 0;
+    },
+    canToggleShowMore() {
+      return (
+        this.isShowingMore ||
+        this.state.items.length >= this.internalShowMoreLimit
+      );
+    },
+    internalShowMoreLimit() {
+      return this.isShowingMore ? this.showMoreLimit : this.limit;
     },
   },
   methods: {
     toggleShowMore() {
       this.isShowingMore = !this.isShowingMore;
+    },
+    truncate(items) {
+      const sliced = items.slice(items, this.internalShowMoreLimit);
+
+      return sliced.map(item =>
+        Object.assign({}, item, {
+          data: Array.isArray(item.data) ? this.truncate(item.data) : item.data,
+        })
+      );
     },
   },
 };</script>

--- a/src/components/HierarchicalMenu.vue
+++ b/src/components/HierarchicalMenu.vue
@@ -12,7 +12,7 @@
       :create-URL="state.createURL"
       :toggle-show-more="toggleShowMore"
     >
-      <ais-hierarchical-menu-list
+      <hierarchical-menu-list
         :items="items"
         :level="0"
         :suit="suit"
@@ -42,7 +42,7 @@ import HierarchicalMenuList from './HierarchicalMenuList.vue';
 export default {
   mixins: [algoliaComponent],
   components: {
-    'ais-hierarchical-menu-list': HierarchicalMenuList,
+    HierarchicalMenuList,
   },
   props: {
     attributes: {

--- a/src/components/HierarchicalMenuList.vue
+++ b/src/components/HierarchicalMenuList.vue
@@ -24,7 +24,7 @@
         <span :class="props.suit('count')">{{ item.count }}</span>
       </a>
 
-      <ais-hierarchical-menu-list
+      <hierarchical-menu-list
         v-if="item.data"
         :items="item.data"
         :level="props.level + 1"

--- a/src/components/HierarchicalMenuList.vue
+++ b/src/components/HierarchicalMenuList.vue
@@ -1,0 +1,63 @@
+<template functional>
+  <ul
+    :class="[
+      props.suit('list'),
+      props.level > 0 && props.suit('list', 'child'),
+      props.suit('list', `lvl${props.level}`)
+    ]"
+  >
+    <li
+      v-for="item in props.items"
+      :key="item.value"
+      :class="[
+        props.suit('item'),
+        item.data && props.suit('item', 'parent'),
+        item.isRefined && props.suit('item', 'selected')
+      ]"
+    >
+      <a
+        :href="props.createURL(item.value)"
+        :class="props.suit('link')"
+        @click.prevent="props.refine(item.value)"
+      >
+        <span :class="props.suit('label')">{{ item.label }}</span>
+        <span :class="props.suit('count')">{{ item.count }}</span>
+      </a>
+
+      <ais-hierarchical-menu-list
+        v-if="item.data"
+        :items="item.data"
+        :level="props.level + 1"
+        :suit="props.suit"
+        :refine="props.refine"
+        :createURL="props.createURL"
+      />
+    </li>
+  </ul>
+</template>
+
+<script>
+export default {
+  props: {
+    items: {
+      type: Array,
+      required: true,
+    },
+    level: {
+      type: Number,
+      required: true,
+    },
+    suit: {
+      type: Function,
+      required: true,
+    },
+    refine: {
+      type: Function,
+      required: true,
+    },
+    createURL: {
+      type: Function,
+      required: true,
+    },
+  },
+};</script>

--- a/src/components/__tests__/HierarchicalMenu.js
+++ b/src/components/__tests__/HierarchicalMenu.js
@@ -1,0 +1,720 @@
+import { mount } from '@vue/test-utils';
+import { __setState } from '../../component';
+import HierarchicalMenu from '../HierarchicalMenu.vue';
+
+jest.mock('../../component');
+
+const apple = {
+  label: 'Apple',
+  value: 'Apple',
+  isRefined: false,
+  count: 80,
+  data: null,
+};
+
+const macbook = {
+  label: 'MacBook',
+  value: 'Apple > MacBook',
+  isRefined: false,
+  count: 40,
+  data: null,
+};
+
+const iphone = {
+  label: 'iPhone',
+  value: 'Apple > iPhone',
+  isRefined: false,
+  count: 20,
+  data: null,
+};
+
+const ipad = {
+  label: 'iPad',
+  value: 'Apple > iPad',
+  isRefined: false,
+  count: 20,
+  data: null,
+};
+
+const macbook13 = {
+  label: 'MacBook 13"',
+  value: 'Apple > MacBook > MacBook 13"',
+  isRefined: false,
+  count: 20,
+  data: null,
+};
+
+const macbook15 = {
+  label: 'MacBook 15"',
+  value: 'Apple > MacBook > MacBook 15"',
+  isRefined: false,
+  count: 10,
+  data: null,
+};
+
+const macbook12 = {
+  label: 'MacBook 12',
+  value: 'Apple > MacBook > MacBook',
+  isRefined: false,
+  count: 10,
+  data: null,
+};
+
+const samsung = {
+  label: 'Samsung',
+  value: 'Samsung',
+  isRefined: false,
+  count: 40,
+  data: null,
+};
+
+const galaxy = {
+  label: 'Galaxy',
+  value: 'Samsung > Galaxy',
+  isRefined: false,
+  count: 30,
+  data: null,
+};
+
+const note = {
+  label: 'Note',
+  value: 'Samsung > Note',
+  isRefined: false,
+  count: 10,
+  data: null,
+};
+
+const microsoft = {
+  label: 'Microsoft',
+  value: 'Microsoft',
+  isRefined: false,
+  count: 20,
+  data: null,
+};
+
+const defaultState = {
+  items: [
+    {
+      ...apple,
+      data: [
+        iphone,
+        ipad,
+        {
+          ...macbook,
+          data: [macbook13, macbook15, macbook12],
+        },
+      ],
+    },
+    {
+      ...samsung,
+      data: [galaxy, note],
+    },
+    microsoft,
+  ],
+  refine: () => {},
+  createURL: () => {},
+};
+
+const defaultProps = {
+  attributes: ['categories.lvl0', 'categories.lvl1', 'categories.lvl2'],
+};
+
+it('accepts an attributes prop', () => {
+  __setState({
+    ...defaultState,
+  });
+
+  const wrapper = mount(HierarchicalMenu, {
+    propsData: defaultProps,
+  });
+
+  expect(wrapper.vm.widgetParams.attributes).toEqual([
+    'categories.lvl0',
+    'categories.lvl1',
+    'categories.lvl2',
+  ]);
+});
+
+it('accepts a limit prop (without showMore)', () => {
+  __setState({
+    ...defaultState,
+  });
+
+  const wrapper = mount(HierarchicalMenu, {
+    propsData: {
+      ...defaultProps,
+      showMore: false,
+      limit: 2,
+      showMoreLimit: 5,
+    },
+  });
+
+  expect(wrapper.vm.widgetParams.limit).toBe(2);
+});
+
+it('accepts a showMoreLimit prop (with showMore)', () => {
+  __setState({
+    ...defaultState,
+  });
+
+  const wrapper = mount(HierarchicalMenu, {
+    propsData: {
+      ...defaultProps,
+      showMore: true,
+      limit: 2,
+      showMoreLimit: 5,
+    },
+  });
+
+  expect(wrapper.vm.widgetParams.limit).toBe(5);
+});
+
+it('accepts a separator prop', () => {
+  __setState({
+    ...defaultState,
+  });
+
+  const wrapper = mount(HierarchicalMenu, {
+    propsData: {
+      ...defaultProps,
+      separator: ' > ',
+    },
+  });
+
+  expect(wrapper.vm.widgetParams.separator).toBe(' > ');
+});
+
+it('accepts a rootPath prop', () => {
+  __setState({
+    ...defaultState,
+  });
+
+  const wrapper = mount(HierarchicalMenu, {
+    propsData: {
+      ...defaultProps,
+      rootPath: 'Apple > MacBook',
+    },
+  });
+
+  expect(wrapper.vm.widgetParams.rootPath).toBe('Apple > MacBook');
+});
+
+it('accepts a showParentLevel prop', () => {
+  __setState({
+    ...defaultState,
+  });
+
+  const wrapper = mount(HierarchicalMenu, {
+    propsData: {
+      ...defaultProps,
+      showParentLevel: false,
+    },
+  });
+
+  expect(wrapper.vm.widgetParams.showParentLevel).toBe(false);
+});
+
+it('accepts a sortBy prop', () => {
+  __setState({
+    ...defaultState,
+  });
+
+  const wrapper = mount(HierarchicalMenu, {
+    propsData: {
+      ...defaultProps,
+      sortBy: ['count:asc'],
+    },
+  });
+
+  expect(wrapper.vm.widgetParams.sortBy).toEqual(['count:asc']);
+});
+
+describe('default render', () => {
+  it('renders correctly', () => {
+    __setState({ ...defaultState });
+
+    const wrapper = mount(HierarchicalMenu, {
+      propsData: defaultProps,
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly without refinement', () => {
+    __setState({
+      ...defaultState,
+      items: [],
+    });
+
+    const wrapper = mount(HierarchicalMenu, {
+      propsData: defaultProps,
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly the parent of sub categories', () => {
+    __setState({
+      ...defaultState,
+    });
+
+    const wrapper = mount(HierarchicalMenu, {
+      propsData: defaultProps,
+    });
+
+    expect(wrapper.findAll('.ais-HierarchicalMenu-item--parent')).toHaveLength(
+      3 // 2 Apple + 1 Samsung
+    );
+  });
+
+  it('renders correctly the list of sub categories', () => {
+    __setState({
+      ...defaultState,
+    });
+
+    const wrapper = mount(HierarchicalMenu, {
+      propsData: defaultProps,
+    });
+
+    expect(wrapper.findAll('.ais-HierarchicalMenu-list--lvl0')).toHaveLength(1);
+    expect(wrapper.findAll('.ais-HierarchicalMenu-list--lvl1')).toHaveLength(2);
+    expect(wrapper.findAll('.ais-HierarchicalMenu-list--lvl2')).toHaveLength(1);
+
+    expect(wrapper.findAll('.ais-HierarchicalMenu-list--child')).toHaveLength(
+      3 // 2 Apple + 1 Samsung
+    );
+  });
+
+  it('renders correctly with a URL for the href', () => {
+    __setState({
+      ...defaultState,
+      createURL: value => `/categories/${value}`,
+    });
+
+    const wrapper = mount(HierarchicalMenu, {
+      propsData: defaultProps,
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly a sub categories selected', () => {
+    __setState({
+      ...defaultState,
+      items: [
+        {
+          ...apple,
+          isRefined: true,
+          data: [
+            iphone,
+            ipad,
+            {
+              ...macbook,
+              isRefined: true,
+              data: [macbook13, macbook15, macbook12],
+            },
+          ],
+        },
+        {
+          ...samsung,
+          data: [galaxy, note],
+        },
+        microsoft,
+      ],
+    });
+
+    const wrapper = mount(HierarchicalMenu, {
+      propsData: defaultProps,
+    });
+
+    expect(
+      wrapper.findAll('.ais-HierarchicalMenu-item--selected')
+    ).toHaveLength(2);
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with a limit', () => {
+    __setState({
+      ...defaultState,
+    });
+
+    const wrapper = mount(HierarchicalMenu, {
+      propsData: {
+        ...defaultProps,
+        showMore: true,
+        limit: 1,
+      },
+    });
+
+    expect(wrapper.findAll('.ais-HierarchicalMenu-item')).toHaveLength(2); // 2 Apple (top + child)
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with a show more limit', () => {
+    __setState({
+      ...defaultState,
+    });
+
+    const wrapper = mount(HierarchicalMenu, {
+      propsData: {
+        ...defaultProps,
+        showMore: true,
+        limit: 1,
+        showMoreLimit: 2,
+      },
+    });
+
+    wrapper.find('button').trigger('click');
+
+    expect(wrapper.findAll('.ais-HierarchicalMenu-item')).toHaveLength(6); // 3 Apple + 3 Samsnug (top + child)
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with show more disabled', () => {
+    __setState({
+      ...defaultState,
+    });
+
+    const wrapper = mount(HierarchicalMenu, {
+      propsData: {
+        ...defaultProps,
+        showMore: true,
+      },
+    });
+
+    const button = wrapper.find('button');
+
+    expect(button.attributes().disabled).toBe('disabled');
+    expect(button.classes()).toContain(
+      'ais-HierarchicalMenu-showMore--disabled'
+    );
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with show more label', () => {
+    __setState({
+      ...defaultState,
+    });
+
+    const wrapper = mount(HierarchicalMenu, {
+      propsData: {
+        ...defaultProps,
+        showMore: true,
+      },
+    });
+
+    expect(wrapper.find('button').text()).toBe('Show more');
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with show more label toggled', () => {
+    __setState({
+      ...defaultState,
+    });
+
+    const wrapper = mount(HierarchicalMenu, {
+      propsData: {
+        ...defaultProps,
+        showMore: true,
+        limit: 1,
+      },
+    });
+
+    const button = wrapper.find('button');
+
+    button.trigger('click');
+
+    expect(wrapper.find('button').text()).toBe('Show less');
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('calls refine on link click', () => {
+    const refine = jest.fn();
+
+    __setState({
+      ...defaultState,
+      refine,
+    });
+
+    const wrapper = mount(HierarchicalMenu, {
+      propsData: defaultProps,
+    });
+
+    wrapper
+      .find('.ais-HierarchicalMenu-list--lvl2')
+      .findAll('a')
+      .at(1)
+      .trigger('click');
+
+    expect(refine).toHaveBeenCalledTimes(1);
+    expect(refine).toHaveBeenCalledWith('Apple > MacBook > MacBook 15"');
+  });
+
+  it('calls toggleShowMore on button click', () => {
+    __setState({
+      ...defaultState,
+    });
+
+    const wrapper = mount(HierarchicalMenu, {
+      propsData: {
+        ...defaultProps,
+        showMore: true,
+        limit: 1,
+      },
+    });
+
+    expect(wrapper.vm.isShowingMore).toBe(false);
+
+    wrapper.find('button').trigger('click');
+
+    expect(wrapper.vm.isShowingMore).toBe(true);
+  });
+});
+
+describe('custom default render', () => {
+  const defaultScopedSlot = `
+    <div
+      slot-scope="state"
+      :class="[!state.canRefine && 'no-refinement']"
+    >
+      <ol>
+        <li
+          v-for="item in state.items"
+          :key="item.value"
+        >
+          <a
+            :href="state.createURL(item.value)"
+            @click.prevent="state.refine(item.value)"
+          >
+            {{item.label}} - {{item.count}}
+          </a>
+          <ol v-if="item.data">
+            <li
+              v-for="child in item.data"
+              :key="child.value"
+            >
+              <a
+                :href="state.createURL(child.value)"
+                @click.prevent="state.refine(child.value)"
+              >
+                {{child.label}} - {{child.count}}
+              </a>
+            </li>
+          </ol>
+        </li>
+      </ol>
+      <button
+        :disabled="!state.canToggleShowMore"
+        @click.prevent="state.toggleShowMore"
+      >
+        {{ state.isShowingMore ? 'View less' : 'View more' }}
+      </button>
+    </div>
+  `;
+
+  it('renders correctly', () => {
+    __setState({ ...defaultState });
+
+    const wrapper = mount(HierarchicalMenu, {
+      propsData: defaultProps,
+      scopedSlots: {
+        default: defaultScopedSlot,
+      },
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly without refinement', () => {
+    __setState({
+      ...defaultState,
+      items: [],
+    });
+
+    const wrapper = mount(HierarchicalMenu, {
+      propsData: defaultProps,
+      scopedSlots: {
+        default: defaultScopedSlot,
+      },
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with an URL for the href', () => {
+    __setState({
+      ...defaultState,
+      createURL: value => `/categories/${value}`,
+    });
+
+    const wrapper = mount(HierarchicalMenu, {
+      propsData: defaultProps,
+      scopedSlots: {
+        default: defaultScopedSlot,
+      },
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with a limit', () => {
+    __setState({
+      ...defaultState,
+    });
+
+    const wrapper = mount(HierarchicalMenu, {
+      propsData: {
+        ...defaultProps,
+        limit: 1,
+      },
+      scopedSlots: {
+        default: defaultScopedSlot,
+      },
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with a show more button toggled', () => {
+    __setState({
+      ...defaultState,
+    });
+
+    const wrapper = mount(HierarchicalMenu, {
+      propsData: {
+        ...defaultProps,
+        limit: 1,
+      },
+      scopedSlots: {
+        default: defaultScopedSlot,
+      },
+    });
+
+    expect(wrapper.find('button').text()).toBe('View more');
+    expect(wrapper.html()).toMatchSnapshot();
+
+    wrapper.find('button').trigger('click');
+
+    expect(wrapper.find('button').text()).toBe('View less');
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with a disabled show more button', () => {
+    __setState({
+      ...defaultState,
+    });
+
+    const wrapper = mount(HierarchicalMenu, {
+      propsData: defaultProps,
+      scopedSlots: {
+        default: defaultScopedSlot,
+      },
+    });
+
+    expect(wrapper.find('button').attributes().disabled).toBe('disabled');
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('calls refine on link click', () => {
+    const refine = jest.fn();
+
+    __setState({
+      ...defaultState,
+      refine,
+    });
+
+    const wrapper = mount(HierarchicalMenu, {
+      propsData: defaultProps,
+      scopedSlots: {
+        default: defaultScopedSlot,
+      },
+    });
+
+    wrapper
+      .findAll('ol')
+      .at(1)
+      .findAll('a')
+      .at(2)
+      .trigger('click');
+
+    expect(refine).toHaveBeenCalledTimes(1);
+    expect(refine).toHaveBeenCalledWith('Apple > MacBook');
+  });
+
+  it('calls toggleShowMore on button click', () => {
+    __setState({
+      ...defaultState,
+    });
+
+    const wrapper = mount(HierarchicalMenu, {
+      propsData: {
+        ...defaultProps,
+        showMore: true,
+        limit: 1,
+      },
+      scopedSlots: {
+        default: defaultScopedSlot,
+      },
+    });
+
+    expect(wrapper.vm.isShowingMore).toBe(false);
+
+    wrapper.find('button').trigger('click');
+
+    expect(wrapper.vm.isShowingMore).toBe(true);
+  });
+});
+
+describe('custom showMoreLabel render', () => {
+  const showMoreLabelScopedSlot = `
+    <span slot-scope="{ isShowingMore }">
+      {{ isShowingMore ? 'Voir moins' : 'Voir plus' }}
+    </span>
+  `;
+
+  it('renders correctly with a custom show more label', () => {
+    __setState({ ...defaultState });
+
+    const wrapper = mount(HierarchicalMenu, {
+      propsData: {
+        ...defaultProps,
+        showMore: true,
+        limit: 1,
+      },
+      scopedSlots: {
+        showMoreLabel: showMoreLabelScopedSlot,
+      },
+    });
+
+    expect(wrapper.find('.ais-HierarchicalMenu-showMore').text()).toBe(
+      'Voir plus'
+    );
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders correctly with a custom show more label toggled', () => {
+    __setState({ ...defaultState });
+
+    const wrapper = mount(HierarchicalMenu, {
+      propsData: {
+        ...defaultProps,
+        showMore: true,
+        limit: 1,
+      },
+      scopedSlots: {
+        showMoreLabel: showMoreLabelScopedSlot,
+      },
+    });
+
+    wrapper.find('button').trigger('click');
+
+    expect(wrapper.find('.ais-HierarchicalMenu-showMore').text()).toBe(
+      'Voir moins'
+    );
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+});

--- a/src/components/__tests__/__snapshots__/HierarchicalMenu.js.snap
+++ b/src/components/__tests__/__snapshots__/HierarchicalMenu.js.snap
@@ -1,0 +1,1369 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`custom default render renders correctly 1`] = `
+
+<div class="ais-HierarchicalMenu">
+  <div class>
+    <ol>
+      <li>
+        <a>
+          Apple - 80
+        </a>
+        <ol>
+          <li>
+            <a>
+              iPhone - 20
+            </a>
+          </li>
+          <li>
+            <a>
+              iPad - 20
+            </a>
+          </li>
+          <li>
+            <a>
+              MacBook - 40
+            </a>
+          </li>
+        </ol>
+      </li>
+      <li>
+        <a>
+          Samsung - 40
+        </a>
+        <ol>
+          <li>
+            <a>
+              Galaxy - 30
+            </a>
+          </li>
+          <li>
+            <a>
+              Note - 10
+            </a>
+          </li>
+        </ol>
+      </li>
+      <li>
+        <a>
+          Microsoft - 20
+        </a>
+      </li>
+    </ol>
+    <button disabled="disabled">
+      View more
+    </button>
+  </div>
+</div>
+
+`;
+
+exports[`custom default render renders correctly with a disabled show more button 1`] = `
+
+<div class="ais-HierarchicalMenu">
+  <div class>
+    <ol>
+      <li>
+        <a>
+          Apple - 80
+        </a>
+        <ol>
+          <li>
+            <a>
+              iPhone - 20
+            </a>
+          </li>
+          <li>
+            <a>
+              iPad - 20
+            </a>
+          </li>
+          <li>
+            <a>
+              MacBook - 40
+            </a>
+          </li>
+        </ol>
+      </li>
+      <li>
+        <a>
+          Samsung - 40
+        </a>
+        <ol>
+          <li>
+            <a>
+              Galaxy - 30
+            </a>
+          </li>
+          <li>
+            <a>
+              Note - 10
+            </a>
+          </li>
+        </ol>
+      </li>
+      <li>
+        <a>
+          Microsoft - 20
+        </a>
+      </li>
+    </ol>
+    <button disabled="disabled">
+      View more
+    </button>
+  </div>
+</div>
+
+`;
+
+exports[`custom default render renders correctly with a limit 1`] = `
+
+<div class="ais-HierarchicalMenu">
+  <div class>
+    <ol>
+      <li>
+        <a>
+          Apple - 80
+        </a>
+        <ol>
+          <li>
+            <a>
+              iPhone - 20
+            </a>
+          </li>
+        </ol>
+      </li>
+    </ol>
+    <button>
+      View more
+    </button>
+  </div>
+</div>
+
+`;
+
+exports[`custom default render renders correctly with a show more button toggled 1`] = `
+
+<div class="ais-HierarchicalMenu">
+  <div class>
+    <ol>
+      <li>
+        <a>
+          Apple - 80
+        </a>
+        <ol>
+          <li>
+            <a>
+              iPhone - 20
+            </a>
+          </li>
+        </ol>
+      </li>
+    </ol>
+    <button>
+      View more
+    </button>
+  </div>
+</div>
+
+`;
+
+exports[`custom default render renders correctly with a show more button toggled 2`] = `
+
+<div class="ais-HierarchicalMenu">
+  <div class>
+    <ol>
+      <li>
+        <a>
+          Apple - 80
+        </a>
+        <ol>
+          <li>
+            <a>
+              iPhone - 20
+            </a>
+          </li>
+          <li>
+            <a>
+              iPad - 20
+            </a>
+          </li>
+          <li>
+            <a>
+              MacBook - 40
+            </a>
+          </li>
+        </ol>
+      </li>
+      <li>
+        <a>
+          Samsung - 40
+        </a>
+        <ol>
+          <li>
+            <a>
+              Galaxy - 30
+            </a>
+          </li>
+          <li>
+            <a>
+              Note - 10
+            </a>
+          </li>
+        </ol>
+      </li>
+      <li>
+        <a>
+          Microsoft - 20
+        </a>
+      </li>
+    </ol>
+    <button>
+      View less
+    </button>
+  </div>
+</div>
+
+`;
+
+exports[`custom default render renders correctly with an URL for the href 1`] = `
+
+<div class="ais-HierarchicalMenu">
+  <div class>
+    <ol>
+      <li>
+        <a href="/categories/Apple">
+          Apple - 80
+        </a>
+        <ol>
+          <li>
+            <a href="/categories/Apple > iPhone">
+              iPhone - 20
+            </a>
+          </li>
+          <li>
+            <a href="/categories/Apple > iPad">
+              iPad - 20
+            </a>
+          </li>
+          <li>
+            <a href="/categories/Apple > MacBook">
+              MacBook - 40
+            </a>
+          </li>
+        </ol>
+      </li>
+      <li>
+        <a href="/categories/Samsung">
+          Samsung - 40
+        </a>
+        <ol>
+          <li>
+            <a href="/categories/Samsung > Galaxy">
+              Galaxy - 30
+            </a>
+          </li>
+          <li>
+            <a href="/categories/Samsung > Note">
+              Note - 10
+            </a>
+          </li>
+        </ol>
+      </li>
+      <li>
+        <a href="/categories/Microsoft">
+          Microsoft - 20
+        </a>
+      </li>
+    </ol>
+    <button disabled="disabled">
+      View more
+    </button>
+  </div>
+</div>
+
+`;
+
+exports[`custom default render renders correctly without refinement 1`] = `
+
+<div class="ais-HierarchicalMenu ais-HierarchicalMenu--noRefinement">
+  <div class="no-refinement">
+    <ol>
+    </ol>
+    <button disabled="disabled">
+      View more
+    </button>
+  </div>
+</div>
+
+`;
+
+exports[`custom showMoreLabel render renders correctly with a custom show more label 1`] = `
+
+<div class="ais-HierarchicalMenu">
+  <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--lvl0">
+    <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent">
+      <a class="ais-HierarchicalMenu-link">
+        <span class="ais-HierarchicalMenu-label">
+          Apple
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          80
+        </span>
+      </a>
+      <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl1">
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              iPhone
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              20
+            </span>
+          </a>
+        </li>
+      </ul>
+    </li>
+  </ul>
+  <button class="ais-HierarchicalMenu-showMore">
+    <span>
+      Voir plus
+    </span>
+  </button>
+</div>
+
+`;
+
+exports[`custom showMoreLabel render renders correctly with a custom show more label toggled 1`] = `
+
+<div class="ais-HierarchicalMenu">
+  <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--lvl0">
+    <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent">
+      <a class="ais-HierarchicalMenu-link">
+        <span class="ais-HierarchicalMenu-label">
+          Apple
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          80
+        </span>
+      </a>
+      <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl1">
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              iPhone
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              20
+            </span>
+          </a>
+        </li>
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              iPad
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              20
+            </span>
+          </a>
+        </li>
+        <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              MacBook
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              40
+            </span>
+          </a>
+          <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl2">
+            <li class="ais-HierarchicalMenu-item">
+              <a class="ais-HierarchicalMenu-link">
+                <span class="ais-HierarchicalMenu-label">
+                  MacBook 13"
+                </span>
+                <span class="ais-HierarchicalMenu-count">
+                  20
+                </span>
+              </a>
+            </li>
+            <li class="ais-HierarchicalMenu-item">
+              <a class="ais-HierarchicalMenu-link">
+                <span class="ais-HierarchicalMenu-label">
+                  MacBook 15"
+                </span>
+                <span class="ais-HierarchicalMenu-count">
+                  10
+                </span>
+              </a>
+            </li>
+            <li class="ais-HierarchicalMenu-item">
+              <a class="ais-HierarchicalMenu-link">
+                <span class="ais-HierarchicalMenu-label">
+                  MacBook 12
+                </span>
+                <span class="ais-HierarchicalMenu-count">
+                  10
+                </span>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent">
+      <a class="ais-HierarchicalMenu-link">
+        <span class="ais-HierarchicalMenu-label">
+          Samsung
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          40
+        </span>
+      </a>
+      <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl1">
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              Galaxy
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              30
+            </span>
+          </a>
+        </li>
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              Note
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              10
+            </span>
+          </a>
+        </li>
+      </ul>
+    </li>
+    <li class="ais-HierarchicalMenu-item">
+      <a class="ais-HierarchicalMenu-link">
+        <span class="ais-HierarchicalMenu-label">
+          Microsoft
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          20
+        </span>
+      </a>
+    </li>
+  </ul>
+  <button class="ais-HierarchicalMenu-showMore">
+    <span>
+      Voir moins
+    </span>
+  </button>
+</div>
+
+`;
+
+exports[`default render renders correctly 1`] = `
+
+<div class="ais-HierarchicalMenu">
+  <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--lvl0">
+    <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent">
+      <a class="ais-HierarchicalMenu-link">
+        <span class="ais-HierarchicalMenu-label">
+          Apple
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          80
+        </span>
+      </a>
+      <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl1">
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              iPhone
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              20
+            </span>
+          </a>
+        </li>
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              iPad
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              20
+            </span>
+          </a>
+        </li>
+        <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              MacBook
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              40
+            </span>
+          </a>
+          <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl2">
+            <li class="ais-HierarchicalMenu-item">
+              <a class="ais-HierarchicalMenu-link">
+                <span class="ais-HierarchicalMenu-label">
+                  MacBook 13"
+                </span>
+                <span class="ais-HierarchicalMenu-count">
+                  20
+                </span>
+              </a>
+            </li>
+            <li class="ais-HierarchicalMenu-item">
+              <a class="ais-HierarchicalMenu-link">
+                <span class="ais-HierarchicalMenu-label">
+                  MacBook 15"
+                </span>
+                <span class="ais-HierarchicalMenu-count">
+                  10
+                </span>
+              </a>
+            </li>
+            <li class="ais-HierarchicalMenu-item">
+              <a class="ais-HierarchicalMenu-link">
+                <span class="ais-HierarchicalMenu-label">
+                  MacBook 12
+                </span>
+                <span class="ais-HierarchicalMenu-count">
+                  10
+                </span>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent">
+      <a class="ais-HierarchicalMenu-link">
+        <span class="ais-HierarchicalMenu-label">
+          Samsung
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          40
+        </span>
+      </a>
+      <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl1">
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              Galaxy
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              30
+            </span>
+          </a>
+        </li>
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              Note
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              10
+            </span>
+          </a>
+        </li>
+      </ul>
+    </li>
+    <li class="ais-HierarchicalMenu-item">
+      <a class="ais-HierarchicalMenu-link">
+        <span class="ais-HierarchicalMenu-label">
+          Microsoft
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          20
+        </span>
+      </a>
+    </li>
+  </ul>
+</div>
+
+`;
+
+exports[`default render renders correctly a sub categories selected 1`] = `
+
+<div class="ais-HierarchicalMenu">
+  <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--lvl0">
+    <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent ais-HierarchicalMenu-item--selected">
+      <a class="ais-HierarchicalMenu-link">
+        <span class="ais-HierarchicalMenu-label">
+          Apple
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          80
+        </span>
+      </a>
+      <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl1">
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              iPhone
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              20
+            </span>
+          </a>
+        </li>
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              iPad
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              20
+            </span>
+          </a>
+        </li>
+        <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent ais-HierarchicalMenu-item--selected">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              MacBook
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              40
+            </span>
+          </a>
+          <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl2">
+            <li class="ais-HierarchicalMenu-item">
+              <a class="ais-HierarchicalMenu-link">
+                <span class="ais-HierarchicalMenu-label">
+                  MacBook 13"
+                </span>
+                <span class="ais-HierarchicalMenu-count">
+                  20
+                </span>
+              </a>
+            </li>
+            <li class="ais-HierarchicalMenu-item">
+              <a class="ais-HierarchicalMenu-link">
+                <span class="ais-HierarchicalMenu-label">
+                  MacBook 15"
+                </span>
+                <span class="ais-HierarchicalMenu-count">
+                  10
+                </span>
+              </a>
+            </li>
+            <li class="ais-HierarchicalMenu-item">
+              <a class="ais-HierarchicalMenu-link">
+                <span class="ais-HierarchicalMenu-label">
+                  MacBook 12
+                </span>
+                <span class="ais-HierarchicalMenu-count">
+                  10
+                </span>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent">
+      <a class="ais-HierarchicalMenu-link">
+        <span class="ais-HierarchicalMenu-label">
+          Samsung
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          40
+        </span>
+      </a>
+      <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl1">
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              Galaxy
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              30
+            </span>
+          </a>
+        </li>
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              Note
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              10
+            </span>
+          </a>
+        </li>
+      </ul>
+    </li>
+    <li class="ais-HierarchicalMenu-item">
+      <a class="ais-HierarchicalMenu-link">
+        <span class="ais-HierarchicalMenu-label">
+          Microsoft
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          20
+        </span>
+      </a>
+    </li>
+  </ul>
+</div>
+
+`;
+
+exports[`default render renders correctly with a URL for the href 1`] = `
+
+<div class="ais-HierarchicalMenu">
+  <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--lvl0">
+    <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent">
+      <a href="/categories/Apple"
+         class="ais-HierarchicalMenu-link"
+      >
+        <span class="ais-HierarchicalMenu-label">
+          Apple
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          80
+        </span>
+      </a>
+      <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl1">
+        <li class="ais-HierarchicalMenu-item">
+          <a href="/categories/Apple > iPhone"
+             class="ais-HierarchicalMenu-link"
+          >
+            <span class="ais-HierarchicalMenu-label">
+              iPhone
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              20
+            </span>
+          </a>
+        </li>
+        <li class="ais-HierarchicalMenu-item">
+          <a href="/categories/Apple > iPad"
+             class="ais-HierarchicalMenu-link"
+          >
+            <span class="ais-HierarchicalMenu-label">
+              iPad
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              20
+            </span>
+          </a>
+        </li>
+        <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent">
+          <a href="/categories/Apple > MacBook"
+             class="ais-HierarchicalMenu-link"
+          >
+            <span class="ais-HierarchicalMenu-label">
+              MacBook
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              40
+            </span>
+          </a>
+          <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl2">
+            <li class="ais-HierarchicalMenu-item">
+              <a href="/categories/Apple > MacBook > MacBook 13&quot;"
+                 class="ais-HierarchicalMenu-link"
+              >
+                <span class="ais-HierarchicalMenu-label">
+                  MacBook 13"
+                </span>
+                <span class="ais-HierarchicalMenu-count">
+                  20
+                </span>
+              </a>
+            </li>
+            <li class="ais-HierarchicalMenu-item">
+              <a href="/categories/Apple > MacBook > MacBook 15&quot;"
+                 class="ais-HierarchicalMenu-link"
+              >
+                <span class="ais-HierarchicalMenu-label">
+                  MacBook 15"
+                </span>
+                <span class="ais-HierarchicalMenu-count">
+                  10
+                </span>
+              </a>
+            </li>
+            <li class="ais-HierarchicalMenu-item">
+              <a href="/categories/Apple > MacBook > MacBook"
+                 class="ais-HierarchicalMenu-link"
+              >
+                <span class="ais-HierarchicalMenu-label">
+                  MacBook 12
+                </span>
+                <span class="ais-HierarchicalMenu-count">
+                  10
+                </span>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent">
+      <a href="/categories/Samsung"
+         class="ais-HierarchicalMenu-link"
+      >
+        <span class="ais-HierarchicalMenu-label">
+          Samsung
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          40
+        </span>
+      </a>
+      <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl1">
+        <li class="ais-HierarchicalMenu-item">
+          <a href="/categories/Samsung > Galaxy"
+             class="ais-HierarchicalMenu-link"
+          >
+            <span class="ais-HierarchicalMenu-label">
+              Galaxy
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              30
+            </span>
+          </a>
+        </li>
+        <li class="ais-HierarchicalMenu-item">
+          <a href="/categories/Samsung > Note"
+             class="ais-HierarchicalMenu-link"
+          >
+            <span class="ais-HierarchicalMenu-label">
+              Note
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              10
+            </span>
+          </a>
+        </li>
+      </ul>
+    </li>
+    <li class="ais-HierarchicalMenu-item">
+      <a href="/categories/Microsoft"
+         class="ais-HierarchicalMenu-link"
+      >
+        <span class="ais-HierarchicalMenu-label">
+          Microsoft
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          20
+        </span>
+      </a>
+    </li>
+  </ul>
+</div>
+
+`;
+
+exports[`default render renders correctly with a limit 1`] = `
+
+<div class="ais-HierarchicalMenu">
+  <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--lvl0">
+    <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent">
+      <a class="ais-HierarchicalMenu-link">
+        <span class="ais-HierarchicalMenu-label">
+          Apple
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          80
+        </span>
+      </a>
+      <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl1">
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              iPhone
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              20
+            </span>
+          </a>
+        </li>
+      </ul>
+    </li>
+  </ul>
+  <button class="ais-HierarchicalMenu-showMore">
+    Show more
+  </button>
+</div>
+
+`;
+
+exports[`default render renders correctly with a show more limit 1`] = `
+
+<div class="ais-HierarchicalMenu">
+  <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--lvl0">
+    <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent">
+      <a class="ais-HierarchicalMenu-link">
+        <span class="ais-HierarchicalMenu-label">
+          Apple
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          80
+        </span>
+      </a>
+      <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl1">
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              iPhone
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              20
+            </span>
+          </a>
+        </li>
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              iPad
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              20
+            </span>
+          </a>
+        </li>
+      </ul>
+    </li>
+    <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent">
+      <a class="ais-HierarchicalMenu-link">
+        <span class="ais-HierarchicalMenu-label">
+          Samsung
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          40
+        </span>
+      </a>
+      <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl1">
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              Galaxy
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              30
+            </span>
+          </a>
+        </li>
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              Note
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              10
+            </span>
+          </a>
+        </li>
+      </ul>
+    </li>
+  </ul>
+  <button class="ais-HierarchicalMenu-showMore">
+    Show less
+  </button>
+</div>
+
+`;
+
+exports[`default render renders correctly with show more disabled 1`] = `
+
+<div class="ais-HierarchicalMenu">
+  <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--lvl0">
+    <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent">
+      <a class="ais-HierarchicalMenu-link">
+        <span class="ais-HierarchicalMenu-label">
+          Apple
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          80
+        </span>
+      </a>
+      <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl1">
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              iPhone
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              20
+            </span>
+          </a>
+        </li>
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              iPad
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              20
+            </span>
+          </a>
+        </li>
+        <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              MacBook
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              40
+            </span>
+          </a>
+          <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl2">
+            <li class="ais-HierarchicalMenu-item">
+              <a class="ais-HierarchicalMenu-link">
+                <span class="ais-HierarchicalMenu-label">
+                  MacBook 13"
+                </span>
+                <span class="ais-HierarchicalMenu-count">
+                  20
+                </span>
+              </a>
+            </li>
+            <li class="ais-HierarchicalMenu-item">
+              <a class="ais-HierarchicalMenu-link">
+                <span class="ais-HierarchicalMenu-label">
+                  MacBook 15"
+                </span>
+                <span class="ais-HierarchicalMenu-count">
+                  10
+                </span>
+              </a>
+            </li>
+            <li class="ais-HierarchicalMenu-item">
+              <a class="ais-HierarchicalMenu-link">
+                <span class="ais-HierarchicalMenu-label">
+                  MacBook 12
+                </span>
+                <span class="ais-HierarchicalMenu-count">
+                  10
+                </span>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent">
+      <a class="ais-HierarchicalMenu-link">
+        <span class="ais-HierarchicalMenu-label">
+          Samsung
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          40
+        </span>
+      </a>
+      <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl1">
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              Galaxy
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              30
+            </span>
+          </a>
+        </li>
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              Note
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              10
+            </span>
+          </a>
+        </li>
+      </ul>
+    </li>
+    <li class="ais-HierarchicalMenu-item">
+      <a class="ais-HierarchicalMenu-link">
+        <span class="ais-HierarchicalMenu-label">
+          Microsoft
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          20
+        </span>
+      </a>
+    </li>
+  </ul>
+  <button disabled="disabled"
+          class="ais-HierarchicalMenu-showMore ais-HierarchicalMenu-showMore--disabled"
+  >
+    Show more
+  </button>
+</div>
+
+`;
+
+exports[`default render renders correctly with show more label 1`] = `
+
+<div class="ais-HierarchicalMenu">
+  <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--lvl0">
+    <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent">
+      <a class="ais-HierarchicalMenu-link">
+        <span class="ais-HierarchicalMenu-label">
+          Apple
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          80
+        </span>
+      </a>
+      <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl1">
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              iPhone
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              20
+            </span>
+          </a>
+        </li>
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              iPad
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              20
+            </span>
+          </a>
+        </li>
+        <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              MacBook
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              40
+            </span>
+          </a>
+          <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl2">
+            <li class="ais-HierarchicalMenu-item">
+              <a class="ais-HierarchicalMenu-link">
+                <span class="ais-HierarchicalMenu-label">
+                  MacBook 13"
+                </span>
+                <span class="ais-HierarchicalMenu-count">
+                  20
+                </span>
+              </a>
+            </li>
+            <li class="ais-HierarchicalMenu-item">
+              <a class="ais-HierarchicalMenu-link">
+                <span class="ais-HierarchicalMenu-label">
+                  MacBook 15"
+                </span>
+                <span class="ais-HierarchicalMenu-count">
+                  10
+                </span>
+              </a>
+            </li>
+            <li class="ais-HierarchicalMenu-item">
+              <a class="ais-HierarchicalMenu-link">
+                <span class="ais-HierarchicalMenu-label">
+                  MacBook 12
+                </span>
+                <span class="ais-HierarchicalMenu-count">
+                  10
+                </span>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent">
+      <a class="ais-HierarchicalMenu-link">
+        <span class="ais-HierarchicalMenu-label">
+          Samsung
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          40
+        </span>
+      </a>
+      <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl1">
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              Galaxy
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              30
+            </span>
+          </a>
+        </li>
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              Note
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              10
+            </span>
+          </a>
+        </li>
+      </ul>
+    </li>
+    <li class="ais-HierarchicalMenu-item">
+      <a class="ais-HierarchicalMenu-link">
+        <span class="ais-HierarchicalMenu-label">
+          Microsoft
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          20
+        </span>
+      </a>
+    </li>
+  </ul>
+  <button disabled="disabled"
+          class="ais-HierarchicalMenu-showMore ais-HierarchicalMenu-showMore--disabled"
+  >
+    Show more
+  </button>
+</div>
+
+`;
+
+exports[`default render renders correctly with show more label toggled 1`] = `
+
+<div class="ais-HierarchicalMenu">
+  <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--lvl0">
+    <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent">
+      <a class="ais-HierarchicalMenu-link">
+        <span class="ais-HierarchicalMenu-label">
+          Apple
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          80
+        </span>
+      </a>
+      <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl1">
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              iPhone
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              20
+            </span>
+          </a>
+        </li>
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              iPad
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              20
+            </span>
+          </a>
+        </li>
+        <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              MacBook
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              40
+            </span>
+          </a>
+          <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl2">
+            <li class="ais-HierarchicalMenu-item">
+              <a class="ais-HierarchicalMenu-link">
+                <span class="ais-HierarchicalMenu-label">
+                  MacBook 13"
+                </span>
+                <span class="ais-HierarchicalMenu-count">
+                  20
+                </span>
+              </a>
+            </li>
+            <li class="ais-HierarchicalMenu-item">
+              <a class="ais-HierarchicalMenu-link">
+                <span class="ais-HierarchicalMenu-label">
+                  MacBook 15"
+                </span>
+                <span class="ais-HierarchicalMenu-count">
+                  10
+                </span>
+              </a>
+            </li>
+            <li class="ais-HierarchicalMenu-item">
+              <a class="ais-HierarchicalMenu-link">
+                <span class="ais-HierarchicalMenu-label">
+                  MacBook 12
+                </span>
+                <span class="ais-HierarchicalMenu-count">
+                  10
+                </span>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent">
+      <a class="ais-HierarchicalMenu-link">
+        <span class="ais-HierarchicalMenu-label">
+          Samsung
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          40
+        </span>
+      </a>
+      <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--child ais-HierarchicalMenu-list--lvl1">
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              Galaxy
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              30
+            </span>
+          </a>
+        </li>
+        <li class="ais-HierarchicalMenu-item">
+          <a class="ais-HierarchicalMenu-link">
+            <span class="ais-HierarchicalMenu-label">
+              Note
+            </span>
+            <span class="ais-HierarchicalMenu-count">
+              10
+            </span>
+          </a>
+        </li>
+      </ul>
+    </li>
+    <li class="ais-HierarchicalMenu-item">
+      <a class="ais-HierarchicalMenu-link">
+        <span class="ais-HierarchicalMenu-label">
+          Microsoft
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          20
+        </span>
+      </a>
+    </li>
+  </ul>
+  <button class="ais-HierarchicalMenu-showMore">
+    Show less
+  </button>
+</div>
+
+`;
+
+exports[`default render renders correctly without refinement 1`] = `
+
+<div class="ais-HierarchicalMenu ais-HierarchicalMenu--noRefinement">
+  <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--lvl0">
+  </ul>
+</div>
+
+`;

--- a/stories/Breadcrumb.stories.js
+++ b/stories/Breadcrumb.stories.js
@@ -4,108 +4,71 @@ import { previewWrapper } from './utils';
 const attributes = [
   'hierarchicalCategories.lvl0',
   'hierarchicalCategories.lvl1',
+  'hierarchicalCategories.lvl2',
 ];
-
-const hierarchicalFacets = [
-  {
-    name: 'hierarchicalCategories.lvl0',
-    attributes,
-    separator: ' > ',
-  },
-];
-
-const hierarchicalFacetsRefinements = {
-  'hierarchicalCategories.lvl0': [
-    'TV & Home Theater > Streaming Media Players',
-  ],
-};
 
 storiesOf('Breadcrumb', module)
-  .addDecorator(previewWrapper())
+  .addDecorator(
+    previewWrapper({
+      filters: `
+        <ais-hierarchical-menu
+          :attributes="[
+            'hierarchicalCategories.lvl0',
+            'hierarchicalCategories.lvl1',
+            'hierarchicalCategories.lvl2',
+          ]"
+        />
+      `,
+    })
+  )
   .add('default', () => ({
     template: `
-      <div>
-        <ais-configure
-          :hierarchicalFacets="hierarchicalFacets"
-          :hierarchicalFacetsRefinements="hierarchicalFacetsRefinements"
-        />
-
-        <ais-breadcrumb :attributes="attributes" />
-      </div>
+      <ais-breadcrumb :attributes="attributes" />
     `,
     data: () => ({
       attributes,
-      hierarchicalFacets,
-      hierarchicalFacetsRefinements,
     }),
   }))
   .add('with a custom root label', () => ({
     template: `
-      <div>
-        <ais-configure
-          :hierarchicalFacets="hierarchicalFacets"
-          :hierarchicalFacetsRefinements="hierarchicalFacetsRefinements"
-        />
-
-        <ais-breadcrumb :attributes="attributes">
-          <template slot="rootLabel">Home Page</template>
-        </ais-breadcrumb>
-      </div>
+      <ais-breadcrumb :attributes="attributes">
+        <template slot="rootLabel">Home Page</template>
+      </ais-breadcrumb>
     `,
     data: () => ({
       attributes,
-      hierarchicalFacets,
-      hierarchicalFacetsRefinements,
     }),
   }))
   .add('with a custom separator', () => ({
     template: `
-      <div>
-        <ais-configure
-          :hierarchicalFacets="hierarchicalFacets"
-          :hierarchicalFacetsRefinements="hierarchicalFacetsRefinements"
-        />
-
-        <ais-breadcrumb :attributes="attributes">
-          <template slot="separator" slot-scope="_">~</template>
-        </ais-breadcrumb>
-      </div>
+      <ais-breadcrumb :attributes="attributes">
+        <template slot="separator" slot-scope="_">~</template>
+      </ais-breadcrumb>
     `,
     data: () => ({
       attributes,
-      hierarchicalFacets,
-      hierarchicalFacetsRefinements,
     }),
   }))
   .add('with a custom render', () => ({
     template: `
-      <div>
-        <ais-configure
-          :hierarchicalFacets="hierarchicalFacets"
-          :hierarchicalFacetsRefinements="hierarchicalFacetsRefinements"
-        />
-
-        <ais-breadcrumb :attributes="attributes">
-          <ul slot-scope="{ items, refine, createURL }">
-            <li
-              v-for="(item, index) in items"
-              :key="item.name"
-              :style="{ fontWeight: index === items.length -1 ? 600 : 400 }"
+      <ais-breadcrumb :attributes="attributes">
+        <ul slot-scope="{ items, refine, createURL }">
+          <li
+            v-for="(item, index) in items"
+            :key="item.name"
+            :style="{ fontWeight: index === items.length -1 ? 600 : 400 }"
+          >
+            <a
+              :href="createURL(item.value)"
+              @click.prevent="refine(item.value)"
             >
-              <a
-                :href="createURL(item.value)"
-                @click.prevent="refine(item.value)"
-              >
-                {{ item.name }}
-              </a>
-            </li>
-          </ul>
-        </ais-breadcrumb>
-      </div>
+              {{ item.name }}
+            </a>
+          </li>
+        </ul>
+      </ais-breadcrumb>
     `,
     data: () => ({
       attributes,
-      hierarchicalFacets,
-      hierarchicalFacetsRefinements,
     }),
   }));

--- a/stories/HierarchicalMenu.stories.js
+++ b/stories/HierarchicalMenu.stories.js
@@ -4,13 +4,6 @@ import { previewWrapper } from './utils';
 storiesOf('HierarchicalMenu', module)
   .addDecorator(previewWrapper())
   .add('default', () => ({
-    template: `<ais-hierarchical-menu :attributes="[
-        'hierarchicalCategories.lvl0',
-        'hierarchicalCategories.lvl1',
-        'hierarchicalCategories.lvl2',
-      ]"></ais-hierarchical-menu>`,
-  }))
-  .add('not showing the parent level', () => ({
     template: `
       <ais-hierarchical-menu
         :attributes="[
@@ -18,20 +11,104 @@ storiesOf('HierarchicalMenu', module)
           'hierarchicalCategories.lvl1',
           'hierarchicalCategories.lvl2',
         ]"
-        :showParentLevel="false"
-      >
-      </ais-hierarchical-menu>`,
+      />
+    `,
   }))
-  .add('custom rendering', () => ({
-    template: `<ais-hierarchical-menu
-      :attributes="[
-        'hierarchicalCategories.lvl0',
-        'hierarchicalCategories.lvl1',
-        'hierarchicalCategories.lvl2',
-      ]"
-    >
-      <template slot-scope="{items}">
-        <pre>{{items}}</pre>
-      </template>
-    </ais-hierarchical-menu>`,
+  .add('with show more', () => ({
+    template: `
+      <ais-hierarchical-menu
+        :attributes="[
+          'hierarchicalCategories.lvl0',
+          'hierarchicalCategories.lvl1',
+          'hierarchicalCategories.lvl2',
+        ]"
+        :limit="2"
+        :show-more-limit="5"
+        :show-more="true"
+      />
+    `,
+  }))
+  .add('with a custom label', () => ({
+    template: `
+      <ais-hierarchical-menu
+        :attributes="[
+          'hierarchicalCategories.lvl0',
+          'hierarchicalCategories.lvl1',
+          'hierarchicalCategories.lvl2',
+        ]"
+        :limit="2"
+        :show-more-limit="5"
+        :showMore="true"
+      >
+        <template slot="showMoreLabel" slot-scope="{ isShowingMore }">
+          {{ isShowingMore ? 'View less' : 'View more' }}
+        </template>
+      </ais-hierarchical-menu>
+    `,
+  }))
+  .add('with a different sort', () => ({
+    template: `
+      <ais-hierarchical-menu
+        :attributes="[
+          'hierarchicalCategories.lvl0',
+          'hierarchicalCategories.lvl1',
+          'hierarchicalCategories.lvl2',
+        ]"
+        :sort-by="['isRefined:desc', 'name:asc']"
+      />
+    `,
+  }))
+  .add('with a custom render', () => ({
+    template: `
+      <ais-hierarchical-menu
+        :attributes="[
+          'hierarchicalCategories.lvl0',
+          'hierarchicalCategories.lvl1',
+          'hierarchicalCategories.lvl2',
+        ]"
+      >
+        <ol slot-scope="{ items, refine, createURL }">
+          <li
+            v-for="item in items"
+            :key="item.value"
+            :style="{ fontWeight: item.isRefined ? 600 : 400 }"
+          >
+            <a
+              :href="createURL(item.value)"
+              @click.prevent="refine(item.value)"
+            >
+              {{item.label}} - {{item.count}}
+            </a>
+            <ol v-if="item.data">
+              <li
+                v-for="child in item.data"
+                :key="child.value"
+                :style="{ fontWeight: child.isRefined ? 600 : 400 }"
+              >
+                <a
+                  :href="createURL(child.value)"
+                  @click.prevent="refine(child.value)"
+                >
+                  {{child.label}} - {{child.count}}
+                </a>
+                <ol v-if="child.data">
+                  <li
+                    v-for="subchild in child.data"
+                    :key="subchild.value"
+                    :style="{ fontWeight: subchild.isRefined ? 600 : 400 }"
+                  >
+                    <a
+                      :href="createURL(subchild.value)"
+                      @click.prevent="refine(subchild.value)"
+                    >
+                      {{subchild.label}} - {{subchild.count}}
+                    </a>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </ais-hierarchical-menu>
+    `,
   }));

--- a/stories/utils.js
+++ b/stories/utils.js
@@ -22,6 +22,10 @@ export const previewWrapper = ({
       </li>
     </ol>
   `,
+  filters = `
+    <!-- @TODO: replace with a RefinementList  -->
+    <ais-menu attribute="brand" />
+  `,
 } = {}) => () => ({
   template: `
     <ais-index
@@ -36,8 +40,7 @@ export const previewWrapper = ({
 
       <div class="container container-playground">
         <div class="panel-left">
-          <!-- @TODO: replace with a RefinementList  -->
-          <ais-menu attribute="brand" />
+          ${filters}
         </div>
         <div class="panel-right">
           <ais-search-box />

--- a/yarn.lock
+++ b/yarn.lock
@@ -262,6 +262,14 @@
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.3.0.tgz#3a129cda7c4e5df2409702626892cb4b96546dd5"
 
+"@types/strip-bom@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/strip-bom/-/strip-bom-3.0.0.tgz#14a8ec3956c2e81edb7520790aecf21c290aebd2"
+
+"@types/strip-json-comments@0.0.30":
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
+
 "@vue/test-utils@^1.0.0-beta.24":
   version "1.0.0-beta.24"
   resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-1.0.0-beta.24.tgz#da7c3165f49f57f23fdb98caccba0f511effb76f"
@@ -1316,6 +1324,15 @@ babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
     babel-template "^6.24.1"
     babel-types "^6.24.1"
 
+babel-plugin-transform-es2015-modules-commonjs@^6.26.0:
+  version "6.26.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz#58a793863a9e7ca870bdc5a881117ffac27db6f3"
+  dependencies:
+    babel-plugin-transform-strict-mode "^6.24.1"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-types "^6.26.0"
+
 babel-plugin-transform-es2015-modules-systemjs@^6.23.0, babel-plugin-transform-es2015-modules-systemjs@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz#ff89a142b9119a906195f5f106ecf305d9407d23"
@@ -1781,7 +1798,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.1.1, bluebird@^3.4.7, bluebird@^3.5.1:
+bluebird@^3.0.5, bluebird@^3.1.1, bluebird@^3.4.7, bluebird@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
@@ -2298,6 +2315,10 @@ cliui@^4.0.0:
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
+clone@2.x:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+
 clone@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.2.tgz#260b7a99ebb1edfe247538175f783243cb19d149"
@@ -2455,6 +2476,13 @@ concurrently@^3.6.1:
     spawn-command "^0.0.2-1"
     supports-color "^3.2.3"
     tree-kill "^1.1.0"
+
+config-chain@~1.1.5:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.11.tgz#aba09747dfbe4c3e70e766a6e41586e1859fc6f2"
+  dependencies:
+    ini "^1.3.4"
+    proto-list "~1.2.1"
 
 console-browserify@^1.1.0:
   version "1.1.0"
@@ -2842,6 +2870,15 @@ css-selector-tokenizer@^0.7.0:
 css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
+
+css@^2.1.0:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.3.tgz#f861f4ba61e79bedc962aa548e5780fd95cbc6be"
+  dependencies:
+    inherits "^2.0.1"
+    source-map "^0.1.38"
+    source-map-resolve "^0.5.1"
+    urix "^0.1.0"
 
 cssesc@^0.1.0:
   version "0.1.0"
@@ -3234,6 +3271,16 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+editorconfig@^0.13.2:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.13.3.tgz#e5219e587951d60958fd94ea9a9a008cdeff1b34"
+  dependencies:
+    bluebird "^3.0.5"
+    commander "^2.9.0"
+    lru-cache "^3.2.0"
+    semver "^5.1.0"
+    sigmund "^1.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -3803,6 +3850,12 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+extract-from-css@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/extract-from-css/-/extract-from-css-0.4.4.tgz#1ea7df2e7c7c6eb9922fa08e8adaea486f6f8f92"
+  dependencies:
+    css "^2.1.0"
+
 extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
@@ -3925,7 +3978,7 @@ finalhandler@1.1.1:
     statuses "~1.4.0"
     unpipe "~1.0.0"
 
-find-babel-config@1.1.0:
+find-babel-config@1.1.0, find-babel-config@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.1.0.tgz#acc01043a6749fec34429be6b64f542ebb5d6355"
   dependencies:
@@ -5568,6 +5621,15 @@ js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
 
+js-beautify@^1.6.14:
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.7.5.tgz#69d9651ef60dbb649f65527b53674950138a7919"
+  dependencies:
+    config-chain "~1.1.5"
+    editorconfig "^0.13.2"
+    mkdirp "~0.5.0"
+    nopt "~3.0.1"
+
 js-stringify@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/js-stringify/-/js-stringify-1.0.2.tgz#1736fddfd9724f28a3682adc6230ae7e4e9679db"
@@ -5956,6 +6018,10 @@ lodash@4.17.5, lodash@^4.13.1:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
+lodash@4.x, lodash@^4.17.10, lodash@^4.17.5:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
 lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
@@ -5963,10 +6029,6 @@ lodash@^3.10.1:
 lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1, lodash@~4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-
-lodash@^4.17.10, lodash@^4.17.5:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -5992,6 +6054,12 @@ lower-case@^1.1.1:
 lru-cache@2:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
+
+lru-cache@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-3.2.0.tgz#71789b3b7f5399bec8565dda38aa30d2a097efee"
+  dependencies:
+    pseudomap "^1.0.1"
 
 lru-cache@^4.0.1:
   version "4.0.2"
@@ -6381,6 +6449,13 @@ no-case@^2.2.0:
   dependencies:
     lower-case "^1.1.1"
 
+node-cache@^4.1.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-4.2.0.tgz#48ac796a874e762582692004a376d26dfa875811"
+  dependencies:
+    clone "2.x"
+    lodash "4.x"
+
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -6512,7 +6587,7 @@ nopt@1.0.10:
   dependencies:
     abbrev "1"
 
-"nopt@2 || 3":
+"nopt@2 || 3", nopt@~3.0.1:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
   dependencies:
@@ -7456,6 +7531,10 @@ prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.9, prop-types@^15.6.0:
     fbjs "^0.8.16"
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+proto-list@~1.2.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
 
 proxy-addr@~2.0.3:
   version "2.0.3"
@@ -8653,7 +8732,7 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
 
-sigmund@~1.0.0:
+sigmund@^1.0.1, sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
 
@@ -8735,7 +8814,7 @@ source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
 
-source-map-resolve@^0.5.0:
+source-map-resolve@^0.5.0, source-map-resolve@^0.5.1:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
   dependencies:
@@ -8762,7 +8841,7 @@ source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
-source-map@0.1.x:
+source-map@0.1.x, source-map@^0.1.38:
   version "0.1.43"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
   dependencies:
@@ -9016,7 +9095,7 @@ strip-indent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
-strip-json-comments@~2.0.1:
+strip-json-comments@^2.0.0, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
@@ -9273,6 +9352,15 @@ trim-right@^1.0.1:
 tryit@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb"
+
+tsconfig@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/tsconfig/-/tsconfig-7.0.0.tgz#84538875a4dc216e5c4a5432b3a4dec3d54e91b7"
+  dependencies:
+    "@types/strip-bom" "^3.0.0"
+    "@types/strip-json-comments" "0.0.30"
+    strip-bom "^3.0.0"
+    strip-json-comments "^2.0.0"
 
 tty-browserify@0.0.0:
   version "0.0.0"
@@ -9587,6 +9675,21 @@ vue-class-component@^6.0.0:
 vue-hot-reload-api@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.0.tgz#97976142405d13d8efae154749e88c4e358cf926"
+
+vue-jest@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/vue-jest/-/vue-jest-2.6.0.tgz#23dc99a4dce0bb59fea3946e1317b234968cf12a"
+  dependencies:
+    babel-plugin-transform-es2015-modules-commonjs "^6.26.0"
+    chalk "^2.1.0"
+    extract-from-css "^0.4.4"
+    find-babel-config "^1.1.0"
+    js-beautify "^1.6.14"
+    node-cache "^4.1.1"
+    object-assign "^4.1.1"
+    source-map "^0.5.6"
+    tsconfig "^7.0.0"
+    vue-template-es2015-compiler "^1.6.0"
 
 vue-json-tree@^0.3.3:
   version "0.3.3"


### PR DESCRIPTION
**Summary**

This PR implements the `HierarchicalMenu` widget. The PR also adds the ability to override the filters section of the preview wrapper from the stories. I've updated the `Breadcrumb` stories to use a `HierarchicalMenu` rather than the `Configure` widget.

I've also updated the Jest plugin that preprocess the Vue files from [Jest Vue Preprocessor](https://github.com/vire/jest-vue-preprocessor) to [Vue Jest](https://github.com/vuejs/vue-jest). The latter has a better support for functional components (it's the official plugin for Jest).

![screen shot 2018-08-20 at 16 10 45](https://user-images.githubusercontent.com/6513513/44345429-a0d10200-a493-11e8-916b-bfd53c88fd32.png)

You can use the widget on [Storybook](https://deploy-preview-494--vue-instantsearch.netlify.com/stories/?selectedKind=HierarchicalMenu).