### PR TITLE
feat(MenuSelect): use a slot for "all"

### DIFF
--- a/docs/src/components/MenuSelect.md
+++ b/docs/src/components/MenuSelect.md
@@ -35,7 +35,7 @@ Name | Scope | Description
 ---|---|---
 default | `{ items: Array<{label: String, value: String}>, canRefine: Boolean, refine: String => void, createURL: () => String }` | Slot to override the DOM output
 item | `{ item: {label: String, value: String} }` | Slot to override the content of the `<option>`. Make sure to use a `<template>` tag as root here, since anything else is invalid DOM.
-all | `{}` | Label for the "no currently selected" optionMake sure to use a `<template>` tag as root here, since anything else is invalid DOM.
+ defaultOption | `{}` | Label for the "no currently selected" optionMake sure to use a `<template>` tag as root here, since anything else is invalid DOM.
 
 ## CSS classes
 

--- a/docs/src/components/MenuSelect.md
+++ b/docs/src/components/MenuSelect.md
@@ -25,7 +25,6 @@ Name | Type | Default | Description | Required
 ---|---|---|---|---
 attribute | `string` | | Name of the attribute for faceting. | yes
 limit | `number` | `10` | How many facets values to retrieve. | no
-label | `string` | `All` | Label for the "no currently selected" option | no
 sortBy | `string[]|function` | `['name:asc']` | How to sort refinements. Possible values: `count`, `isRefined`, `name:asc`, `name:desc`. You can also use a sort function that behaves like the standard JavaScript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax). | no
 transformItems | `(items: object[]) => object[]` | `x => x` | Function which receives the items, which will be called before displaying them. Should return a new array with the same shape as the original array. Useful for mapping over the items to transform, remove or reorder them | -
 class-names | Object | `{}` | Override class names | no
@@ -35,7 +34,8 @@ class-names | Object | `{}` | Override class names | no
 Name | Scope | Description
 ---|---|---
 default | `{ items: Array<{label: String, value: String}>, canRefine: Boolean, refine: String => void, createURL: () => String }` | Slot to override the DOM output
-item | `{ item: {label: String, value: String} }` | Slot to override the content of the `<option>`. Make sure to use a `<template>` tag here, since anything else is invalid DOM.
+item | `{ item: {label: String, value: String} }` | Slot to override the content of the `<option>`. Make sure to use a `<template>` tag as root here, since anything else is invalid DOM.
+all | `{}` | Label for the "no currently selected" optionMake sure to use a `<template>` tag as root here, since anything else is invalid DOM.
 
 ## CSS classes
 

--- a/src/components/MenuSelect.vue
+++ b/src/components/MenuSelect.vue
@@ -17,7 +17,7 @@
           :class="suit('option')"
           value=""
         >
-          {{ label }}
+          <slot name="all">See all</slot>
         </option>
         <option
           v-for="item in state.items"
@@ -67,10 +67,6 @@ export default {
       default() {
         return ['name:asc'];
       },
-    },
-    label: {
-      type: String,
-      default: 'See all',
     },
     transformItems: {
       type: Function,

--- a/src/components/MenuSelect.vue
+++ b/src/components/MenuSelect.vue
@@ -17,7 +17,7 @@
           :class="suit('option')"
           value=""
         >
-          <slot name="all">See all</slot>
+          <slot name="defaultOption">See all</slot>
         </option>
         <option
           v-for="item in state.items"

--- a/src/components/__tests__/MenuSelect.js
+++ b/src/components/__tests__/MenuSelect.js
@@ -111,13 +111,17 @@ describe('default render', () => {
 
     const props = {
       ...defaultProps,
-      label: 'None',
     };
 
     const wrapper = mount(MenuSelect, {
       propsData: props,
+      slots: {
+        // tag is needed here for Vue Test Utils, even if it's invalid HTML
+        all: '<span>None</span>',
+      },
     });
 
+    expect(wrapper.find('option').html()).toContain('None');
     expect(wrapper.html()).toMatchSnapshot();
   });
 

--- a/src/components/__tests__/MenuSelect.js
+++ b/src/components/__tests__/MenuSelect.js
@@ -117,7 +117,7 @@ describe('default render', () => {
       propsData: props,
       slots: {
         // tag is needed here for Vue Test Utils, even if it's invalid HTML
-        all: '<span>None</span>',
+        defaultOption: '<span>None</span>',
       },
     });
 

--- a/src/components/__tests__/__snapshots__/MenuSelect.js.snap
+++ b/src/components/__tests__/__snapshots__/MenuSelect.js.snap
@@ -104,7 +104,9 @@ exports[`default render renders correctly with custom label 1`] = `
     <option value
             class="ais-MenuSelect-option"
     >
-      None
+      <span>
+        None
+      </span>
     </option>
     <option class="ais-MenuSelect-option"
             value="Apple"


### PR DESCRIPTION
This is a breaking change, change from `<ais-menu-select :label="all">` to `<ais-menu-select><template slot="defaultOption">all</template></ais-menu-select>`

closes IFW-333