### PR TITLE
feat(CurrentRefinements): give createURL to slot

### DIFF
--- a/docs/src/components/CurrentRefinements.md
+++ b/docs/src/components/CurrentRefinements.md
@@ -54,7 +54,7 @@ Note that you can not use `includedAttributes` and `excludedAttributes` at the s
 name | scope | Description
 ---|---|---
 `default` | `{ items: Item[], refine: Item => void, createURL: Item.value => string }` | Override how all the items look
-`item` | `{ item: Item, refine: Item => void }` | Override how an item looks
+`item` | `{ item: Item, refine: Item => void, createURL: () => string }` | Override how an item looks
 
 All elements in `items` have the keys:
 

--- a/src/components/CurrentRefinements.vue
+++ b/src/components/CurrentRefinements.vue
@@ -17,6 +17,7 @@
             name="item"
             :refine="state.refine"
             :item="item"
+            :createURL="() => state.createURL(item.value)"
           >
             <span :class="suit('item')">
               <span :class="suit('label')">{{ item.attribute | capitalize }}: {{ item.label }}</span>

--- a/src/components/__tests__/CurrentRefinements.js
+++ b/src/components/__tests__/CurrentRefinements.js
@@ -223,3 +223,170 @@ it('calls `refine` with an item', () => {
     computedLabel: 'apple',
   });
 });
