### PR TITLE
docs(SearchClient): preventing (initial & empty) request

### DIFF
--- a/docs/src/advanced/conditional-requests.md
+++ b/docs/src/advanced/conditional-requests.md
@@ -69,7 +69,7 @@ Functionally this is not any different from directly passing the created search 
 
 ## Mocking a search request
 
-Since we don't want to do a request when the query is `""`, we first need to detect it:
+Since we don't want to do a request when the query is empty (`""`), we first need to detect it:
 
 ```js
 const searchClient = {

--- a/docs/src/advanced/conditional-requests.md
+++ b/docs/src/advanced/conditional-requests.md
@@ -84,7 +84,7 @@ const searchClient = {
 
 There can be multiple requests done in case a user for example clicks a hierarchical menu open. For now this doesn't really have a big impact, except that we have to make sure to check that every query is empty before we intercept.
 
-Then we need to return a [Response](https://www.algolia.com/doc/api-reference/api-methods/search/?language=javascript#response). This is an array of objects, of the same length as the `requests` array. At the bare minimum, each object needs to contain: `processingTimeMS`, `nbHits`, `hits` and `facets`:
+Then, we need to return a [formatted response](https://www.algolia.com/doc/api-reference/api-methods/search/?language=javascript#response). This is an array of objects of the same length as the `requests` array. At the bare minimum, each object needs to contain: `processingTimeMS`, `nbHits`, `hits` and `facets`:
 
 ```js
 const searchClient = {

--- a/docs/src/advanced/conditional-requests.md
+++ b/docs/src/advanced/conditional-requests.md
@@ -82,7 +82,7 @@ const searchClient = {
 }
 ```
 
-There can be multiple requests done in case a user for example clicks a hierarchical menu open. For now this doesn't really have a big impact, except that we have to make sure to check that every query is empty before we intercept.
+There can be multiple requests done in case a user for example clicks a hierarchical menu open. For now, this doesn't really have a big impact except that we have to make sure to check that every query is empty before we intercept the function call.
 
 Then, we need to return a [formatted response](https://www.algolia.com/doc/api-reference/api-methods/search/?language=javascript#response). This is an array of objects of the same length as the `requests` array. At the bare minimum, each object needs to contain: `processingTimeMS`, `nbHits`, `hits` and `facets`:
 

--- a/docs/src/advanced/conditional-requests.md
+++ b/docs/src/advanced/conditional-requests.md
@@ -1,0 +1,168 @@
+---
+title: Conditionally doing search requests
+mainTitle: Advanced
+layout: main.pug
+category: Advanced
+withHeadings: true
+navWeight: 7
+editable: true
+githubSource: docs/src/advanced/conditional-requests.md
+---
+
+> NOTE: this guide **has** been updated for v2
+
+InstantSearch will do a requests to Algolia servers on every key stroke, which means that it's fast and users will see updated results instantly. This also means that a request is being done to show the initial results on an empty query. While this usually isn't an issue and even a feature, since it warms up the network connection so subsequent requests will be done faster too.
+
+However, there are cases in which you do not want to do extra network requests than strictly necessary, for example when you are using a custom backend, or when the initial results are never displayed.
+
+## How it's made possible
+
+InstantSearch is the UI part on top a search client with a state managed by a [JavaScript Helper](https://github.com/algolia/algoliasearch-helper-js). These three layers are composable and can be interchanged to leverage the InstantSearch widgets system with different search clients.
+
+The [search client](https://github.com/algolia/algoliasearch-client-javascript) that Algolia offers queries Algolia's backends whenever the user refines the search. It is possible to implement your own search client that queries your backend, which then queries Algolia's backend with the [Algolia search client](https://github.com/algolia/algoliasearch-client-javascript) on your server.
+
+To create your own client, you will need to implement a given interface that receives and returns formatted data that InstantSearch can understand.
+
+## Implementing a proxy
+
+The way we will prevent searches to Algolia from happening in certain use cases is by making a proxy object around the `algoliasearch` client. This will then be passed to `ais-instant-search`:
+
+```vue
+<template>
+  <ais-instant-search
+    :search-client="searchClient"
+    index-name="instant_search"
+  >
+    <ais-search-box />
+    <ais-hits />
+  </ais-instant-search>
+</template>
+
+<script>
+import algoliasearch from "algoliasearch/lite";
+
+const algoliaClient = algoliasearch(
+  "latency",
+  "6be0576ff61c053d5f9a3225e2a90f76"
+);
+
+const searchClient = {
+  async search(requests) {
+    return algoliaClient.search(requests);
+  },
+  async searchForFacetValues(requests) {
+    return algoliaClient.searchForFacetValues(requests);
+  }
+};
+
+export default {
+  data() {
+    return {
+      searchClient,
+    };
+  }
+};
+</script>
+```
+
+Functionally this is not any different from directly passing the created search client from the `algoliasearch` call, but what it empowers us is conditionally **not** calling the Algolia search request, and thus not doing the query.
+
+## Mocking a search request
+
+Since we don't want to do a request when the query is `""`, we first need to detect it:
+
+```js
+const searchClient = {
+  async search(requests) {
+    if (requests.every(({ params: { query } }) => Boolean(query) === false)) {
+      // here we need to do something else
+    }
+    return algoliaClient.search(requests);
+  },
+}
+```
+
+There can be multiple requests done in case a user for example clicks a hierarchical menu open. For now this doesn't really have a big impact, except that we have to make sure to check that every query is empty before we intercept.
+
+Then we need to return a [Response](https://www.algolia.com/doc/api-reference/api-methods/search/?language=javascript#response). This is an array of objects, of the same length as the `requests` array. At the bare minimum, each object needs to contain: `processingTimeMS`, `nbHits`, `hits` and `facets`:
+
+```js
+const searchClient = {
+  async search(requests) {
+    if (requests.every(({ params: { query } }) => Boolean(query) === false)) {
+      return {
+        results: requests.map(params => {
+          return {
+            processingTimeMS: 0,
+            nbHits: 0,
+            hits: [],
+            facets: {},
+          };
+        })
+      };
+    }
+    return algoliaClient.search(requests);
+  },
+}
+```
+
+We can then build both together and get to a result like this:
+
+```vue
+<template>
+  <ais-instant-search
+    :search-client="searchClient"
+    index-name="instant_search"
+  >
+    <ais-search-box />
+    <ais-hits />
+  </ais-instant-search>
+</template>
+
+<script>
+import algoliasearch from "algoliasearch/lite";
+
+const algoliaClient = algoliasearch(
+  "latency",
+  "6be0576ff61c053d5f9a3225e2a90f76"
+);
+
+const searchClient = {
+  async search(requests) {
+    // eslint-disable-next-line no-console
+    console.log(
+      "change conditional if any of the other facets are faked",
+      requests
+    );
+    if (requests.every(({ params: { query } }) => Boolean(query) === false)) {
+      return {
+        results: requests.map(params => {
+          // eslint-disable-next-line no-console
+          console.log("fake something of the result if necessary", params);
+          return {
+            processingTimeMS: 0,
+            nbHits: 0,
+            hits: [],
+            facets: {},
+          };
+        })
+      };
+    }
+    return algoliaClient.search(requests);
+  },
+  async searchForFacetValues(requests) {
+    return algoliaClient.searchForFacetValues(requests);
+  }
+};
+
+export default {
+  data() {
+    return {
+      searchClient,
+    };
+  }
+};
+</script>
+```
+
+<iframe src="https://codesandbox.io/embed/9o4qo147jw?module=%2Fsrc%2FApp.vue" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>

--- a/docs/src/advanced/conditional-requests.md
+++ b/docs/src/advanced/conditional-requests.md
@@ -17,7 +17,7 @@ However, there are cases in which you do not want to do extra network requests t
 
 ## How it's made possible
 
-InstantSearch is the UI part on top a search client with a state managed by a [JavaScript Helper](https://github.com/algolia/algoliasearch-helper-js). These three layers are composable and can be interchanged to leverage the InstantSearch widgets system with different search clients.
+InstantSearch is the UI part on top of a search client with a state managed by a [JavaScript Helper](https://github.com/algolia/algoliasearch-helper-js). These three layers are composable and can be interchanged to leverage the InstantSearch widgets system with different search clients.
 
 The [search client](https://github.com/algolia/algoliasearch-client-javascript) that Algolia offers queries Algolia's backends whenever the user refines the search. It is possible to implement your own search client that queries your backend, which then queries Algolia's backend with the [Algolia search client](https://github.com/algolia/algoliasearch-client-javascript) on your server.
 

--- a/docs/src/advanced/conditional-requests.md
+++ b/docs/src/advanced/conditional-requests.md
@@ -39,11 +39,11 @@ The way we will prevent searches to Algolia from happening in certain use cases 
 </template>
 
 <script>
-import algoliasearch from "algoliasearch/lite";
+import algoliasearch from 'algoliasearch/lite';
 
 const algoliaClient = algoliasearch(
-  "latency",
-  "6be0576ff61c053d5f9a3225e2a90f76"
+  'latency',
+  '6be0576ff61c053d5f9a3225e2a90f76'
 );
 
 const searchClient = {
@@ -52,7 +52,7 @@ const searchClient = {
   },
   async searchForFacetValues(requests) {
     return algoliaClient.searchForFacetValues(requests);
-  }
+  },
 };
 
 export default {
@@ -60,7 +60,7 @@ export default {
     return {
       searchClient,
     };
-  }
+  },
 };
 </script>
 ```
@@ -79,7 +79,7 @@ const searchClient = {
     }
     return algoliaClient.search(requests);
   },
