### PR TITLE
feat(insights): add insights support to InfiniteHits widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   "bundlesize": [
     {
       "path": "./dist/vue-instantsearch.js",
-      "maxSize": "66 kB"
+      "maxSize": "67 kB"
     },
     {
       "path": "./dist/vue-instantsearch.esm.js",

--- a/src/components/InfiniteHits.vue
+++ b/src/components/InfiniteHits.vue
@@ -37,6 +37,7 @@
             name="item"
             :item="item"
             :index="index"
+            :insights="state.insights"
           >objectID: {{ item.objectID }}, index: {{ index }}</slot>
         </li>
       </ol>

--- a/src/components/InfiniteHits.vue
+++ b/src/components/InfiniteHits.vue
@@ -25,6 +25,7 @@
       :refine-previous="refinePrevious"
       :refine-next="refineNext"
       :refine="refineNext"
+      :insights="state.insights"
     >
       <ol :class="suit('list')">
         <li
@@ -59,13 +60,13 @@
 
 <script>
 import { createWidgetMixin } from '../mixins/widget';
-import { connectInfiniteHits } from 'instantsearch.js/es/connectors';
+import { connectInfiniteHitsWithInsights } from 'instantsearch.js/es/connectors';
 import { createSuitMixin } from '../mixins/suit';
 
 export default {
   name: 'AisInfiniteHits',
   mixins: [
-    createWidgetMixin({ connector: connectInfiniteHits }),
+    createWidgetMixin({ connector: connectInfiniteHitsWithInsights }),
     createSuitMixin({ name: 'InfiniteHits' }),
   ],
   props: {

--- a/src/components/__tests__/InfiniteHits.js
+++ b/src/components/__tests__/InfiniteHits.js
@@ -221,3 +221,31 @@ it('expect to call showMore on click', () => {
 
   expect(showMore).toHaveBeenCalled();
 });
+
+it('exposes insights prop to the default slot', () => {
+  const insights = jest.fn();
+
+  __setState({
+    ...defaultState,
+    insights,
+  });
+
+  const wrapper = mount(InfiniteHits, {
+    scopedSlots: {
+      default: `
+        <ul slot-scope="{ items, insights }">
+          <li v-for="(item, itemIndex) in items" >
+            <button :id="'add-to-cart-' + item.objectID" @click="insights('clickedObjectIDsAfterSearch', {eventName: 'Add to cart', objectIDs: [item.objectID]})">
+              Add to cart
+            </button>
+          </li>
+        </ul>
+      `,
+    },
+  });
+  wrapper.find('#add-to-cart-00002').trigger('click');
+  expect(insights).toHaveBeenCalledWith('clickedObjectIDsAfterSearch', {
+    eventName: 'Add to cart',
+    objectIDs: ['00002'],
+  });
+});

--- a/src/components/__tests__/InfiniteHits.js
+++ b/src/components/__tests__/InfiniteHits.js
@@ -249,3 +249,29 @@ it('exposes insights prop to the default slot', () => {
     objectIDs: ['00002'],
   });
 });
+
+it('exposes insights prop to the item slot', () => {
+  const insights = jest.fn();
+
+  __setState({
+    ...defaultState,
+    insights,
+  });
+
+  const wrapper = mount(InfiniteHits, {
+    scopedSlots: {
+      item: `
+          <div slot-scope="{ item, insights }">
+            <button :id="'add-to-cart-' + item.objectID" @click="insights('clickedObjectIDsAfterSearch', {eventName: 'Add to cart', objectIDs: [item.objectID]})">
+              Add to cart
+            </button>
+          </div>
+      `,
+    },
+  });
+  wrapper.find('#add-to-cart-00002').trigger('click');
+  expect(insights).toHaveBeenCalledWith('clickedObjectIDsAfterSearch', {
+    eventName: 'Add to cart',
+    objectIDs: ['00002'],
+  });
+});

--- a/stories/InfiniteHits.stories.js
+++ b/stories/InfiniteHits.stories.js
@@ -133,9 +133,9 @@ storiesOf('ais-infinite-hits', module)
         action(`[InsightsClient] sent ${method} with payload`)(payload),
     })
   )
