### PR TITLE
chore(stories): avoid classnames conflict for container

### DIFF
--- a/.storybook/styles.css
+++ b/.storybook/styles.css
@@ -5,12 +5,12 @@ body {
   margin: 10px;
 }
 
-.container {
+.vis-container {
   position: relative;
   padding: 50px 40px 40px;
 }
 
-.container::after {
+.vis-container::after {
   font-size: 13px;
   top: 0;
   left: 0;
@@ -23,12 +23,12 @@ body {
   border-width: 0 1px 1px 0;
 }
 
-.container-preview {
+.vis-container-preview {
   border: solid 1px #e4e4e4;
   border-radius: 5px 5px 0px 0px;
 }
 
-.container-preview::after {
+.vis-container-preview::after {
   content: 'Preview';
   border-radius: 4px 0 0;
 }
@@ -37,14 +37,14 @@ body {
   margin-bottom: 10px;
 }
 
-.container-playground {
+.vis-container-playground {
   border-left: solid 1px #e4e4e4;
   border-right: solid 1px #e4e4e4;
   border-bottom: solid 1px #e4e4e4;
   display: flex;
 }
 
-.container-playground::after {
+.vis-container-playground::after {
   content: 'Playground';
 }
 

--- a/stories/utils.js
+++ b/stories/utils.js
@@ -37,11 +37,11 @@ export const previewWrapper = ({
       index-name="${indexName}"
     >
       <ais-configure :hitsPerPage="3" />
-      <div class="container container-preview">
+      <div class="vis-container vis-container-preview">
         <story />
       </div>
 
-      <div class="container container-playground">
+      <div class="vis-container vis-container-playground">
         <div class="panel-left">
           ${filters}
         </div>


### PR DESCRIPTION
Avoid a conflict with the classname of Storybook.

**Before**:

![screenshot 2018-11-13 at 18 22 12](https://user-images.githubusercontent.com/6513513/48431056-1128b000-e771-11e8-995d-ab023e005bf9.png)

**After**:

![screenshot 2018-11-13 at 18 21 27](https://user-images.githubusercontent.com/6513513/48431064-1554cd80-e771-11e8-9198-8560cea40ccd.png)
