### PR TITLE
feat: allow search box to be controlled -> multi query!

### DIFF
--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -89,13 +89,13 @@ export default {
           this.$emit('input', this.value);
           this.state.refine(this.value);
         }
-        return this.value || this.localValue;
+        return this.value || this.localValue || this.state.query || '';
       },
       set(val) {
         this.localValue = val;
+        this.state.refine(val);
         if (this.isControlled) {
           this.$emit('input', val);
-          this.state.refine(val);
         }
       },
     },

--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -52,6 +52,14 @@ export default {
       type: String,
       default: 'Clear',
     },
+    value: {
+      type: String,
+      default: undefined,
+    },
+    name: {
+      // @TODO: just for debugging, remove IRL
+      type: String,
+    },
   },
   data() {
     return {
@@ -73,11 +81,32 @@ export default {
   computed: {
     currentRefinement: {
       get() {
-        return  this.state.query || '';
+        const isControlled = typeof this.value !== 'undefined';
+        console.log('get', this.name, {
+          model: this.value,
+          query: this.state.query,
+          isControlled
+        });
+
+        if (isControlled && this.state.query !== this.value) {
+          // works but infinite loop
+          this.state.refine(this.value);
+        }
+        return this.value || this.state.query || '';
       },
       set(value) {
-        this.$emit('input', value);
-        this.state.refine(value);
+        const isControlled = typeof this.value !== 'undefined';
+        console.log('set', this.name, {
+          value,
+          query: this.state.query,
+          model: this.value,
+          isControlled
+        });
+
+        if ((isControlled && this.value !== value) || !isControlled) {
+          this.$emit('input', value);
+          this.state.refine(value);
+        }
       },
     },
   },

--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -52,13 +52,9 @@ export default {
       type: String,
       default: 'Clear',
     },
-    value: {
-      type: String,
-    }
   },
   data() {
     return {
-      _value: this.value,
       widgetName: 'SearchBox',
     };
   },
@@ -77,14 +73,11 @@ export default {
   computed: {
     currentRefinement: {
       get() {
-        console.log('get')
-        return this._value || this.state.query || '';
+        return  this.state.query || '';
       },
       set(value) {
-        console.log("set", value)
-        this._value = value;
-        this.state.refine(value);
         this.$emit('input', value);
+        this.state.refine(value);
       },
     },
   },

--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -56,13 +56,10 @@ export default {
       type: String,
       default: undefined,
     },
-    name: {
-      // @TODO: just for debugging, remove IRL
-      type: String,
-    },
   },
   data() {
     return {
+      localValue: '',
       widgetName: 'SearchBox',
     };
   },
@@ -79,33 +76,26 @@ export default {
     },
   },
   computed: {
+    isControlled() {
+      return typeof this.value !== 'undefined';
+    },
     currentRefinement: {
       get() {
-        const isControlled = typeof this.value !== 'undefined';
-        console.log('get', this.name, {
-          model: this.value,
-          query: this.state.query,
-          isControlled
-        });
-
-        if (isControlled && this.state.query !== this.value) {
-          // works but infinite loop
+        // if the input is controlled, but not up to date
+        // this means it didn't search, and we should pretend it was `set`
+        if (this.isControlled && this.value !== this.localValue) {
+          // eslint-disable-next-line vue/no-side-effects-in-computed-properties
+          this.localValue = this.value;
+          this.$emit('input', this.value);
           this.state.refine(this.value);
         }
-        return this.value || this.state.query || '';
+        return this.value || this.localValue;
       },
-      set(value) {
-        const isControlled = typeof this.value !== 'undefined';
-        console.log('set', this.name, {
-          value,
-          query: this.state.query,
-          model: this.value,
-          isControlled
-        });
-
-        if ((isControlled && this.value !== value) || !isControlled) {
-          this.$emit('input', value);
-          this.state.refine(value);
+      set(val) {
+        this.localValue = val;
+        if (this.isControlled) {
+          this.$emit('input', val);
+          this.state.refine(val);
         }
       },
     },

--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -52,9 +52,13 @@ export default {
       type: String,
       default: 'Clear',
     },
+    value: {
+      type: String,
+    }
   },
   data() {
     return {
+      _value: this.value,
       widgetName: 'SearchBox',
     };
   },
@@ -73,10 +77,14 @@ export default {
   computed: {
     currentRefinement: {
       get() {
-        return this.state.query || '';
+        console.log('get')
+        return this._value || this.state.query || '';
       },
       set(value) {
+        console.log("set", value)
+        this._value = value;
         this.state.refine(value);
+        this.$emit('input', value);
       },
     },
   },

--- a/stories/MultiIndex.stories.js
+++ b/stories/MultiIndex.stories.js
@@ -5,7 +5,7 @@ storiesOf('MultiIndex', module).add('simple usage', () => ({
   template: `
   <div>
     <ais-index :search-client="searchClient" index-name="ikea">
-      <ais-search-box @input="setOtherOne"/>
+      <ais-search-box v-model="query" name="one"/>
       <ais-configure :restrictSearchableAttributes="['name']"/>
       <ais-hits>
         <template slot="item" slot-scope="{ item }">
@@ -15,11 +15,7 @@ storiesOf('MultiIndex', module).add('simple usage', () => ({
     </ais-index>
     <hr />
     <ais-index :search-client="searchClient" index-name="instant_search">
-      <ais-search-box>
-        <template slot="default" slot-scope="{ refine }">
-          <!-- idk how ot use refine here -->
-        </template>
-      </ais-search-box>
+      <ais-search-box v-model="query" name="two"/>
       <ais-configure :restrictSearchableAttributes="['name']"/>
       <ais-hits>
         <template slot="item" slot-scope="{ item }">
@@ -31,6 +27,7 @@ storiesOf('MultiIndex', module).add('simple usage', () => ({
   `,
   data() {
     return {
+      query: '',
       searchClient: algoliasearch(
         'latency',
         '6be0576ff61c053d5f9a3225e2a90f76'

--- a/stories/MultiIndex.stories.js
+++ b/stories/MultiIndex.stories.js
@@ -30,7 +30,11 @@ storiesOf('MultiIndex', module).add('simple usage', () => ({
       query: '',
       searchClient: algoliasearch(
         'latency',
-        '6be0576ff61c053d5f9a3225e2a90f76'
+        '6be0576ff61c053d5f9a3225e2a90f76',
+        {
+          // this is necessary, because we call the same refine 2 times?
+          _useRequestCache: true,
+        }
       ),
     };
   },

--- a/stories/MultiIndex.stories.js
+++ b/stories/MultiIndex.stories.js
@@ -5,7 +5,7 @@ storiesOf('MultiIndex', module).add('simple usage', () => ({
   template: `
   <div>
     <ais-index :search-client="searchClient" index-name="ikea">
-      <ais-search-box v-model="query"/>
+      <ais-search-box @input="setOtherOne"/>
       <ais-configure :restrictSearchableAttributes="['name']"/>
       <ais-hits>
         <template slot="item" slot-scope="{ item }">
@@ -15,7 +15,11 @@ storiesOf('MultiIndex', module).add('simple usage', () => ({
     </ais-index>
     <hr />
     <ais-index :search-client="searchClient" index-name="instant_search">
-      <ais-search-box v-model="query" />
+      <ais-search-box>
+        <template slot="default" slot-scope="{ refine }">
+          <!-- idk how ot use refine here -->
+        </template>
+      </ais-search-box>
       <ais-configure :restrictSearchableAttributes="['name']"/>
       <ais-hits>
         <template slot="item" slot-scope="{ item }">
@@ -27,7 +31,6 @@ storiesOf('MultiIndex', module).add('simple usage', () => ({
   `,
   data() {
     return {
-      query: '',
       searchClient: algoliasearch(
         'latency',
         '6be0576ff61c053d5f9a3225e2a90f76'

--- a/stories/MultiIndex.stories.js
+++ b/stories/MultiIndex.stories.js
@@ -1,0 +1,37 @@
+import { storiesOf } from '@storybook/vue';
+import algoliasearch from 'algoliasearch';
+
+storiesOf('MultiIndex', module).add('simple usage', () => ({
+  template: `
+  <div>
+    <ais-index :search-client="searchClient" index-name="ikea">
+      <ais-search-box v-model="query"/>
+      <ais-configure :restrictSearchableAttributes="['name']"/>
+      <ais-hits>
+        <template slot="item" slot-scope="{ item }">
+          <h3><ais-highlight :hit="item" attribute="name"/></h3>
+        </template>
+      </ais-hits>
+    </ais-index>
+    <hr />
+    <ais-index :search-client="searchClient" index-name="instant_search">
+      <ais-search-box v-model="query" />
+      <ais-configure :restrictSearchableAttributes="['name']"/>
+      <ais-hits>
+        <template slot="item" slot-scope="{ item }">
+          <h3><ais-highlight :hit="item" attribute="name"/></h3>
+        </template>
+      </ais-hits>
+    </ais-index>
+  </div>
+  `,
+  data() {
+    return {
+      query: '',
+      searchClient: algoliasearch(
+        'latency',
+        '6be0576ff61c053d5f9a3225e2a90f76'
+      ),
+    };
+  },
+}));

--- a/stories/MultiIndex.stories.js
+++ b/stories/MultiIndex.stories.js
@@ -5,7 +5,7 @@ storiesOf('MultiIndex', module).add('simple usage', () => ({
   template: `
   <div>
     <ais-index :search-client="searchClient" index-name="ikea">
-      <ais-search-box v-model="query" name="one"/>
+      <ais-search-box v-model="query"/>
       <ais-configure :restrictSearchableAttributes="['name']"/>
       <ais-hits>
         <template slot="item" slot-scope="{ item }">
@@ -15,7 +15,7 @@ storiesOf('MultiIndex', module).add('simple usage', () => ({
     </ais-index>
     <hr />
     <ais-index :search-client="searchClient" index-name="instant_search">
-      <ais-search-box v-model="query" name="two"/>
+      <ais-search-box v-model="query" hidden/>
       <ais-configure :restrictSearchableAttributes="['name']"/>
       <ais-hits>
         <template slot="item" slot-scope="{ item }">


### PR DESCRIPTION
We allow the search box to be controlled via v-model. If you do that, you can sync between multiple search boxes across multiple indices

There's still an issue that this does 2n requests (not sure why, but at least it works). This would be caught by the newer request cache (not enabled by default)