### PR TITLE
chore(stories): move RefinementList example on brand

### DIFF
--- a/stories/RefinementList.stories.js
+++ b/stories/RefinementList.stories.js
@@ -5,13 +5,13 @@ storiesOf('ais-refinement-list', module)
   .addDecorator(previewWrapper({ filters: '' }))
   .add('default', () => ({
     template: `
-      <ais-refinement-list attribute="categories" />
+      <ais-refinement-list attribute="brand" />
     `,
   }))
   .add('with searchbox', () => ({
     template: `
       <ais-refinement-list
-        attribute="categories"
+        attribute="brand"
         searchable
       />
     `,
@@ -19,7 +19,7 @@ storiesOf('ais-refinement-list', module)
   .add('with show more', () => ({
     template: `
       <ais-refinement-list
-        attribute="categories"
+        attribute="brand"
         show-more
       />
     `,
@@ -27,7 +27,7 @@ storiesOf('ais-refinement-list', module)
   .add('with transform items', () => ({
     template: `
       <ais-refinement-list
-        attribute="categories"
+        attribute="brand"
         :transform-items="transformItems"
       />
     `,
@@ -43,7 +43,7 @@ storiesOf('ais-refinement-list', module)
   }))
   .add('item custom rendering', () => ({
     template: `
-    <ais-refinement-list attribute="categories">
+    <ais-refinement-list attribute="brand">
       <template slot="item" slot-scope="{item, refine}">
         <button
           @click="refine(item.value)"
@@ -55,7 +55,7 @@ storiesOf('ais-refinement-list', module)
   }))
   .add('full custom rendering', () => ({
     template: `
-    <ais-refinement-list attribute="categories" searchable show-more>
+    <ais-refinement-list attribute="brand" searchable show-more>
       <template slot-scope="{
         items,
         refine,

--- a/stories/RefinementList.stories.js
+++ b/stories/RefinementList.stories.js
@@ -4,23 +4,25 @@ import { previewWrapper } from './utils';
 storiesOf('ais-refinement-list', module)
   .addDecorator(previewWrapper({ filters: '' }))
   .add('default', () => ({
-    template: `<ais-refinement-list attribute="categories"></ais-refinement-list>`,
+    template: `
+      <ais-refinement-list attribute="categories" />
+    `,
   }))
   .add('with searchbox', () => ({
     template: `
       <ais-refinement-list
         attribute="categories"
         searchable
-      >
-      </ais-refinement-list>`,
+      />
+    `,
   }))
   .add('with show more', () => ({
     template: `
       <ais-refinement-list
         attribute="categories"
         show-more
-      >
-      </ais-refinement-list>`,
+      />
+    `,
   }))
   .add('with transform items', () => ({
     template: `


### PR DESCRIPTION
The searchable RefinementList was not working because the `categories` attribute is not searchable. I've updated all the stories to `brand` (which is searchable) for consistencies accross the stories of this widget.