### PR TITLE
More clearly clarify how to use URL Synchronization

### DIFF
--- a/docs/src/advanced/url-sync.md
+++ b/docs/src/advanced/url-sync.md
@@ -1,19 +1,19 @@
 ---
-title: Synchronize with Vue Router
+title: URL Synchronization
 mainTitle: Advanced
 layout: main.pug
 category: Advanced
 withHeadings: true
 navWeight: 3
 editable: true
-githubSource: docs/src/advanced/vue-router-url-sync.md
+githubSource: docs/src/advanced/url-sync.md
 ---
 
 > NOTE: this guide **has** been updated for v2
 
 
 
-The `routing` prop on `ais-instant-search` accepts an object. The simplest way to get started without customising URLs at all is the following:
+The `routing` prop on `ais-instant-search` accepts an object. The simplest way to get started synchronizing search state to the URL, without customising URLs, is through the following:
 
 ```vue
 <template>
@@ -41,10 +41,12 @@ export default {
 </script>
 ```
 
-They're routing object contains two keys: `history` and `stateMapping`:
+The routing object contains two keys: `history` and `stateMapping`:
 
 - **history**: used for writing and reading to the URL,
 - **stateMapping**: used for mapping the InstantSearch state towards the state that will be read and written to the URL.
+
+# Customising URL Synchronization
 
 If you want to customise which things are written in the URL but don't want to customise how exactly the URL looks you will use state mapping. The way to do this is replacing the call to `stateMapping` with an object with the functions `stateToRoute` and `routeToState`.
 

--- a/docs/src/advanced/url-sync.md
+++ b/docs/src/advanced/url-sync.md
@@ -46,7 +46,7 @@ The routing object contains two keys: `history` and `stateMapping`:
 - **history**: used for writing and reading to the URL,
 - **stateMapping**: used for mapping the InstantSearch state towards the state that will be read and written to the URL.
 
-# Customising URL Synchronization
+## Customising URL Synchronization
 
 If you want to customise which things are written in the URL but don't want to customise how exactly the URL looks you will use state mapping. The way to do this is replacing the call to `stateMapping` with an object with the functions `stateToRoute` and `routeToState`.
 


### PR DESCRIPTION
The docs, as they are written and structured currently, suggest that synchornization is only possible with Vue Router.

The proposed changes make this more generic both in the navigation menu and in the documentation itself.

Out of the box, if you just create a `routing` object with `historyRouter()` and `simpleMapping()` then this will work whether you are using Vue Router or not.

I've then separated the section with a heading for times when you may want to customise this functionality (including use with Vue Router).