### PR TITLE
feat(CurrentRefinements): consolidate API

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -18,6 +18,7 @@ import './styles.css';
 import Vue from 'vue';
 import InstantSearch from '../src/instantsearch';
 
+Vue.config.productionTip = false;
 Vue.use(InstantSearch);
 
 const req = require.context('../stories', true, /\.stories\.js$/);

--- a/.storybook/styles.css
+++ b/.storybook/styles.css
@@ -114,3 +114,15 @@ input {
   border-color: #c4c8d8;
   border-radius: 5px !important;
 }
+
+button {
+  border-style: solid !important;
+  border-width: 1px;
+  padding: 0.2em;
+  border-color: black;
+  border-radius: 5px !important;
+}
+
+button:disabled {
+  border-color: #c4c8d8;
+}

--- a/docs/src/components/ClearRefinements.md
+++ b/docs/src/components/ClearRefinements.md
@@ -16,15 +16,16 @@ A button that clears the `query`, the `active refinements`, or both when pressed
 ## Usage
 
 ```html
-<ais-clear-refinements />
+<ais-clear-refinements
+  :excluded-attributes="['categories']"
+/>
 ```
 
 ## Props
 
 Name | Type | Default | Description | Required
 ---|---|---|---|---
-clearsQuery | `boolean` | `false` | Also clears the query | no
-excludedAttributes | `string[]` | `[]` | Attributes not to clear | no
+excludedAttributes | `string[]` | `["query"]` | Attributes not to clear | no
 classNames | Object | | Override class names | no
 
 ## Slots

--- a/docs/src/components/ClearRefinements.md
+++ b/docs/src/components/ClearRefinements.md
@@ -25,7 +25,7 @@ A button that clears the `query`, the `active refinements`, or both when pressed
 
 Name | Type | Default | Description | Required
 ---|---|---|---|---
-excludedAttributes | `string[]` | `["query"]` | Attributes not to clear | no
+excludedAttributes | `string[]` | `['query']` | Attributes not to clear | no
 classNames | Object | | Override class names | no
 
 ## Slots

--- a/docs/src/components/CurrentRefinements.md
+++ b/docs/src/components/CurrentRefinements.md
@@ -56,12 +56,12 @@ name | scope | Description
 `default` | `{ items: Item[], refine: Item => void }` | Override how all the items look
 `item` | `{ item: Item, refine: Item => void }` | Override how an item looks
 
-an Item has the keys:
+All elements in `items` have the keys:
 
-* "type": which can be "facet", "exclude", "disjunctive", "hierarchical", "numeric" or "query"
-* "attribute": used as the key
-* "label": string form of the value
-* "value": necessary for the refinement to work correctly, no need to be changed
+* `type`: which can be "facet", "exclude", "disjunctive", "hierarchical", "numeric" or "query"
+* `attribute`: used as the key
+* `label`: string form of the value
+* `value`: necessary for the refinement to work correctly, no need to be changed
 
 ## CSS classes
 

--- a/docs/src/components/CurrentRefinements.md
+++ b/docs/src/components/CurrentRefinements.md
@@ -20,7 +20,7 @@ Show the currently refined values and allow them to be unset.
   <ais-current-refinements
     :excluded-attributes="[]"
     :transform-items="transformItems"
-  ></ais-current-refinements>
+  />
 </template>
 
 <script>

--- a/docs/src/components/CurrentRefinements.md
+++ b/docs/src/components/CurrentRefinements.md
@@ -22,6 +22,7 @@ Show the currently refined values and allow them to be unset.
     :transform-items="transformItems"
   ></ais-current-refinements>
 </template>
