### PR TITLE
feat(infiniteHits): add previous button

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "eslint-plugin-jest": "22.3.0",
     "eslint-plugin-prettier": "3.0.0",
     "eslint-plugin-vue": "4.7.1",
-    "instantsearch.css": "7.1.1",
+    "instantsearch.css": "7.3.1",
     "jest": "23.6.0",
     "jest-serializer-html": "6.0.0",
     "jest-vue-preprocessor": "1.4.0",

--- a/src/components/InfiniteHits.vue
+++ b/src/components/InfiniteHits.vue
@@ -3,11 +3,28 @@
     v-if="state"
     :class="suit()"
   >
+
+    <slot
+      v-if="state.widgetParams.showPrevious"
+      name="loadPrevious"
+      :refinePrevious="refinePrevious"
+      :page="state.results.page"
+      :is-first-page="state.isFirstPage"
+    >
+      <button
+        :class="[suit('loadPrevious'), state.isFirstPage && suit('loadPrevious', 'disabled')]"
+        :disabled="state.isFirstPage"
+        @click="refinePrevious()"
+      >Show previous results</button>
+    </slot>
+
     <slot
       :items="items"
       :results="state.results"
       :is-last-page="state.isLastPage"
-      :refine="refine"
+      :refinePrevious="refinePrevious"
+      :refineNext="refineNext"
+      :refine="refineNext"
     >
       <ol :class="suit('list')">
         <li
@@ -25,14 +42,15 @@
 
       <slot
         name="loadMore"
-        :refine="refine"
+        :refineNext="refineNext"
+        :refine="refineNext"
         :page="state.results.page"
         :is-last-page="state.isLastPage"
       >
         <button
           :class="[suit('loadMore'), state.isLastPage && suit('loadMore', 'disabled')]"
           :disabled="state.isLastPage"
-          @click="refine"
+          @click="refineNext()"
         >Show more results</button>
       </slot>
     </slot>
