### PR TITLE
docs(website): redirect Netlify website to Algolia

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -1,0 +1,1 @@
+/ https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/vue/

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "babel-node start.js",
-    "build:dev": "babel-node build.js && cd .. && yarn storybook:build && yarn examples:build",
+    "build:dev": "babel-node build.js && (cd .. && yarn storybook:build && yarn examples:build) && cp _redirects ./dist/",
     "build": "NODE_ENV='production' babel-node build.js && cd .. && yarn storybook:build && yarn examples:build",
     "deploy": "yarn run build && gh-pages -d dist"
   },


### PR DESCRIPTION
This redirects the Vue InstantSearch Netlify website index page to the Algolia documentation website.

I just copied the Netlify `_redirects` file to the website `dist/` folder during the build process. This should be enough for now since we'll get rid of the docgen website.