### PR TITLE
feat(panel): provide noRefinement scope to slots

### DIFF
--- a/src/components/Panel.vue
+++ b/src/components/Panel.vue
@@ -6,11 +6,11 @@
     >
       <slot
         name="header"
-        :no-refinement="!canRefine"
+        :has-refinements="canRefine"
       />
     </div>
     <div :class="suit('body')">
-      <slot :no-refinement="!canRefine" />
+      <slot :has-refinements="canRefine" />
     </div>
     <div
       v-if="$slots.footer || $scopedSlots.footer"
@@ -18,7 +18,7 @@
     >
       <slot
         name="footer"
-        :no-refinement="!canRefine"
+        :has-refinements="canRefine"
       />
     </div>
   </div>

--- a/src/components/Panel.vue
+++ b/src/components/Panel.vue
@@ -1,7 +1,7 @@
 <template>
   <div :class="[suit(), !canRefine && suit('', 'noRefinement')]">
     <div
-      v-if="$slots.header"
+      v-if="$slots.header || $scopedSlots.header"
       :class="suit('header')"
     >
       <slot
@@ -13,7 +13,7 @@
       <slot :no-refinement="!canRefine" />
     </div>
     <div
-      v-if="$slots.footer"
+      v-if="$slots.footer || $scopedSlots.footer"
       :class="suit('footer')"
     >
       <slot

--- a/src/components/Panel.vue
+++ b/src/components/Panel.vue
@@ -6,11 +6,11 @@
     >
       <slot
         name="header"
-        no-refinement="!canRefine"
+        :no-refinement="!canRefine"
       />
     </div>
     <div :class="suit('body')">
-      <slot no-refinement="!canRefine" />
+      <slot :no-refinement="!canRefine" />
     </div>
     <div
       v-if="$slots.footer"
@@ -18,7 +18,7 @@
     >
       <slot
         name="footer"
-        no-refinement="!canRefine"
+        :no-refinement="!canRefine"
       />
     </div>
   </div>

--- a/src/components/Panel.vue
+++ b/src/components/Panel.vue
@@ -4,16 +4,22 @@
       v-if="$slots.header"
       :class="suit('header')"
     >
-      <slot name="header" />
+      <slot
+        name="header"
+        no-refinement="!canRefine"
+      />
     </div>
     <div :class="suit('body')">
-      <slot />
+      <slot no-refinement="!canRefine" />
     </div>
     <div
       v-if="$slots.footer"
       :class="suit('footer')"
     >
-      <slot name="footer" />
+      <slot
+        name="footer"
+        no-refinement="!canRefine"
+      />
     </div>
   </div>
 </template>

--- a/src/components/__tests__/Panel.js
+++ b/src/components/__tests__/Panel.js
@@ -32,9 +32,13 @@ describe('default render', () => {
 
   it('passes data without refinement', () => {
     const defaultScopedSlot = jest.fn();
+    const headerScopedSlot = jest.fn();
+    const footerScopedSlot = jest.fn();
     const wrapper = mount(Panel, {
       scopedSlots: {
         default: defaultScopedSlot,
+        header: headerScopedSlot,
+        footer: footerScopedSlot,
       },
     });
 
@@ -43,6 +47,29 @@ describe('default render', () => {
     });
 
     expect(defaultScopedSlot).toHaveBeenCalledWith({ noRefinement: true });
+    expect(headerScopedSlot).toHaveBeenCalledWith({ noRefinement: true });
+    expect(footerScopedSlot).toHaveBeenCalledWith({ noRefinement: true });
+  });
+
+  it('passes data with refinement', () => {
+    const defaultScopedSlot = jest.fn();
+    const headerScopedSlot = jest.fn();
+    const footerScopedSlot = jest.fn();
+    const wrapper = mount(Panel, {
+      scopedSlots: {
+        default: defaultScopedSlot,
+        header: headerScopedSlot,
+        footer: footerScopedSlot,
+      },
+    });
+
+    wrapper.setData({
+      canRefine: true,
+    });
+
+    expect(defaultScopedSlot).toHaveBeenCalledWith({ noRefinement: false });
+    expect(headerScopedSlot).toHaveBeenCalledWith({ noRefinement: false });
+    expect(footerScopedSlot).toHaveBeenCalledWith({ noRefinement: false });
   });
 
   it('renders correctly with header', () => {

--- a/src/components/__tests__/Panel.js
+++ b/src/components/__tests__/Panel.js
@@ -30,6 +30,21 @@ describe('default render', () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
+  it('passes data without refinement', () => {
+    const defaultScopedSlot = jest.fn();
+    const wrapper = mount(Panel, {
+      scopedSlots: {
+        default: defaultScopedSlot,
+      },
+    });
+
+    wrapper.setData({
+      canRefine: false,
+    });
+
+    expect(defaultScopedSlot).toHaveBeenCalledWith({ noRefinement: true });
+  });
+
   it('renders correctly with header', () => {
     const wrapper = mount(Panel, {
       slots: {

--- a/src/components/__tests__/Panel.js
+++ b/src/components/__tests__/Panel.js
@@ -46,9 +46,9 @@ describe('default render', () => {
       canRefine: false,
     });
 
-    expect(defaultScopedSlot).toHaveBeenCalledWith({ noRefinement: true });
-    expect(headerScopedSlot).toHaveBeenCalledWith({ noRefinement: true });
-    expect(footerScopedSlot).toHaveBeenCalledWith({ noRefinement: true });
+    expect(defaultScopedSlot).toHaveBeenCalledWith({ hasRefinements: false });
+    expect(headerScopedSlot).toHaveBeenCalledWith({ hasRefinements: false });
+    expect(footerScopedSlot).toHaveBeenCalledWith({ hasRefinements: false });
   });
 
   it('passes data with refinement', () => {
@@ -67,9 +67,9 @@ describe('default render', () => {
       canRefine: true,
     });
 
-    expect(defaultScopedSlot).toHaveBeenCalledWith({ noRefinement: false });
-    expect(headerScopedSlot).toHaveBeenCalledWith({ noRefinement: false });
-    expect(footerScopedSlot).toHaveBeenCalledWith({ noRefinement: false });
+    expect(defaultScopedSlot).toHaveBeenCalledWith({ hasRefinements: true });
+    expect(headerScopedSlot).toHaveBeenCalledWith({ hasRefinements: true });
+    expect(footerScopedSlot).toHaveBeenCalledWith({ hasRefinements: true });
   });
 
   it('renders correctly with header', () => {


### PR DESCRIPTION
This allows you to create interface like:

```vue
<ais-panel>
  <template slot="header">Hi</template>
  <template slot="default" slot-scope="{ noRefinement }">
    <p v-if="noRefinement">no results</p>
    <ais-refinement-list attribute="brand" />
  </template>
</ais-panel>
```

sandbox with this: https://codesandbox.io/s/znw7ry52wl (which now obviously doesn't work).

fixes #347