-  .add('with insights', () => ({
+  .add('with insights on default slot', () => ({
     template: `
-    <div>
+      <div>
         <ais-configure :clickAnalytics="true" />
         <ais-infinite-hits>
           <div slot-scope="{ items, refine, isLastPage, insights }">
@@ -154,6 +154,19 @@ storiesOf('ais-infinite-hits', module)
             </button>
           </div>
         </ais-infinite-hits>
-    </div>
+      </div>
+    `,
+  }))
+  .add('with insights on item slot', () => ({
+    template: `
+      <div>
+        <ais-configure :clickAnalytics="true" />
+        <ais-infinite-hits>
+          <div slot="item" slot-scope="{ item, insights }">
+            custom objectID: {{item.objectID}}
+            <button @click="insights('clickedObjectIDsAfterSearch', { eventName: 'Add to cart', objectIDs: [item.objectID] })">Add to cart</button>
+          </div>
+        </ais-infinite-hits>
+      </div>
     `,
   }));

--- a/stories/InfiniteHits.stories.js
+++ b/stories/InfiniteHits.stories.js
@@ -138,7 +138,7 @@ storiesOf('ais-infinite-hits', module)
     <div>
         <ais-configure :clickAnalytics="true" />
         <ais-infinite-hits>
-          <div slot-scope="{ items, refine, insights }">
+          <div slot-scope="{ items, refine, isLastPage, insights }">
             <div
               v-for="item in items"
               :key="item.objectID"

--- a/stories/InfiniteHits.stories.js
+++ b/stories/InfiniteHits.stories.js
@@ -1,7 +1,8 @@
 import { storiesOf } from '@storybook/vue';
+import { action } from '@storybook/addon-actions';
+import { simple } from 'instantsearch.js/es/lib/stateMappings';
 import { previewWrapper } from './utils';
 import { MemoryRouter } from './MemoryRouter';
-import { simple } from 'instantsearch.js/es/lib/stateMappings';
 
 storiesOf('ais-infinite-hits', module)
   .addDecorator(previewWrapper())
@@ -123,4 +124,36 @@ storiesOf('ais-infinite-hits', module)
           </button>
         </div>
       </ais-infinite-hits>`,
+  }));
+
+storiesOf('ais-infinite-hits', module)
+  .addDecorator(
+    previewWrapper({
+      insightsClient: (method, payload) =>
+        action(`[InsightsClient] sent ${method} with payload`)(payload),
+    })
+  )
+  .add('with insights', () => ({
+    template: `
+    <div>
+        <ais-configure :clickAnalytics="true" />
+        <ais-infinite-hits>
+          <div slot-scope="{ items, refine, insights }">
+            <div
+              v-for="item in items"
+              :key="item.objectID"
+            >
+              custom objectID: {{item.objectID}}
+              <button @click="insights('clickedObjectIDsAfterSearch', { eventName: 'Add to cart', objectIDs: [item.objectID] })">Add to cart</button>
+            </div>
+            <button
+              :disabled="isLastPage"
+              @click="refine"
+            >
+              Load more
+            </button>
+          </div>
+        </ais-infinite-hits>
+    </div>
+    `,
   }));


### PR DESCRIPTION
⚠️ This PR depends on #664, it can't work until it's merged. It will stay as draft until then.

**Summary**
This integrates insights with Vue Instantsearch to help using Click
Analytics in InfiniteHits.

Using `connectInfiniteHitsWithInsights` instead of `connectInfiniteHits`
exposed a new property `insights` to the internal state, which user can
call to emit insights events.

**Result**
```html
<ais-infinite-hits>
  <div slot-scope="{ items, refine, insights }">

    <div v-for="item in items">
      <button @click="insights('clickedObjectIDsAfterSearch', { eventName: 'Add to cart', objectIDs: [item.objectID] })">Add to cart</button>
    </div>

    <button @click="refine()"> Load more </button>
  </div>
</ais-infinite-hits>
```