### PR TITLE
docs(range-input): add two slider examples

### DIFF
--- a/.storybook/styles.css
+++ b/.storybook/styles.css
@@ -102,3 +102,8 @@ body {
 .autosuggest__results_item-highlighted {
   background-color: rgb(206, 202, 202);
 }
+
+/* vuetify v-app */
+.application--wrap {
+  min-height: unset !important;
+}

--- a/package.json
+++ b/package.json
@@ -87,7 +87,9 @@
     "vue-jest": "2.6.0",
     "vue-json-tree": "0.3.3",
     "vue-loader": "14.2.2",
-    "vue-template-compiler": "2.5.17"
+    "vue-slider-component": "^2.7.7",
+    "vue-template-compiler": "2.5.17",
+    "vuetify": "^1.2.4"
   },
   "jest": {
     "setupFiles": [

--- a/stories/RangeInput.stories.js
+++ b/stories/RangeInput.stories.js
@@ -1,6 +1,13 @@
 import { storiesOf } from '@storybook/vue';
 import { previewWrapper } from './utils';
 
+import VueSlider from 'vue-slider-component';
+
+import Vuetify from 'vuetify';
+import 'vuetify/dist/vuetify.css';
+import Vue from 'vue';
+Vue.use(Vuetify);
+
 storiesOf('RangeInput', module)
   .addDecorator(previewWrapper())
   .add('default', () => ({
@@ -63,6 +70,61 @@ storiesOf('RangeInput', module)
         max: undefined,
       };
     },
+  }))
+  .add('with vue-slider-component', () => ({
+    template: `
+      <ais-range-input attribute="price">
+        <template slot-scope="{ refine, currentRefinements, range }">
+          <vue-slider
+            :min="range.min"
+            :max="range.max"
+            :value="toValue(currentRefinements, range)"
+            @input="refine($event[0], $event[1])"
+          />
+        </template>
+      </ais-range-input>
+    `,
+    methods: {
+      toValue([min, max], range) {
+        return [
+          min === -Infinity ? range.min : min,
+          max === Infinity ? range.max : max,
+        ];
+      },
+    },
+    components: { VueSlider },
+  }))
+  .add('with vuetify slider', () => ({
+    template: `
+      <v-app>
+        <ais-range-input attribute="price">
+          <template slot-scope="{ refine, currentRefinements, range }">
+            <v-range-slider
+              :min="range.min"
+              :max="range.max"
+              :value="toValue(currentRefinements, range)"
+              @input="refine($event[0], $event[1])"
+            />
+          </template>
+        </ais-range-input>
+      </v-app>
+    `,
+    data() {
+      return {
+        price: [5, 20],
+      };
+    },
+    methods: {
+      toValue([min, max], range) {
+        return [
+          min === -Infinity ? range.min : min,
+          max === Infinity ? range.max : max,
+        ];
+      },
+    },
+    // components: {
+    //   VRangeSlider,
+    // },
   }))
   .add('with a Panel', () => ({
     template: `

--- a/yarn.lock
+++ b/yarn.lock
@@ -10217,6 +10217,10 @@ vue-property-decorator@6.0.0:
     reflect-metadata "^0.1.10"
     vue-class-component "^6.0.0"
 
+vue-slider-component@^2.7.7:
+  version "2.7.7"
+  resolved "https://registry.yarnpkg.com/vue-slider-component/-/vue-slider-component-2.7.7.tgz#dba63bb4b0cf9c80a06b1e6bf5103390d10404c6"
+
 vue-style-loader@^4.0.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/vue-style-loader/-/vue-style-loader-4.1.2.tgz#dedf349806f25ceb4e64f3ad7c0a44fba735fcf8"
@@ -10244,6 +10248,10 @@ vue-template-validator@^1.1.5:
 vue@2.5.17:
   version "2.5.17"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.17.tgz#0f8789ad718be68ca1872629832ed533589c6ada"
+
+vuetify@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-1.2.4.tgz#b03a634791b1627e7aab89ed4651a5cd1ea2f211"
 
 walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
adds two examples: vuetify and vue-slider-component

Both aren't really that great, but they definitely work. For both I had to patch the currentRefinement not to be -Infinity and Infinity. Maybe that's something that should be done in the connector or render method instead? 