+
+describe('custom render', () => {
+  const defaultScopedSlot = `
+    <div slot-scope="{ items, createURL, refine }">
+      <div v-for="item in items" :key="item.attributeName">
+        <button
+          @click="refine(item.value)"
+        >
+          <a :href="createURL(item.value)">
+            url
+          </a>
+          <pre>{{item}}</pre>
+        </button>
+      </div>
+    </div>
+  `;
+
+  const itemScopedSlot = `
+    <div slot-scope="{ item, createURL, refine }">
+      <button
+        @click="refine()"
+      >
+        <a :href="createURL()">
+          url
+        </a>
+        <pre>{{item}}</pre>
+      </button>
+    </div>
+  `;
+
+  const refinements = [
+    {
+      attributeName: 'brands',
+      computedLabel: 'apple',
+    },
+    {
+      attributeName: 'colors',
+      computedLabel: 'red',
+    },
+    {
+      attributeName: 'requirements',
+      computedLabel: 'free',
+    },
+  ];
+
+  it('gives all relevant info to scoped slot', () => {
+    __setState({
+      refinements,
+      refine: jest.fn(),
+      createURL: jest.fn(
+        ({ attributeName, computedLabel }) =>
+          `?${attributeName}=${computedLabel}`
+      ),
+    });
+
+    const wrapper = mount(CurrentRefinements, {
+      scopedSlots: {
+        default: defaultScopedSlot,
+      },
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('has same amount of items', () => {
+    __setState({
+      refinements,
+      refine: jest.fn(),
+      createURL: jest.fn(
+        ({ attributeName, computedLabel }) =>
+          `?${attributeName}=${computedLabel}`
+      ),
+    });
+
+    const wrapper = mount(CurrentRefinements, {
+      scopedSlots: {
+        default: defaultScopedSlot,
+      },
+    });
+
+    expect(wrapper.findAll('button')).toHaveLength(refinements.length);
+  });
+
+  it('creates URLs', () => {
+    __setState({
+      refinements,
+      refine: jest.fn(),
+      createURL: jest.fn(
+        ({ attributeName, computedLabel }) =>
+          `?${attributeName}=${computedLabel}`
+      ),
+    });
+
+    const wrapper = mount(CurrentRefinements, {
+      scopedSlots: {
+        default: defaultScopedSlot,
+      },
+    });
+
+    expect(
+      wrapper
+        .findAll('button a')
+        .filter(link => Boolean(link.attributes('href')))
+    ).toHaveLength(refinements.length);
+  });
+
+  it('item slot gives all relevant info to scoped slot', () => {
+    __setState({
+      refinements,
+      refine: jest.fn(),
+      createURL: jest.fn(
+        ({ attributeName, computedLabel }) =>
+          `?${attributeName}=${computedLabel}`
+      ),
+    });
+
+    const wrapper = mount(CurrentRefinements, {
+      scopedSlots: {
+        item: itemScopedSlot,
+      },
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('item slot has same amount of items', () => {
+    __setState({
+      refinements,
+      refine: jest.fn(),
+      createURL: jest.fn(
+        ({ attributeName, computedLabel }) =>
+          `?${attributeName}=${computedLabel}`
+      ),
+    });
+
+    const wrapper = mount(CurrentRefinements, {
+      scopedSlots: {
+        item: itemScopedSlot,
+      },
+    });
+
+    expect(wrapper.findAll('button')).toHaveLength(refinements.length);
+  });
+
+  it('item slot has URLs', () => {
+    __setState({
+      refinements,
+      refine: jest.fn(),
+      createURL: jest.fn(
+        ({ attributeName, computedLabel }) =>
+          `?${attributeName}=${computedLabel}`
+      ),
+    });
+
+    const wrapper = mount(CurrentRefinements, {
+      scopedSlots: {
+        item: itemScopedSlot,
+      },
+    });
+
+    expect(
+      wrapper
+        .findAll('button a')
+        .filter(link => Boolean(link.attributes('href')))
+    ).toHaveLength(refinements.length);
+  });
+});

--- a/src/components/__tests__/__snapshots__/CurrentRefinements.js.snap
+++ b/src/components/__tests__/__snapshots__/CurrentRefinements.js.snap
@@ -1,5 +1,131 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`custom render gives all relevant info to scoped slot 1`] = `
+
+<div class="ais-CurrentRefinements">
+  <div>
+    <div>
+      <button>
+        <a href="?brands=apple">
+          url
+        </a>
+        <pre>
+          {
+  "attribute": "brands",
+  "label": "apple",
+  "value": {
+    "attributeName": "brands",
+    "computedLabel": "apple"
+  }
+}
+        </pre>
+      </button>
+    </div>
+    <div>
+      <button>
+        <a href="?colors=red">
+          url
+        </a>
+        <pre>
+          {
+  "attribute": "colors",
+  "label": "red",
+  "value": {
+    "attributeName": "colors",
+    "computedLabel": "red"
+  }
+}
+        </pre>
+      </button>
+    </div>
+    <div>
+      <button>
+        <a href="?requirements=free">
+          url
+        </a>
+        <pre>
+          {
+  "attribute": "requirements",
+  "label": "free",
+  "value": {
+    "attributeName": "requirements",
+    "computedLabel": "free"
+  }
+}
+        </pre>
+      </button>
+    </div>
+  </div>
+</div>
+
+`;
+
+exports[`custom render item slot gives all relevant info to scoped slot 1`] = `
+
+<div class="ais-CurrentRefinements">
+  <ul class="ais-CurrentRefinements-list">
+    <li>
+      <div>
+        <button>
+          <a href="?brands=apple">
+            url
+          </a>
+          <pre>
+            {
+  "attribute": "brands",
+  "label": "apple",
+  "value": {
+    "attributeName": "brands",
+    "computedLabel": "apple"
+  }
+}
+          </pre>
+        </button>
+      </div>
+    </li>
+    <li>
+      <div>
+        <button>
+          <a href="?colors=red">
+            url
+          </a>
+          <pre>
+            {
+  "attribute": "colors",
+  "label": "red",
+  "value": {
+    "attributeName": "colors",
+    "computedLabel": "red"
+  }
+}
+          </pre>
+        </button>
+      </div>
+    </li>
+    <li>
+      <div>
+        <button>
+          <a href="?requirements=free">
+            url
+          </a>
+          <pre>
+            {
+  "attribute": "requirements",
+  "label": "free",
+  "value": {
+    "attributeName": "requirements",
+    "computedLabel": "free"
+  }
+}
+          </pre>
+        </button>
+      </div>
+    </li>
+  </ul>
+</div>
+
+`;
+
 exports[`default value of excludedAttributes is ["query"] 1`] = `
 
 <div class="ais-CurrentRefinements ais-CurrentRefinements--noRefinement">


### PR DESCRIPTION
The function is prefilled this with the item.

I'm doubting if maybe it should be prefilled with the url in the `item` itself instead? This is a larger change and we can do it another time though