### PR TITLE
chore(release): allow prerelease

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,7 +28,7 @@ The project uses [conventional commit format](https://github.com/angular/angular
 To release the library, the first step is to create a "release PR" by running:
 
 ```bash
-bin/release-branch.sh
+yarn release:branch
 ```
 
 This will ask you the new version of the library, and update all the required files accordingly.
@@ -42,13 +42,13 @@ Once the changes are approved you can merge it there.
 You can now fetch the latest changes from the remote master branch and run:
 
 ```bash
-bin/publish.sh
+yarn release:publish
 ```
 
 This will:
 
-* publish the new version on NPM
-* tag and push the tag to GitHub
+- publish the new version on NPM
+- tag and push the tag to GitHub
 
 ## Documentation
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "lint:fix": "eslint --ext .js,.vue . --fix",
     "format": "prettier --write '**/*.{js,md,vue,css}'",
     "changelog": "conventional-changelog --preset angular --infile CHANGELOG.md --same-file",
-    "changelog:unreleased": "conventional-changelog --preset angular --output-unreleased"
+    "changelog:unreleased": "conventional-changelog --preset angular --output-unreleased",
+    "release:branch": "scripts/release-branch.sh",
+    "release:publish": "scripts/release-publish.sh"
   },
   "dependencies": {
     "algoliasearch": "^3.30.0",

--- a/scripts/get-npm-tag.js
+++ b/scripts/get-npm-tag.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+/* eslint-disable import/no-commonjs */
+/* eslint-disable no-console */
+const { version } = require('../package.json');
+
+const getReleaseTag = _version => {
+  const [match = 'latest'] = _version.match(/[a-z]+/) || [];
+  return match;
+};
+
+// give this on to the main script
+console.log(getReleaseTag(version));

--- a/scripts/get-npm-tag.js
+++ b/scripts/get-npm-tag.js
@@ -8,5 +8,4 @@ const getReleaseTag = _version => {
   return match;
 };
 
-// give this on to the main script
-console.log(getReleaseTag(version));
+process.stdout.write(getReleaseTag(version));

--- a/scripts/get-version.js
+++ b/scripts/get-version.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+/* eslint-disable import/no-commonjs */
+/* eslint-disable no-console */
+const { version } = require('../package.json');
+
+// give this on to the main script
+console.log(version);

--- a/scripts/get-version.js
+++ b/scripts/get-version.js
@@ -3,5 +3,4 @@
 /* eslint-disable no-console */
 const { version } = require('../package.json');
 
-// give this on to the main script
-console.log(version);
+process.stdout.write(version);

--- a/scripts/release-branch.sh
+++ b/scripts/release-branch.sh
@@ -4,8 +4,12 @@ set -eu
 
 readonly CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [ "$CURRENT_BRANCH" != master ]; then
-  echo "You must be on 'master' branch to release, aborting..."
-  exit 1
+  read -n 1 -p "WARNING! You are not currently on the master branch. Are you sure you want to continue? [Y/n]" reply
+  echo ""
+  if [ "$reply" == "n" ]; then
+    echo "Aborting..."
+    exit 1
+  fi
 fi
 
 if ! git diff-index --quiet HEAD --; then

--- a/scripts/release-branch.sh
+++ b/scripts/release-branch.sh
@@ -35,7 +35,7 @@ if ! yarn run changelog; then
   exit 1
 fi
 
-readonly PACKAGE_VERSION=$(bin/get-version.js)
+readonly PACKAGE_VERSION=$(scripts/get-version.js)
 
 git checkout -b "chore/release-$PACKAGE_VERSION"
 

--- a/scripts/release-branch.sh
+++ b/scripts/release-branch.sh
@@ -35,11 +35,7 @@ if ! yarn run changelog; then
   exit 1
 fi
 
-readonly PACKAGE_VERSION=$(< package.json grep version \
-  | head -1 \
-  | awk -F: '{ print $2 }' \
-  | sed 's/[",]//g' \
-  | tr -d '[:space:]')
+readonly PACKAGE_VERSION=$(bin/get-version.js)
 
 git checkout -b "chore/release-$PACKAGE_VERSION"
 

--- a/scripts/release-publish.sh
+++ b/scripts/release-publish.sh
@@ -23,13 +23,9 @@ if ! yarn run test; then
   exit 1
 fi
 
-readonly PACKAGE_VERSION=$(< package.json grep version \
-  | head -1 \
-  | awk -F: '{ print $2 }' \
-  | sed 's/[",]//g' \
-  | tr -d '[:space:]')
+readonly PACKAGE_VERSION=$(bin/get-version.js)
 
-npm publish
+npm publish --tag=$(bin/get-npm-tag.js)
 
 git tag "v$PACKAGE_VERSION"
 

--- a/scripts/release-publish.sh
+++ b/scripts/release-publish.sh
@@ -23,9 +23,9 @@ if ! yarn run test; then
   exit 1
 fi
 
-readonly PACKAGE_VERSION=$(bin/get-version.js)
+readonly PACKAGE_VERSION=$(scripts/get-version.js)
 
-npm publish --tag=$(bin/get-npm-tag.js)
+npm publish --tag=$(scripts/get-npm-tag.js)
 
 git tag "v$PACKAGE_VERSION"
 


### PR DESCRIPTION
The flow didn't change, except that now you can give a prerelease-style version and it will release on the right npm tag