+
 <script>
 export default {
   data() {

--- a/docs/src/components/CurrentRefinements.md
+++ b/docs/src/components/CurrentRefinements.md
@@ -28,10 +28,10 @@ export default {
   data() {
     return {
       transformItems: items =>
-        items.map(item => {
-          item.label = item.label.toLocaleUpperCase();
-          return item;
-        })
+        items.map(item => ({
+          ...label,
+          label: item.label.toLocaleUpperCase()
+        }))
     };
   }
 };

--- a/docs/src/components/CurrentRefinements.md
+++ b/docs/src/components/CurrentRefinements.md
@@ -42,7 +42,7 @@ export default {
 Name | Type | Default | Description | Required
 ---|---|---|---|---
 includedAttributes | Array | | Attributes to show or clear | -
-excludedAttributes | Array | `["query"]` | Attributes not to show or clear | -
+excludedAttributes | Array | `['query']` | Attributes not to show or clear | -
 transformItems | `(items: object[]) => object[]` | `x => x` | Function which receives the items, which will be called before displaying them. Should return a new array with the same shape as the original array. Useful for mapping over the items to transform, remove or reorder them | -
 classNames | Object | | Override class names | no
 

--- a/docs/src/components/CurrentRefinements.md
+++ b/docs/src/components/CurrentRefinements.md
@@ -16,26 +16,51 @@ Show the currently refined values and allow them to be unset.
 ## Usage
 
 ```html
-<ais-current-refinements :clears-query="true"></ais-current-refinements>
+<template>
+  <ais-current-refinements
+    :excluded-attributes="[]"
+    :transform-items="transformItems"
+  ></ais-current-refinements>
+</template>
+<script>
+export default {
+  data() {
+    return {
+      transformItems: items =>
+        items.map(item => {
+          item.label = item.label.toLocaleUpperCase();
+          return item;
+        })
+    };
+  }
+};
+</script>
 ```
 
 ## Props
 
 Name | Type | Default | Description | Required
 ---|---|---|---|---
-transformItems | Function | | Allows you to format and change the attributes | -
-clearsQuery | Boolean | `false` | Should the 'clear all' button also clear the query? | -
-excludedAttributes | Array | `[]` | Attributes not to show or clear | -
+includedAttributes | Array | | Attributes to show or clear | -
+excludedAttributes | Array | `["query"]` | Attributes not to show or clear | -
 transformItems | `(items: object[]) => object[]` | `x => x` | Function which receives the items, which will be called before displaying them. Should return a new array with the same shape as the original array. Useful for mapping over the items to transform, remove or reorder them | -
 classNames | Object | | Override class names | no
+
+Note that you can not use `includedAttributes` and `excludedAttributes` at the same time. Included attributes are exclusive, and thus take precedence over excluded attributes.
 
 ## Slots
 
 name | scope | Description
 ---|---|---
-`default` | `{ items: Item[], refine: Item => void, clearAll: () => void }` | Override how all the items look
+`default` | `{ items: Item[], refine: Item => void }` | Override how all the items look
 `item` | `{ item: Item, refine: Item => void }` | Override how an item looks
-`clearAllLabel` | `{ items: Item[] }` | Override how the "clear all" button looks
+
+an Item has the keys:
+
+* "type": which can be "facet", "exclude", "disjunctive", "hierarchical", "numeric" or "query"
+* "attribute": used as the key
+* "label": string form of the value
+* "value": necessary for the refinement to work correctly, no need to be changed
 
 ## CSS classes
 

--- a/src/components/ClearRefinements.vue
+++ b/src/components/ClearRefinements.vue
@@ -1,7 +1,19 @@
 <template>
-  <div v-if="state" :class="suit()">
-    <slot :can-refine="canRefine" :refine="state.refine" :createURL="state.createURL">
-      <button type="reset" :class="[suit('button'), !canRefine && suit('button', 'disabled')]" :disabled="!canRefine" @click.prevent="state.refine">
+  <div
+    v-if="state"
+    :class="suit()"
+  >
+    <slot
+      :can-refine="canRefine"
+      :refine="state.refine"
+      :createURL="state.createURL"
+    >
+      <button
+        type="reset"
+        :class="[suit('button'), !canRefine && suit('button', 'disabled')]"
+        :disabled="!canRefine"
+        @click.prevent="state.refine"
+      >
         <slot name="resetLabel">
           Clear refinements
         </slot>
@@ -36,7 +48,9 @@ export default {
       return {
         clearsQuery: this.excludedAttributes.every(item => item !== 'query'),
         // note the difference: excludeAttributes vs. excludedAttributes
-        excludeAttributes: this.excludedAttributes.filter(item => item !== 'query'),
+        excludeAttributes: this.excludedAttributes.filter(
+          item => item !== 'query'
+        ),
       };
     },
     canRefine() {

--- a/src/components/ClearRefinements.vue
+++ b/src/components/ClearRefinements.vue
@@ -1,19 +1,7 @@
 <template>
-  <div
-    v-if="state"
-    :class="suit()"
-  >
-    <slot
-      :can-refine="canRefine"
-      :refine="state.refine"
-      :createURL="state.createURL"
-    >
-      <button
-        type="reset"
-        :class="[suit('button'), !canRefine && suit('button', 'disabled')]"
-        :disabled="!canRefine"
-        @click.prevent="state.refine"
-      >
+  <div v-if="state" :class="suit()">
+    <slot :can-refine="canRefine" :refine="state.refine" :createURL="state.createURL">
+      <button type="reset" :class="[suit('button'), !canRefine && suit('button', 'disabled')]" :disabled="!canRefine" @click.prevent="state.refine">
         <slot name="resetLabel">
           Clear refinements
         </slot>
@@ -38,21 +26,17 @@ export default {
     createSuitMixin({ name: 'ClearRefinements' }),
   ],
   props: {
-    clearsQuery: {
-      type: Boolean,
-      default: false,
-    },
     excludedAttributes: {
       type: Array,
-      default: () => [],
+      default: () => ['query'],
     },
   },
   computed: {
     widgetParams() {
       return {
-        clearsQuery: this.clearsQuery,
-        excludeAttributes: this.excludedAttributes,
-        transformItems: this.transformItems,
+        clearsQuery: this.excludedAttributes.every(item => item !== 'query'),
+        // note the difference: excludeAttributes vs. excludedAttributes
+        excludeAttributes: this.excludedAttributes.filter(item => item !== 'query'),
       };
     },
     canRefine() {

--- a/src/components/CurrentRefinements.vue
+++ b/src/components/CurrentRefinements.vue
@@ -5,7 +5,6 @@
   >
     <slot
       :refine="state.refine"
-      :clear-all="state.clearAllClick"
       :items="refinements"
     >
       <ul :class="suit('list')">
@@ -19,25 +18,15 @@
             :item="item"
           >
             <span :class="suit('item')">
-              <span :class="suit('label')">{{ item.attributeName | capitalize }}: {{ item.computedLabel }}</span>
+              <span :class="suit('label')">{{ item.attribute | capitalize }}: {{ item.label }}</span>
               <button
                 :class="suit('delete')"
-                @click="state.refine(item)"
+                @click="state.refine(item.value)"
               >✕</button>
             </span>
           </slot>
         </li>
       </ul>
-      <button
-        :class="suit('reset')"
-        @click="state.clearAllClick()"
-        v-if="refinements.length > 0"
-      >
-        <slot
-          name="clearAllLabel"
-          :items="refinements"
-        >Clear all</slot>
-      </button>
     </slot>
   </div>
 </template>
@@ -58,13 +47,13 @@ export default {
     }),
   ],
   props: {
-    clearsQuery: {
-      type: Boolean,
-      default: false,
+    includedAttributes: {
+      type: Array,
+      default: null,
     },
     excludedAttributes: {
       type: Array,
-      default: () => [],
+      default: () => ['query'],
     },
     transformItems: {
       type: Function,
@@ -78,24 +67,31 @@ export default {
       return this.refinements.length === 0;
     },
     refinements() {
-      // excludedAttributes isn't implemented in IS.js
-      return this.state.refinements
-        .filter(
-          ({ attributeName }) =>
-            this.excludedAttributes.indexOf(attributeName) === -1
-        )
-        .map(item => {
-          if (item.type === 'query') {
-            // eslint-disable-next-line no-param-reassign
-            item.attributeName = 'query';
-          }
-          return item;
-        });
+      let refinements = this.state.refinements.map(item => ({
+        type: item.type,
+        attribute: item.type === 'query' ? 'query' : item.attributeName,
+        label: item.computedLabel,
+        value: item,
+      }));
+
+      if (this.includedAttributes) {
+        refinements = refinements.filter(
+          ({ attribute }) => this.includedAttributes.indexOf(attribute) !== -1
+        );
+      } else {
+        refinements = refinements.filter(
+          ({ attribute }) => this.excludedAttributes.indexOf(attribute) === -1
+        );
+      }
+      return this.transformItems(refinements);
     },
     widgetParams() {
       return {
-        transformItems: this.transformItems,
-        clearsQuery: this.clearsQuery,
+        clearsQuery:
+          this.excludedAttributes.indexOf('query') === -1 &&
+          (this.includedAttributes
+            ? this.includedAttributes.indexOf('query') > -1
+            : true),
       };
     },
   },

--- a/src/components/CurrentRefinements.vue
+++ b/src/components/CurrentRefinements.vue
@@ -90,7 +90,7 @@ export default {
         clearsQuery:
           this.excludedAttributes.indexOf('query') === -1 &&
           (this.includedAttributes
-            ? this.includedAttributes.indexOf('query') > -1
+            ? this.includedAttributes.indexOf('query') !== -1
             : true),
       };
     },

--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -90,7 +90,7 @@ export default {
           this.$emit('input', this.value);
           this.state.refine(this.value);
         }
-        return this.value || this.localValue || this.state.query || '';
+        return this.value || this.state.query || '';
       },
       set(val) {
         this.localValue = val;

--- a/src/components/__tests__/ClearRefinements.js
+++ b/src/components/__tests__/ClearRefinements.js
@@ -11,21 +11,7 @@ const defaultState = {
   createURL: () => {},
 };
 
-it('accepts an clearsQuery prop', () => {
-  __setState({
-    ...defaultState,
-  });
-
-  const wrapper = mount(ClearRefinements, {
-    propsData: {
-      clearsQuery: true,
-    },
-  });
-
-  expect(wrapper.vm.widgetParams.clearsQuery).toBe(true);
-});
-
-it('accepts an excludeAttributes prop', () => {
+it('accepts an excludedAttributes prop', () => {
   __setState({
     ...defaultState,
   });
@@ -37,6 +23,35 @@ it('accepts an excludeAttributes prop', () => {
   });
 
   expect(wrapper.vm.widgetParams.excludeAttributes).toEqual(['brand']);
+});
+
+it('query in excluded attributes sets clearsQuery', () => {
+  __setState({
+    ...defaultState,
+  });
+
+  const wrapper = mount(ClearRefinements, {
+    propsData: {
+      excludedAttributes: ['query', 'brand'],
+    },
+  });
+
+  expect(wrapper.vm.widgetParams.excludeAttributes).toEqual(['brand']);
+  expect(wrapper.vm.widgetParams.clearsQuery).toEqual(false);
+});
+
+it('clears query by empty excluded attributes', () => {
+  __setState({
+    ...defaultState,
+  });
+
+  const wrapper = mount(ClearRefinements, {
+    propsData: {
+      excludedAttributes: [],
+    },
+  });
+
+  expect(wrapper.vm.widgetParams.clearsQuery).toEqual(true);
 });
 
 describe('default render', () => {

--- a/src/components/__tests__/CurrentRefinements.js
+++ b/src/components/__tests__/CurrentRefinements.js
@@ -45,7 +45,7 @@ it('TransformItems happens after excludedAttributes', () => {
   );
 });
 
-it("transformItems happens after excludedAttributes (so it doesn't include query by default", () => {
+it("transformItems happens after excludedAttributes (so it doesn't include query by default)", () => {
   __setState({
     refinements: [
       { type: 'query', query: 'hi there everyone!' },

--- a/src/components/__tests__/CurrentRefinements.js
+++ b/src/components/__tests__/CurrentRefinements.js
@@ -9,27 +9,43 @@ it('TransformItems happens after excludedAttributes', () => {
   __setState({
     refinements: [
       { type: 'query', query: 'hi there everyone!' },
-      { type: 'disjunctive', attribute: 'brand', value: 'Insignia™' },
+      { type: 'disjunctive', attributeName: 'brand', value: 'Insignia™' },
     ],
   });
 
-  const transformItems = items =>
-    items.filter(({ attribute }) => attribute === 'query');
+  const transformItems = items => {
+    expect(items).toHaveLength(0);
+    return [
+      { type: 'query', attribute: 'query', query: 'dogs' },
+      { type: 'disjunctive', attribute: 'brand', value: 'Insignia™' },
+    ];
+  };
 
   const wrapper = mount(CurrentRefinements, {
     propsData: {
       transformItems,
-      excludedAttributes: [],
+      excludedAttributes: ['query', 'brand'],
     },
   });
 
-  expect(wrapper.vm.refinements).toHaveLength(1);
+  expect(wrapper.vm.refinements).toHaveLength(2);
   expect(wrapper.vm.refinements[0]).toEqual(
-    expect.objectContaining({ type: 'query', attribute: 'query' })
+    expect.objectContaining({
+      type: 'query',
+      attribute: 'query',
+      query: 'dogs',
+    })
+  );
+  expect(wrapper.vm.refinements[1]).toEqual(
+    expect.objectContaining({
+      type: 'disjunctive',
+      attribute: 'brand',
+      value: 'Insignia™',
+    })
   );
 });
 
-it("TransformItems happens after excludedAttributes (so it doesn't include query by default", () => {
+it("transformItems happens after excludedAttributes (so it doesn't include query by default", () => {
   __setState({
     refinements: [
       { type: 'query', query: 'hi there everyone!' },

--- a/src/components/__tests__/CurrentRefinements.js
+++ b/src/components/__tests__/CurrentRefinements.js
@@ -147,7 +147,7 @@ it('default value of excludedAttributes is ["query"]', () => {
   expect(labels).toHaveLength(0);
 });
 
-it('includedAttributes overrides excludedAttributes', () => {
+it('includedAttributes overrides excludedAttributes (also for query)', () => {
   __setState({
     refinements: [
       {
@@ -172,7 +172,7 @@ it('includedAttributes overrides excludedAttributes', () => {
   expect(label.text()).toMatch(/Query/);
 });
 
-it('includedAttributes overrides excludedAttributes 2', () => {
+it('includedAttributes overrides excludedAttributes', () => {
   __setState({
     refinements: [
       {

--- a/src/components/__tests__/__snapshots__/CurrentRefinements.js.snap
+++ b/src/components/__tests__/__snapshots__/CurrentRefinements.js.snap
@@ -9,7 +9,7 @@ exports[`default value of excludedAttributes is ["query"] 1`] = `
 
 `;
 
-exports[`includedAttributes overrides excludedAttributes 1`] = `
+exports[`includedAttributes overrides excludedAttributes (also for query) 1`] = `
 
 <div class="ais-CurrentRefinements">
   <ul class="ais-CurrentRefinements-list">
@@ -28,7 +28,7 @@ exports[`includedAttributes overrides excludedAttributes 1`] = `
 
 `;
 
-exports[`includedAttributes overrides excludedAttributes 2 1`] = `
+exports[`includedAttributes overrides excludedAttributes 1`] = `
 
 <div class="ais-CurrentRefinements">
   <ul class="ais-CurrentRefinements-list">

--- a/src/components/__tests__/__snapshots__/CurrentRefinements.js.snap
+++ b/src/components/__tests__/__snapshots__/CurrentRefinements.js.snap
@@ -1,5 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`default value of excludedAttributes is ["query"] 1`] = `
+
+<div class="ais-CurrentRefinements ais-CurrentRefinements--noRefinement">
+  <ul class="ais-CurrentRefinements-list">
+  </ul>
+</div>
+
+`;
+
+exports[`includedAttributes overrides excludedAttributes 1`] = `
+
+<div class="ais-CurrentRefinements">
+  <ul class="ais-CurrentRefinements-list">
+    <li>
+      <span class="ais-CurrentRefinements-item">
+        <span class="ais-CurrentRefinements-label">
+          Query: some query
+        </span>
+        <button class="ais-CurrentRefinements-delete">
+          ✕
+        </button>
+      </span>
+    </li>
+  </ul>
+</div>
+
+`;
+
+exports[`includedAttributes overrides excludedAttributes 2 1`] = `
+
+<div class="ais-CurrentRefinements">
+  <ul class="ais-CurrentRefinements-list">
+    <li>
+      <span class="ais-CurrentRefinements-item">
+        <span class="ais-CurrentRefinements-label">
+          Hi there:
+        </span>
+        <button class="ais-CurrentRefinements-delete">
+          ✕
+        </button>
+      </span>
+    </li>
+  </ul>
+</div>
+
+`;
+
 exports[`renders correctly (empty) 1`] = `
 
 <div class="ais-CurrentRefinements ais-CurrentRefinements--noRefinement">
@@ -23,10 +70,37 @@ exports[`renders correctly (with query) 1`] = `
         </button>
       </span>
     </li>
+    <li>
+      <span class="ais-CurrentRefinements-item">
+        <span class="ais-CurrentRefinements-label">
+          Brands: apple
+        </span>
+        <button class="ais-CurrentRefinements-delete">
+          ✕
+        </button>
+      </span>
+    </li>
+    <li>
+      <span class="ais-CurrentRefinements-item">
+        <span class="ais-CurrentRefinements-label">
+          Colors: red
+        </span>
+        <button class="ais-CurrentRefinements-delete">
+          ✕
+        </button>
+      </span>
+    </li>
+    <li>
+      <span class="ais-CurrentRefinements-item">
+        <span class="ais-CurrentRefinements-label">
+          Requirements: free
+        </span>
+        <button class="ais-CurrentRefinements-delete">
+          ✕
+        </button>
+      </span>
+    </li>
   </ul>
-  <button class="ais-CurrentRefinements-reset">
-    Clear all
-  </button>
 </div>
 
 `;
@@ -66,9 +140,6 @@ exports[`renders correctly (with refinements) 1`] = `
       </span>
     </li>
   </ul>
-  <button class="ais-CurrentRefinements-reset">
-    Clear all
-  </button>
 </div>
 
 `;

--- a/stories/ClearRefinements.stories.js
+++ b/stories/ClearRefinements.stories.js
@@ -8,14 +8,33 @@ storiesOf('ais-clear-refinements', module)
       <ais-clear-refinements />
     `,
   }))
-  .add('with clears query', () => ({
+  .add('also clearing query', () => ({
     template: `
       <div>
         <div class="preview-spacer">
-          <ais-clear-refinements :clearsQuery="true" />
+          <ais-clear-refinements :excluded-attributes="[]" />
         </div>
 
         <span>TIP: type something first</span>
+      </div>
+    `,
+  }))
+  .add('not clearing "brand"', () => ({
+    template: `
+      <div>
+        <div class="preview-spacer">
+          <ais-clear-refinements :excluded-attributes="['brand']" />
+          <hr />
+          <ais-hierarchical-menu
+            :attributes="[
+              'hierarchicalCategories.lvl0',
+              'hierarchicalCategories.lvl1',
+              'hierarchicalCategories.lvl2',
+            ]"
+          />
+          <hr />
+          <ais-range-input attribute="price" />
+        </div>
       </div>
     `,
   }))

--- a/stories/CurrentRefinements.stories.js
+++ b/stories/CurrentRefinements.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from '@storybook/vue';
 import { previewWrapper } from './utils';
-import { withKnobs, boolean } from '@storybook/addon-knobs/vue';
+import { withKnobs, array } from '@storybook/addon-knobs/vue';
 
 storiesOf('ais-current-refinements', module)
   .addDecorator(previewWrapper())
@@ -12,13 +12,13 @@ storiesOf('ais-current-refinements', module)
   }))
   .add('with a refinement to clear', () => ({
     template: `
-      <ais-current-refinements :clears-query="true" />
+      <ais-current-refinements :excluded-attributes="[]" />
     `,
   }))
   .add('with multiple refinements to clear', () => ({
     template: `
       <div>
-        <ais-current-refinements :clears-query="true" />
+        <ais-current-refinements :excluded-attributes="[]" />
         <hr />
         <ais-hierarchical-menu
           :attributes="[
@@ -35,10 +35,9 @@ storiesOf('ais-current-refinements', module)
   .add('with excluded attributes', () => ({
     template: `
       <div>
-        excludes: Brand
+        <p><strong>excludes: Brand</strong>
         <ais-current-refinements
           :excluded-attributes="['brand']"
-          :clears-query="true"
         />
         <hr />
         <ais-hierarchical-menu
@@ -61,14 +60,9 @@ storiesOf('ais-current-refinements', module)
       transformItems(items) {
         return items.map(item =>
           Object.assign({}, item, {
-            computedLabel: item.computedLabel.toUpperCase(),
+            label: item.label.toUpperCase(),
           })
         );
       },
     },
-  }))
-  .add('playground', () => ({
-    template: `
-      <ais-current-refinements :clears-query="${boolean('clears-query')}" />
-    `,
   }));

--- a/stories/CurrentRefinements.stories.js
+++ b/stories/CurrentRefinements.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from '@storybook/vue';
 import { previewWrapper } from './utils';
-import { withKnobs, array } from '@storybook/addon-knobs/vue';
+import { withKnobs } from '@storybook/addon-knobs/vue';
 
 storiesOf('ais-current-refinements', module)
   .addDecorator(previewWrapper())


### PR DESCRIPTION
API of ClearRefinements & CurrentRefinements is consolidated

1. ClearRefinements has no `includedAttributes`. This is waiting for v3 of InstantSearch.js and will be added without breaking change
2. Searchbox: don't display internal value (otherwise you can clear the query but it stays visible)
3. CurrentRefinements: `includedAttributes` transparently takes precedence over `excludedAttributes`. 

If you don't want to display specific attributes listed in `includedAttributes`, don't write them or use `transformItems`. 

This doesn't implement the "merged items" done in InstantSearch.js v3, which will be added later (we can do a major maybe)