### PR TITLE
fix(components): remove faulty whitespace

### DIFF
--- a/src/components/Breadcrumb.vue
+++ b/src/components/Breadcrumb.vue
@@ -39,12 +39,8 @@
             :href="state.createURL(item.value)"
             :class="suit('link')"
             @click.prevent="state.refine(item.value)"
-          >
-            {{ item.name }}
-          </a>
-          <span v-else>
-            {{ item.name }}
-          </span>
+          >{{ item.name }}</a>
+          <span v-else>{{ item.name }}</span>
         </li>
       </ul>
     </slot>

--- a/src/components/ClearRefinements.vue
+++ b/src/components/ClearRefinements.vue
@@ -14,9 +14,7 @@
         :disabled="!canRefine"
         @click.prevent="state.refine"
       >
-        <slot name="resetLabel">
-          Clear refinements
-        </slot>
+        <slot name="resetLabel">Clear refinements</slot>
       </button>
     </slot>
   </div>

--- a/src/components/HierarchicalMenu.vue
+++ b/src/components/HierarchicalMenu.vue
@@ -32,9 +32,7 @@
         <slot
           name="showMoreLabel"
           :is-showing-more="isShowingMore"
-        >
-          {{ isShowingMore ? 'Show less' : 'Show more' }}
-        </slot>
+        >{{ isShowingMore ? 'Show less' : 'Show more' }}</slot>
       </button>
     </slot>
   </div>

--- a/src/components/Hits.vue
+++ b/src/components/Hits.vue
@@ -14,9 +14,7 @@
             name="item"
             :item="item"
             :index="itemIndex"
-          >
-            objectID: {{ item.objectID }}, index: {{ itemIndex }}
-          </slot>
+          >objectID: {{ item.objectID }}, index: {{ itemIndex }}</slot>
         </li>
       </ol>
     </slot>

--- a/src/components/HitsPerPage.vue
+++ b/src/components/HitsPerPage.vue
@@ -18,9 +18,7 @@
           :key="item.value"
           :class="suit('option')"
           :value="item.value"
-        >
-          {{ item.label }}
-        </option>
+        >{{ item.label }}</option>
       </select>
     </slot>
   </div>

--- a/src/components/InfiniteHits.vue
+++ b/src/components/InfiniteHits.vue
@@ -19,9 +19,7 @@
             name="item"
             :item="item"
             :index="index"
-          >
-            objectID: {{ item.objectID }}, index: {{ index }}
-          </slot>
+          >objectID: {{ item.objectID }}, index: {{ index }}</slot>
         </li>
       </ol>
 
@@ -35,9 +33,7 @@
           :class="[suit('loadMore'), state.isLastPage && suit('loadMore', 'disabled')]"
           :disabled="state.isLastPage"
           @click="refine"
-        >
-          Show more results
-        </button>
+        >Show more results</button>
       </slot>
     </slot>
   </div>

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -38,9 +38,7 @@
         <slot
           name="showMoreLabel"
           :is-showing-more="state.isShowingMore"
-        >
-          {{ state.isShowingMore ? 'Show less' : 'Show more' }}
-        </slot>
+        >{{ state.isShowingMore ? 'Show less' : 'Show more' }}</slot>
       </button>
     </slot>
   </div>

--- a/src/components/MenuSelect.vue
+++ b/src/components/MenuSelect.vue
@@ -29,9 +29,7 @@
           <slot
             name="item"
             :item="item"
-          >
-            {{ item.label }} ({{ item.count }})
-          </slot>
+          >{{ item.label }} ({{ item.count }})</slot>
         </option>
       </select>
     </slot>

--- a/src/components/NumericMenu.vue
+++ b/src/components/NumericMenu.vue
@@ -24,9 +24,7 @@
               :checked="item.isRefined"
               @change="state.refine($event.target.value)"
             >
-            <span :class="suit('labelText')">
-              {{ item.label }}
-            </span>
+            <span :class="suit('labelText')">{{ item.label }}</span>
           </label>
         </li>
       </ul>

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -40,9 +40,7 @@
               <span
                 :class="suit('link')"
                 aria-label="First"
-              >
-                ‹‹
-              </span>
+              >‹‹</span>
             </template>
           </slot>
         </li>
@@ -66,17 +64,13 @@
                 aria-label="Previous"
                 :href="state.createURL(state.currentRefinement - 1)"
                 @click.prevent="refine(state.currentRefinement - 1)"
-              >
-                ‹
-              </a>
+              >‹</a>
             </template>
             <template v-else>
               <span
                 :class="suit('link')"
                 aria-label="Previous"
