### PR TITLE
fix(toggle-refinement): display label

### DIFF
--- a/src/components/ToggleRefinement.vue
+++ b/src/components/ToggleRefinement.vue
@@ -18,7 +18,7 @@
           :checked="state.value.isRefined"
           @change="state.refine(state.value)"
         >
-        <span :class="suit('labelText')">{{ state.value.name }}</span>
+        <span :class="suit('labelText')">{{ label }}</span>
         <span
           v-if="state.value.count !== null"
           :class="suit('count')"

--- a/src/components/__tests__/ToggleRefinement.js
+++ b/src/components/__tests__/ToggleRefinement.js
@@ -6,7 +6,7 @@ jest.mock('../../mixins/widget');
 jest.mock('../../mixins/panel');
 
 const defaultValue = {
-  name: 'Free Shipping',
+  name: 'free_shipping',
   count: 100,
   isRefined: false,
 };

--- a/src/components/__tests__/__snapshots__/ToggleRefinement.js.snap
+++ b/src/components/__tests__/__snapshots__/ToggleRefinement.js.snap
@@ -5,7 +5,7 @@ exports[`custom default render renders correctly 1`] = `
 <div class="ais-ToggleRefinement">
   <a class>
     <span>
-      Free Shipping
+      free_shipping
     </span>
     <span>
       (is disabled)
@@ -22,7 +22,7 @@ exports[`custom default render renders correctly with a URL for the href 1`] = `
      class
   >
     <span>
-      Free Shipping
+      free_shipping
     </span>
     <span>
       (is disabled)
@@ -37,7 +37,7 @@ exports[`custom default render renders correctly with the value selected 1`] = `
 <div class="ais-ToggleRefinement">
   <a class>
     <span>
-      Free Shipping
+      free_shipping
     </span>
     <span>
       (is enabled)
@@ -52,7 +52,7 @@ exports[`custom default render renders correctly without refinement 1`] = `
 <div class="ais-ToggleRefinement ais-ToggleRefinement--noRefinement">
   <a class="noRefinement">
     <span>
-      Free Shipping
+      free_shipping
     </span>
     <span>
       (is disabled)
@@ -67,7 +67,7 @@ exports[`default render renders correctly 1`] = `
 <div class="ais-ToggleRefinement">
   <label class="ais-ToggleRefinement-label">
     <input type="checkbox"
-           name="Free Shipping"
+           name="free_shipping"
            class="ais-ToggleRefinement-checkbox"
            value="true"
     >
@@ -87,7 +87,7 @@ exports[`default render renders correctly without refinement (with 0) 1`] = `
 <div class="ais-ToggleRefinement ais-ToggleRefinement--noRefinement">
   <label class="ais-ToggleRefinement-label">
     <input type="checkbox"
-           name="Free Shipping"
+           name="free_shipping"
            class="ais-ToggleRefinement-checkbox"
            value="true"
     >
@@ -107,7 +107,7 @@ exports[`default render renders correctly without refinement (with null) 1`] = `
 <div class="ais-ToggleRefinement ais-ToggleRefinement--noRefinement">
   <label class="ais-ToggleRefinement-label">
     <input type="checkbox"
-           name="Free Shipping"
+           name="free_shipping"
            class="ais-ToggleRefinement-checkbox"
            value="true"
     >


### PR DESCRIPTION
The required `label` of the [`ais-toggle-refinement`](https://www.algolia.com/doc/api-reference/widgets/toggle-refinement/vue/) widget was not used in the template, thus ignored. The [deployed story](https://vue-instantsearch.netlify.com/stories/?selectedKind=ais-toggle-refinement&selectedStory=default) should display "Free shipping" but displays the attribute name "free_shipping".

This issue was reported by a user.