### PR TITLE
fix(rating-menu): remove nonfunctional min prop

### DIFF
--- a/docs/src/components/RatingMenu.md
+++ b/docs/src/components/RatingMenu.md
@@ -24,7 +24,6 @@ A rating menu is a numeric list of a rating. By default visualized with stars. N
 Name | Type | Default | Description | Required
 ---|---|---|---|---
 attribute | string |  | The attribute to use for the rating | yes
-min | number | `1` | minimum rating to show | no
 max | number | `5` | maximum rating to show | no
 class-names | Object | `{}` | Override class names | no
 

--- a/src/components/RatingMenu.vue
+++ b/src/components/RatingMenu.vue
@@ -98,10 +98,6 @@ export default {
       type: String,
       required: true,
     },
-    min: {
-      type: Number,
-      default: 1,
-    },
     max: {
       type: Number,
       default: 5,
@@ -111,7 +107,6 @@ export default {
     widgetParams() {
       return {
         attributeName: this.attribute,
-        min: this.min,
         max: this.max,
       };
     },


### PR DESCRIPTION
This isn't a breaking change, since it wasn't functional, but I've mentioned it in the changelog