### PR TITLE
feat(ais-instant-search): expose createInstantSearchComponent

### DIFF
--- a/src/instantsearch.js
+++ b/src/instantsearch.js
@@ -2,3 +2,6 @@ export { createWidgetMixin } from './mixins/widget';
 export * from './widgets';
 export { plugin as default } from './plugin';
 export { createInstantSearch } from './util/createInstantSearch';
+export {
+  createInstantSearchComponent,
+} from './util/createInstantSearchComponent';


### PR DESCRIPTION
This has been requested in #656 by @JoaoPedroAS51 and @DavidRouyer in the context of using SSR with our current solution for multi-index.

Exposing this allows people to pass more arguments which can be read later to have more than one InstantSearch instance in SSR contexts

@DavidRouyer, can you explain exactly how this solves your problem? 