-}
+};
 ```
 
 There can be multiple requests done in case a user for example clicks a hierarchical menu open. For now, this doesn't really have a big impact except that we have to make sure to check that every query is empty before we intercept the function call.
@@ -98,12 +98,12 @@ const searchClient = {
             hits: [],
             facets: {},
           };
-        })
+        }),
       };
     }
     return algoliaClient.search(requests);
   },
-}
+};
 ```
 
 We can then build both together and get to a result like this:
@@ -120,11 +120,11 @@ We can then build both together and get to a result like this:
 </template>
 
 <script>
-import algoliasearch from "algoliasearch/lite";
+import algoliasearch from 'algoliasearch/lite';
 
 const algoliaClient = algoliasearch(
-  "latency",
-  "6be0576ff61c053d5f9a3225e2a90f76"
+  'latency',
+  '6be0576ff61c053d5f9a3225e2a90f76'
 );
 
 const searchClient = {
@@ -140,14 +140,14 @@ const searchClient = {
             hits: [],
             facets: {},
           };
-        })
+        }),
       };
     }
     return algoliaClient.search(requests);
   },
   async searchForFacetValues(requests) {
     return algoliaClient.searchForFacetValues(requests);
-  }
+  },
 };
 
 export default {
@@ -155,7 +155,7 @@ export default {
     return {
       searchClient,
     };
-  }
+  },
 };
 </script>
 ```

--- a/docs/src/advanced/conditional-requests.md
+++ b/docs/src/advanced/conditional-requests.md
@@ -129,16 +129,11 @@ const algoliaClient = algoliasearch(
 
 const searchClient = {
   async search(requests) {
-    // eslint-disable-next-line no-console
-    console.log(
-      "change conditional if any of the other facets are faked",
-      requests
-    );
+    // change conditional if any of the other facets are faked"
     if (requests.every(({ params: { query } }) => Boolean(query) === false)) {
       return {
         results: requests.map(params => {
-          // eslint-disable-next-line no-console
-          console.log("fake something of the result if necessary", params);
+          // fake something of the result if used by the search interface
           return {
             processingTimeMS: 0,
             nbHits: 0,

--- a/docs/src/advanced/conditional-requests.md
+++ b/docs/src/advanced/conditional-requests.md
@@ -1,5 +1,5 @@
 ---
-title: Conditionally doing search requests
+title: Conditionally making search requests
 mainTitle: Advanced
 layout: main.pug
 category: Advanced

--- a/docs/src/advanced/conditional-requests.md
+++ b/docs/src/advanced/conditional-requests.md
@@ -11,7 +11,7 @@ githubSource: docs/src/advanced/conditional-requests.md
 
 > NOTE: this guide **has** been updated for v2
 
-InstantSearch will do a requests to Algolia servers on every key stroke, which means that it's fast and users will see updated results instantly. This also means that a request is being done to show the initial results on an empty query. While this usually isn't an issue and even a feature, since it warms up the network connection so subsequent requests will be done faster too.
+InstantSearch sends a request to Algolia servers on every keystroke, which means that it's fast and users will see updated results instantly. A request is also sent to show the initial results on an empty query. This is the original behavior since it warms up the network connection so subsequent requests will be done faster too.
 
 However, there are cases in which you do not want to do extra network requests than strictly necessary, for example when you are using a custom backend, or when the initial results are never displayed.
 


### PR DESCRIPTION
This is the most correct way of preventing initial search, both in InstantSearch v1 and v2

fixes no specific open issue, but people have been asking this capability time and time again.

IFW-220