### PR TITLE
docs(v2): add noindex to docs

### DIFF
--- a/docs/layouts/common/meta.pug
+++ b/docs/layouts/common/meta.pug
@@ -34,5 +34,7 @@ html(lang='en')
     link(rel='stylesheet', href="stylesheets/style.css?v=114")
     link(rel="stylesheet", href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css")
     link(rel="stylesheet", href="//cdn.jsdelivr.net/npm/instantsearch.js@2.0.0-beta.1/dist/instantsearch.min.css")
+    
+    meta(name="robots", content="noindex, nofollow")
 
   block body


### PR DESCRIPTION
This is fine, since v2 docs aren't commonly used and not indexed in Google yet anyway