-              >
-                ‹
-              </span>
+              >‹</span>
             </template>
           </slot>
         </li>
@@ -101,9 +95,7 @@
               :class="suit('link')"
               :href="state.createURL(page)"
               @click.prevent="refine(page)"
-            >
-              {{ page + 1 }}
-            </a>
+            >{{ page + 1 }}</a>
           </slot>
         </li>
 
@@ -133,9 +125,7 @@
               <span
                 :class="suit('link')"
                 aria-label="Next"
-              >
-                ›
-              </span>
+              >›</span>
             </template>
           </slot>
         </li>
@@ -165,9 +155,7 @@
               <span
                 :class="suit('link')"
                 aria-label="Last"
-              >
-                ››
-              </span>
+              >››</span>
             </template>
           </slot>
         </li>

--- a/src/components/RatingMenu.vue
+++ b/src/components/RatingMenu.vue
@@ -68,9 +68,7 @@
             >
               <slot name="andUp">&amp; Up</slot>
             </span>
-            <span :class="suit('count')">
-              {{ item.count }}
-            </span>
+            <span :class="suit('count')">{{ item.count }}</span>
           </a>
         </li>
       </ul>

--- a/src/components/RefinementList.vue
+++ b/src/components/RefinementList.vue
@@ -87,9 +87,7 @@
         <slot
           name="showMoreLabel"
           :is-showing-more="state.isShowingMore"
-        >
-          Show {{ state.isShowingMore ? 'less' : 'more' }}
-        </slot>
+        >Show {{ state.isShowingMore ? 'less' : 'more' }}</slot>
       </button>
     </slot>
   </div>

--- a/src/components/SortBy.vue
+++ b/src/components/SortBy.vue
@@ -19,9 +19,7 @@
           :class="suit('option')"
           :value="item.value"
           :selected="item.value === state.currentRefinement"
-        >
-          {{ item.label }}
-        </option>
+        >{{ item.label }}</option>
       </select>
     </slot>
   </div>

--- a/src/components/Stats.vue
+++ b/src/components/Stats.vue
@@ -7,9 +7,7 @@
       v-bind="state"
       :results="state.instantSearchInstance.helper.lastResults"
     >
-      <span :class="suit('text')">
-        {{ state.nbHits.toLocaleString() }} results found in {{ state.processingTimeMS.toLocaleString() }}ms
-      </span>
+      <span :class="suit('text')">{{ state.nbHits.toLocaleString() }} results found in {{ state.processingTimeMS.toLocaleString() }}ms</span>
     </slot>
   </div>
 </template>

--- a/src/components/ToggleRefinement.vue
+++ b/src/components/ToggleRefinement.vue
@@ -18,15 +18,11 @@
           :checked="state.value.isRefined"
           @change="state.refine(state.value)"
         >
-        <span :class="suit('labelText')">
-          {{ state.value.name }}
-        </span>
+        <span :class="suit('labelText')">{{ state.value.name }}</span>
         <span
           v-if="state.value.count !== null"
           :class="suit('count')"
-        >
-          {{ state.value.count.toLocaleString() }}
-        </span>
+        >{{ state.value.count.toLocaleString() }}</span>
       </label>
     </slot>
   </div>

--- a/src/mixins/widget.js
+++ b/src/mixins/widget.js
@@ -31,9 +31,7 @@ it's not the recommended way of making custom components.
 
 If you want to disable this message, pass { connector: true } to the mixin.
 
-Read more on using connectors:
-http://alg.li/vue-custom
-`
+Read more on using connectors: http://alg.li/vue-custom`
       );
     }
   },

--- a/src/mixins/widget.js
+++ b/src/mixins/widget.js
@@ -31,7 +31,7 @@ it's not the recommended way of making custom components.
 
 If you want to disable this message, pass { connector: true } to the mixin.
 
-Read more on using connectors: http://alg.li/vue-custom`
+Read more on using connectors: https://alg.li/vue-custom`
       );
     }
   },

--- a/src/mixins/widget.js
+++ b/src/mixins/widget.js
@@ -31,9 +31,9 @@ it's not the recommended way of making custom components.
 
 If you want to disable this message, pass { connector: true } to the mixin.
 
-(TODO: update v2 link)
-Read more on using connectors: https://community.algolia.com/vue-instantsearch/getting-started/custom-components.html
-        `
+Read more on using connectors:
+http://alg.li/vue-custom
+`
       );
     }
   },


### PR DESCRIPTION
If an inline element has whitespace, and then a text node, Vue will preserve this whitespace inside the component, and thus it will take up bundle size (a tiny little bit)