### PR TITLE
docs(v1): add redirect to root & noindex to rest

### DIFF
--- a/docs/layouts/common/meta.pug
+++ b/docs/layouts/common/meta.pug
@@ -35,4 +35,6 @@ html(lang='en')
     link(rel="stylesheet", href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css")
     link(rel="stylesheet", href="//cdn.jsdelivr.net/npm/instantsearch.js@2.0.0-beta.1/dist/instantsearch.min.css")
 
+    meta(name="robots", content="noindex, nofollow")
+
   block body

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "scripts": {
     "dev": "babel-node start.js",
-    "build:dev": "babel-node build.js && cd .. && yarn storybook:build",
-    "build": "NODE_ENV='production' babel-node build.js && cd .. && yarn storybook:build",
+    "build:dev": "babel-node build.js && (cd .. && yarn storybook:build) && cp src/_redirects docs",
+    "build": "NODE_ENV='production' babel-node build.js && (cd .. && yarn storybook:build) && cp src/_redirects docs",
     "deploy": "yarn run build && gh-pages -d dist"
   },
   "dependencies": {

--- a/docs/src/_redirects
+++ b/docs/src/_redirects
@@ -1,0 +1,1 @@
+/ https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/vue/


### PR DESCRIPTION
depends on https://github.com/algolia/doc/pull/2662 to be released first

This doesn't need to be put on gh-pages, since it will be replaced by netlify