### PR TITLE
docs(https): fix https mixed content

### DIFF
--- a/docs/src/data/communityHeader.json
+++ b/docs/src/data/communityHeader.json
@@ -9,7 +9,7 @@
       {
         "name": "InstantSearch.js",
         "url": "https://community.algolia.com/instantsearch.js/v2",
-        "logo": "http://res.cloudinary.com/hilnmyskv/image/upload/v1500619122/instantsearch-icon_black.svg",
+        "logo": "https://res.cloudinary.com/hilnmyskv/image/upload/v1500619122/instantsearch-icon_black.svg",
         "backgroundColor": "#fecf50"
       },
       {
@@ -21,7 +21,7 @@
       {
         "name": "Android InstantSearch",
         "url": "https://community.algolia.com/instantsearch-android/",
-        "logo": "http://res.cloudinary.com/hilnmyskv/image/upload/v1500619122/instantsearch-icon_white.svg",
+        "logo": "https://res.cloudinary.com/hilnmyskv/image/upload/v1500619122/instantsearch-icon_white.svg",
         "backgroundColor": "linear-gradient(112deg, #21c7d0, #2dde98)"
       },
       {


### PR DESCRIPTION
I get a lot of emails from Netlify about this:

![image](https://user-images.githubusercontent.com/123822/45268290-0ce2cc80-b47a-11e8-95c5-ad692396d31d.png)

Worth checking other *-instantsearch websites for this:
![image](https://user-images.githubusercontent.com/123822/45268294-1c621580-b47a-11e8-9015-626c4fd8b4d2.png)