@@ -51,6 +69,10 @@ export default {
     createSuitMixin({ name: 'InfiniteHits' }),
   ],
   props: {
+    showPrevious: {
+      type: Boolean,
+      default: false,
+    },
     escapeHTML: {
       type: Boolean,
       default: true,
@@ -65,6 +87,7 @@ export default {
   computed: {
     widgetParams() {
       return {
+        showPrevious: this.showPrevious,
         escapeHTML: this.escapeHTML,
         transformItems: this.transformItems,
       };
@@ -76,9 +99,12 @@ export default {
     },
   },
   methods: {
-    refine() {
-      // Fixes InstantSearch.js connectors API: every function
-      // that trigger a search must be called `refine`
+    // Fixes InstantSearch.js connectors API: every function
+    // that trigger a search must be called `refine`
+    refinePrevious() {
+      this.state.showPrevious();
+    },
+    refineNext() {
       this.state.showMore();
     },
   },

--- a/src/components/InfiniteHits.vue
+++ b/src/components/InfiniteHits.vue
@@ -22,7 +22,7 @@
       :items="items"
       :results="state.results"
       :is-last-page="state.isLastPage"
-      :refinePrevious="refinePrevious"
+      :refine-previous="refinePrevious"
       :refineNext="refineNext"
       :refine="refineNext"
     >

--- a/src/components/InfiniteHits.vue
+++ b/src/components/InfiniteHits.vue
@@ -99,8 +99,6 @@ export default {
     },
   },
   methods: {
-    // Fixes InstantSearch.js connectors API: every function
-    // that trigger a search must be called `refine`
     refinePrevious() {
       this.state.showPrevious();
     },

--- a/src/components/InfiniteHits.vue
+++ b/src/components/InfiniteHits.vue
@@ -42,7 +42,7 @@
 
       <slot
         name="loadMore"
-        :refineNext="refineNext"
+        :refine-next="refineNext"
         :refine="refineNext"
         :page="state.results.page"
         :is-last-page="state.isLastPage"

--- a/src/components/InfiniteHits.vue
+++ b/src/components/InfiniteHits.vue
@@ -5,7 +5,7 @@
   >
 
     <slot
-      v-if="state.widgetParams.showPrevious"
+      v-if="showPrevious"
       name="loadPrevious"
       :refinePrevious="refinePrevious"
       :page="state.results.page"

--- a/src/components/InfiniteHits.vue
+++ b/src/components/InfiniteHits.vue
@@ -7,7 +7,7 @@
     <slot
       v-if="showPrevious"
       name="loadPrevious"
-      :refinePrevious="refinePrevious"
+      :refine-previous="refinePrevious"
       :page="state.results.page"
       :is-first-page="state.isFirstPage"
     >

--- a/src/components/InfiniteHits.vue
+++ b/src/components/InfiniteHits.vue
@@ -23,7 +23,7 @@
       :results="state.results"
       :is-last-page="state.isLastPage"
       :refine-previous="refinePrevious"
-      :refineNext="refineNext"
+      :refine-next="refineNext"
       :refine="refineNext"
     >
       <ol :class="suit('list')">

--- a/src/components/__tests__/InfiniteHits.js
+++ b/src/components/__tests__/InfiniteHits.js
@@ -154,6 +154,22 @@ it('renders correctly on the last page', () => {
   expect(wrapper.html()).toMatchSnapshot();
 });
 
+it('renders correctly when not on the first page', () => {
+  __setState({
+    ...defaultState,
+    isFirstPage: false,
+    isLastPage: false,
+  });
+
+  const wrapper = mount(InfiniteHits, {
+    propsData: {
+      showPrevious: true,
+    },
+  });
+
+  expect(wrapper.html()).toMatchSnapshot();
+});
+
 it('expect to call showPrevious on click', () => {
   const showPrevious = jest.fn();
 

--- a/src/components/__tests__/InfiniteHits.js
+++ b/src/components/__tests__/InfiniteHits.js
@@ -168,7 +168,7 @@ it('expect to call showPrevious on click', () => {
 
   const wrapper = mount(InfiniteHits);
 
-  expect(showPrevious).not.toHaveBeenCalled();
+  expect(showPrevious).toHaveBeenCalledTimes(0);
 
   wrapper.find('.ais-InfiniteHits-loadPrevious').trigger('click');
 

--- a/src/components/__tests__/InfiniteHits.js
+++ b/src/components/__tests__/InfiniteHits.js
@@ -5,6 +5,11 @@ import InfiniteHits from '../InfiniteHits.vue';
 jest.mock('../../mixins/widget');
 
 const defaultState = {
+  widgetParams: {
+    showPrevious: false,
+    escapeHTML: true,
+    transformItems: items => items,
+  },
   hits: [
     {
       objectID: '00001',
@@ -25,8 +30,10 @@ const defaultState = {
   results: {
     page: 0,
   },
+  isFirstPage: false,
   isLastPage: false,
   showMore: () => {},
+  showPrevious: () => {},
 };
 
 it('accepts a escapeHTML prop', () => {
@@ -57,6 +64,20 @@ it('accepts a transformItems prop', () => {
   });
 
   expect(wrapper.vm.widgetParams.transformItems).toBe(transformItems);
+});
+
+it('accepts a showPrevious prop', () => {
+  __setState({
+    ...defaultState,
+  });
+
+  const wrapper = mount(InfiniteHits, {
+    propsData: {
+      showPrevious: true,
+    },
+  });
+
+  expect(wrapper.vm.widgetParams.showPrevious).toBe(true);
 });
 
 it('renders correctly', () => {
@@ -107,6 +128,21 @@ it('renders correctly with a custom item rendering', () => {
   expect(wrapper.html()).toMatchSnapshot();
 });
 
+it('renders correctly on the first page', () => {
+  __setState({
+    ...defaultState,
+    widgetParams: {
+      ...defaultState.widgetParams,
+      showPrevious: true,
+    },
+    isFirstPage: true,
+  });
+
+  const wrapper = mount(InfiniteHits);
+
+  expect(wrapper.html()).toMatchSnapshot();
+});
+
 it('renders correctly on the last page', () => {
   __setState({
     ...defaultState,
@@ -116,6 +152,27 @@ it('renders correctly on the last page', () => {
   const wrapper = mount(InfiniteHits);
 
   expect(wrapper.html()).toMatchSnapshot();
+});
+
+it('expect to call showPrevious on click', () => {
+  const showPrevious = jest.fn();
+
+  __setState({
+    ...defaultState,
+    widgetParams: {
+      ...defaultState.widgetParams,
+      showPrevious: true,
+    },
+    showPrevious,
+  });
+
+  const wrapper = mount(InfiniteHits);
+
+  expect(showPrevious).not.toHaveBeenCalled();
+
+  wrapper.find('.ais-InfiniteHits-loadPrevious').trigger('click');
+
+  expect(showPrevious).toHaveBeenCalled();
 });
 
 it('expect to call showMore on click', () => {

--- a/src/components/__tests__/InfiniteHits.js
+++ b/src/components/__tests__/InfiniteHits.js
@@ -131,14 +131,14 @@ it('renders correctly with a custom item rendering', () => {
 it('renders correctly on the first page', () => {
   __setState({
     ...defaultState,
-    widgetParams: {
-      ...defaultState.widgetParams,
-      showPrevious: true,
-    },
     isFirstPage: true,
   });
 
-  const wrapper = mount(InfiniteHits);
+  const wrapper = mount(InfiniteHits, {
+    propsData: {
+      showPrevious: true,
+    },
+  });
 
   expect(wrapper.html()).toMatchSnapshot();
 });
@@ -159,14 +159,14 @@ it('expect to call showPrevious on click', () => {
 
   __setState({
     ...defaultState,
-    widgetParams: {
-      ...defaultState.widgetParams,
-      showPrevious: true,
-    },
     showPrevious,
   });
 
-  const wrapper = mount(InfiniteHits);
+  const wrapper = mount(InfiniteHits, {
+    propsData: {
+      showPrevious: true,
+    },
+  });
 
   expect(showPrevious).toHaveBeenCalledTimes(0);
 

--- a/src/components/__tests__/InfiniteHits.js
+++ b/src/components/__tests__/InfiniteHits.js
@@ -172,7 +172,7 @@ it('expect to call showPrevious on click', () => {
 
   wrapper.find('.ais-InfiniteHits-loadPrevious').trigger('click');
 
-  expect(showPrevious).toHaveBeenCalled();
+  expect(showPrevious).toHaveBeenCalledTimes(1);
 });
 
 it('expect to call showMore on click', () => {

--- a/src/components/__tests__/InfiniteHits.js
+++ b/src/components/__tests__/InfiniteHits.js
@@ -140,6 +140,13 @@ it('renders correctly on the first page', () => {
     },
   });
 
+  const previousButton = wrapper.find('.ais-InfiniteHits-loadPrevious');
+
+  expect(previousButton.exists()).toEqual(true);
+  expect(
+    previousButton.classes('ais-InfiniteHits-loadPrevious--disabled')
+  ).toEqual(true);
+  expect(previousButton.attributes('disabled')).toEqual('disabled');
   expect(wrapper.html()).toMatchSnapshot();
 });
 
@@ -167,6 +174,13 @@ it('renders correctly when not on the first page', () => {
     },
   });
 
+  const previousButton = wrapper.find('.ais-InfiniteHits-loadPrevious');
+
+  expect(previousButton.exists()).toEqual(true);
+  expect(
+    previousButton.classes('ais-InfiniteHits-loadPrevious--disabled')
+  ).toEqual(false);
+  expect(previousButton.attributes('disabled')).toEqual(undefined);
   expect(wrapper.html()).toMatchSnapshot();
 });
 

--- a/src/components/__tests__/__snapshots__/InfiniteHits.js.snap
+++ b/src/components/__tests__/__snapshots__/InfiniteHits.js.snap
@@ -27,6 +27,38 @@ exports[`renders correctly 1`] = `
 
 `;
 
+exports[`renders correctly on the first page 1`] = `
+
+<div class="ais-InfiniteHits">
+  <button disabled="disabled"
+          class="ais-InfiniteHits-loadPrevious ais-InfiniteHits-loadPrevious--disabled"
+  >
+    Show previous results
+  </button>
+  <ol class="ais-InfiniteHits-list">
+    <li class="ais-InfiniteHits-item">
+      objectID: 00001, index: 0
+    </li>
+    <li class="ais-InfiniteHits-item">
+      objectID: 00002, index: 1
+    </li>
+    <li class="ais-InfiniteHits-item">
+      objectID: 00003, index: 2
+    </li>
+    <li class="ais-InfiniteHits-item">
+      objectID: 00004, index: 3
+    </li>
+    <li class="ais-InfiniteHits-item">
+      objectID: 00005, index: 4
+    </li>
+  </ol>
+  <button class="ais-InfiniteHits-loadMore">
+    Show more results
+  </button>
+</div>
+
+`;
+
 exports[`renders correctly on the last page 1`] = `
 
 <div class="ais-InfiniteHits">

--- a/src/components/__tests__/__snapshots__/InfiniteHits.js.snap
+++ b/src/components/__tests__/__snapshots__/InfiniteHits.js.snap
@@ -88,6 +88,36 @@ exports[`renders correctly on the last page 1`] = `
 
 `;
 
+exports[`renders correctly when not on the first page 1`] = `
+
+<div class="ais-InfiniteHits">
+  <button class="ais-InfiniteHits-loadPrevious">
+    Show previous results
+  </button>
+  <ol class="ais-InfiniteHits-list">
+    <li class="ais-InfiniteHits-item">
+      objectID: 00001, index: 0
+    </li>
+    <li class="ais-InfiniteHits-item">
+      objectID: 00002, index: 1
+    </li>
+    <li class="ais-InfiniteHits-item">
+      objectID: 00003, index: 2
+    </li>
+    <li class="ais-InfiniteHits-item">
+      objectID: 00004, index: 3
+    </li>
+    <li class="ais-InfiniteHits-item">
+      objectID: 00005, index: 4
+    </li>
+  </ol>
+  <button class="ais-InfiniteHits-loadMore">
+    Show more results
+  </button>
+</div>
+
+`;
+
 exports[`renders correctly with a custom item rendering 1`] = `
 
 <div class="ais-InfiniteHits">

--- a/stories/InfiniteHits.stories.js
+++ b/stories/InfiniteHits.stories.js
@@ -103,7 +103,7 @@ storiesOf('ais-infinite-hits', module)
   }))
   .add('with a custom show previous render', () => ({
     template: `
-      <ais-infinite-hits :show-previous=true>
+      <ais-infinite-hits :show-previous="true">
         <div slot="loadPrevious" slot-scope="{ refinePrevious, isFirstPage }">
           <button
             :disabled="isFirstPage"

--- a/stories/InfiniteHits.stories.js
+++ b/stories/InfiniteHits.stories.js
@@ -89,12 +89,14 @@ storiesOf('ais-infinite-hits', module)
   }));
 
 storiesOf('ais-infinite-hits', module)
-  .addDecorator(previewWrapper({
-    routing: {
-      router: new MemoryRouter({page: 3}),
-      stateMapping: simple()
-    },
-  }))
+  .addDecorator(
+    previewWrapper({
+      routing: {
+        router: new MemoryRouter({ page: 3 }),
+        stateMapping: simple(),
+      },
+    })
+  )
   .add('with show previous enabled', () => ({
     template: `
       <ais-infinite-hits :show-previous=true></ais-infinite-hits>`,

--- a/stories/InfiniteHits.stories.js
+++ b/stories/InfiniteHits.stories.js
@@ -99,7 +99,7 @@ storiesOf('ais-infinite-hits', module)
   )
   .add('with show previous enabled', () => ({
     template: `
-      <ais-infinite-hits :show-previous=true></ais-infinite-hits>`,
+      <ais-infinite-hits :show-previous="true"></ais-infinite-hits>`,
   }))
   .add('with a custom show previous render', () => ({
     template: `

--- a/stories/InfiniteHits.stories.js
+++ b/stories/InfiniteHits.stories.js
@@ -1,5 +1,7 @@
 import { storiesOf } from '@storybook/vue';
 import { previewWrapper } from './utils';
+import { MemoryRouter } from './MemoryRouter';
+import { simple } from 'instantsearch.js/es/lib/stateMappings';
 
 storiesOf('ais-infinite-hits', module)
   .addDecorator(previewWrapper())
@@ -84,4 +86,29 @@ storiesOf('ais-infinite-hits', module)
         <template slot="footer">Footer</template>
       </ais-panel>
     `,
+  }));
+
+storiesOf('ais-infinite-hits', module)
+  .addDecorator(previewWrapper({
+    routing: {
+      router: new MemoryRouter({page: 3}),
+      stateMapping: simple()
+    },
+  }))
+  .add('with show previous enabled', () => ({
+    template: `
+      <ais-infinite-hits :show-previous=true></ais-infinite-hits>`,
+  }))
+  .add('with a custom show previous render', () => ({
+    template: `
+      <ais-infinite-hits :show-previous=true>
+        <div slot="loadPrevious" slot-scope="{ refinePrevious, page, isFirstPage }">
+          <button
+            :disabled="isFirstPage"
+            @click="refinePrevious"
+          >
+            Gimme {{ isFirstPage ? "nothing anymore" : "previous page" }}!
+          </button>
+        </div>
+      </ais-infinite-hits>`,
   }));

--- a/stories/InfiniteHits.stories.js
+++ b/stories/InfiniteHits.stories.js
@@ -100,7 +100,17 @@ storiesOf('ais-infinite-hits', module)
   .add('with show previous enabled', () => ({
     template: `
       <ais-infinite-hits :show-previous="true"></ais-infinite-hits>`,
-  }))
+  }));
+
+storiesOf('ais-infinite-hits', module)
+  .addDecorator(
+    previewWrapper({
+      routing: {
+        router: new MemoryRouter({ page: 3 }),
+        stateMapping: simple(),
+      },
+    })
+  )
   .add('with a custom show previous render', () => ({
     template: `
       <ais-infinite-hits :show-previous="true">

--- a/stories/InfiniteHits.stories.js
+++ b/stories/InfiniteHits.stories.js
@@ -104,7 +104,7 @@ storiesOf('ais-infinite-hits', module)
   .add('with a custom show previous render', () => ({
     template: `
       <ais-infinite-hits :show-previous=true>
-        <div slot="loadPrevious" slot-scope="{ refinePrevious, page, isFirstPage }">
+        <div slot="loadPrevious" slot-scope="{ refinePrevious, isFirstPage }">
           <button
             :disabled="isFirstPage"
             @click="refinePrevious"

--- a/stories/MemoryRouter.js
+++ b/stories/MemoryRouter.js
@@ -1,0 +1,18 @@
+export class MemoryRouter {
+  constructor(initialState = {}) {
+    this._memoryState = initialState;
+  }
+  write(routeState) {
+    this._memoryState = routeState;
+  }
+  read() {
+    return this._memoryState;
+  }
+  createURL() {
+    return '';
+  }
+  onUpdate() {
+    return {};
+  }
+  dispose() {}
+}

--- a/stories/MemoryRouter.js
+++ b/stories/MemoryRouter.js
@@ -14,7 +14,5 @@ export class MemoryRouter {
   onUpdate() {
     return {};
   }
-  dispose() {
-    this._memoryState = {};
-  }
+  dispose() {}
 }

--- a/stories/MemoryRouter.js
+++ b/stories/MemoryRouter.js
@@ -14,5 +14,7 @@ export class MemoryRouter {
   onUpdate() {
     return {};
   }
-  dispose() {}
+  dispose() {
+    this._memoryState = {};
+  }
 }

--- a/stories/utils.js
+++ b/stories/utils.js
@@ -31,11 +31,13 @@ export const previewWrapper = ({
     <ais-refinement-list attribute="brand" />
     <ais-configure :hitsPerPage="3" />
   `,
+  routing
 } = {}) => () => ({
   template: `
     <ais-instant-search
       :search-client="searchClient"
       index-name="${indexName}"
+      :routing="routing"
     >
       <div class="vis-container vis-container-preview">
         <story />
@@ -59,6 +61,7 @@ export const previewWrapper = ({
   data() {
     return {
       searchClient,
+      routing
     };
   },
 });

--- a/stories/utils.js
+++ b/stories/utils.js
@@ -31,7 +31,7 @@ export const previewWrapper = ({
     <ais-refinement-list attribute="brand" />
     <ais-configure :hitsPerPage="3" />
   `,
-  routing
+  routing,
 } = {}) => () => ({
   template: `
     <ais-instant-search
@@ -61,7 +61,7 @@ export const previewWrapper = ({
   data() {
     return {
       searchClient,
-      routing
+      routing,
     };
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5880,10 +5880,10 @@ insert-css@^2.0.0:
   resolved "https://registry.yarnpkg.com/insert-css/-/insert-css-2.0.0.tgz#eb5d1097b7542f4c79ea3060d3aee07d053880f4"
   integrity sha1-610Ql7dUL0x56jBg067gfQU4gPQ=
 
-instantsearch.css@7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.1.1.tgz#64fa9f07ff39ab088b00cd3f0fa3ea697d2215f7"
-  integrity sha512-8+2FLbZk9uK+VRFJ4tXByMNX9KTsPOrY/nkw4oe+8HH+jcHoVMQkUdxbFu7mSUHUdZjh5kK9Xk8IQau1Sy+VKw==
+instantsearch.css@7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.3.1.tgz#7ab74a8f355091ae040947a9cf5438f379026622"
+  integrity sha512-/kaMDna5D+Q9mImNBHEhb9HgHATDOFKYii7N1Iwvrj+lmD9gBJLqVhUw67gftq2O0QI330pFza+CRscIwB1wQQ==
 
 instantsearch.js@^3.4.0:
   version "3.4.0"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

The [InfiniteHits widget](https://www.algolia.com/doc/api-reference/widgets/infinite-hits/vue/) is used to display a list of results with a “Show more” button. The user can click on this button to display more results without leaving its current page context.

Each time the user click on the “Show more” button the user will navigate to a new page (provided that [the routing option is enabled in ais-instant-search](https://www.algolia.com/doc/api-reference/widgets/instantsearch/vue/)).

However, in the case the user navigates directly to a particular page (direct link, previous button, page refresh) then the widget only displays the last result page.

This change add a previous button to the Infinite Hits widget to give the possibility to the user to load the previous result pages.

For implementation details see [the full RFC](https://github.com/algolia/instantsearch-rfcs/blob/master/accepted/infinite-hits-previous-page.md).

Before being mergeable, this change requires a new release of https://github.com/algolia/instantsearch.js with the previous button feature:

* [x] Merge https://github.com/algolia/instantsearch.js/pull/3675
* [x] Publish new `instantsearch.js` release
* [x] Update `vue-instantsearch` dependencies to use the new `instantsearch.js` release

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

Some "with previous button enabled" and "with a custom show previous render" stories were added for the Instant Hits widget.

https://deploy-preview-659--vue-instantsearch.netlify.com/stories/?selectedKind=ais-infinite-hits&selectedStory=with%20show%20previous%20enabled&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybooks%2Fstorybook-addon-knobs