### PR TITLE
fix(umd): prevent inclusion of Vue in bundle

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -47,6 +47,7 @@ export default [
   },
   {
     input: 'src/instantsearch.umd.js',
+    external: ['vue'],
     output: [
       {
         file: `dist/vue-instantsearch.js`,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -54,6 +54,9 @@ export default [
         format: 'umd',
         name: 'VueInstantSearch',
         exports: 'named',
+        globals: {
+          vue: 'Vue',
+        },
       },
     ],
     plugins: [

--- a/src/instantsearch.umd.js
+++ b/src/instantsearch.umd.js
@@ -1,8 +1,8 @@
-import InstantSearch from './instantsearch';
+import plugin from './instantsearch';
 
 // Automatically register Algolia Search components if Vue is available globally
 if (typeof window !== 'undefined' && window.Vue) {
-  window.Vue.use(InstantSearch);
+  window.Vue.use(plugin);
 }
 
 export * from './instantsearch';

--- a/src/instantsearch.umd.js
+++ b/src/instantsearch.umd.js
@@ -1,4 +1,4 @@
-import plugin from './instantsearch';
+import { plugin } from './plugin';
 
 // Automatically register Algolia Search components if Vue is available globally
 if (typeof window !== 'undefined' && window.Vue) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,12 +1,11 @@
 /* eslint import/namespace: ['error', { allowComputed: true }]*/
-import Vue from 'vue';
 
 import * as widgets from './widgets';
 
-export const plugin = Object.assign({}, widgets, {
-  install() {
+export const plugin = {
+  install(Vue) {
     Object.keys(widgets).forEach(widgetName => {
       Vue.component(widgets[widgetName].name, widgets[widgetName]);
     });
   },
-});
+};

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -3,9 +3,9 @@
 import * as widgets from './widgets';
 
 export const plugin = {
-  install(Vue) {
+  install(localVue) {
     Object.keys(widgets).forEach(widgetName => {
-      Vue.component(widgets[widgetName].name, widgets[widgetName]);
+      localVue.component(widgets[widgetName].name, widgets[widgetName]);
     });
   },
 };


### PR DESCRIPTION
This is fixed in two spots:

1. add Vue to externals for the UMD (used in Panel)
2. use the Vue object passed to the install function instead of importing it ourselves (in the plugin)

Furthermore this also fixes the plugin which needlessly exposes all widgets (you can already import them easily, since the default export is being put on the window)