### PR TITLE
docs(v1): more visible deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Vue InstantSearch is available in the npm registry. Install it:
 
 ```sh
 # with npm
-npm install --save vue-instantsearch
+npm install --save vue-instantsearch@1
 
 # with yarn
-yarn add vue-instantsearch
+yarn add vue-instantsearch@1
 ```
 
 To learn more about the usage, follow our [getting started guide](https://community.algolia.com/vue-instantsearch/getting-started/getting-started.html).

--- a/docs/layouts/common/header.pug
+++ b/docs/layouts/common/header.pug
@@ -3,4 +3,4 @@ div !{header}
     .banner__description
       a(href='https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/vue/')
         p
-          strong ⚠️This documentation is outdated, for Vue InstantSearch v2 documentation, go here ⚠️ →
+          strong ⚠️ This documentation is outdated, for Vue InstantSearch v2 documentation, go here ⚠️

--- a/docs/layouts/common/header.pug
+++ b/docs/layouts/common/header.pug
@@ -1,6 +1,6 @@
 div !{header}
-   .marketing-banner
-     .banner__description
-       a(href='https://www.algolia.com/doc/guides/building-search-ui/upgrade-guides/vue/#upgrade-from-v1-to-v2')
-         p
-           strong Announcing the new version of Vue InstantSearch 🎉. Curious? Go check out our migration guide →
+  .marketing-banner
+    .banner__description
+      a(href='https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/vue/')
+        p
+          strong ⚠️This documentation is outdated, for Vue InstantSearch v2 documentation, go here ⚠️ →

--- a/docs/src/advanced/integrate-with-nuxt.md
+++ b/docs/src/advanced/integrate-with-nuxt.md
@@ -47,7 +47,7 @@ Now that your basic Nuxt application is ready, let's add Vue InstantSearch to it
 First, you need to install `vue-instantsearch` as a dependency:
 
 ```shell
-$ npm install --save vue-instantsearch
+$ npm install --save vue-instantsearch@1
 ```
 
 By default, Vue InstantSearch exports a Vue plugin, and you need to register it.

--- a/docs/src/getting-started/getting-started.md
+++ b/docs/src/getting-started/getting-started.md
@@ -37,7 +37,7 @@ $ npm install
 Add Vue InstantSearch as a dependency, it's published on [npm](https://www.npmjs.com):
 
 ```shell
-$ npm install --save vue-instantsearch
+$ npm install --save vue-instantsearch@1
 ```
 
 ## Run the development environment

--- a/docs/src/getting-started/installing.md.hbs
+++ b/docs/src/getting-started/installing.md.hbs
@@ -15,7 +15,7 @@ be used in a `<script>` tag.
 ## Via `npm`
 
 ```shell
-$ npm install vue-instantsearch --save
+$ npm install vue-instantsearch@1 --save
 # yarn add vue-instantsearch
 ```
 

--- a/docs/src/stylesheets/components/_banner.sass
+++ b/docs/src/stylesheets/components/_banner.sass
@@ -1,10 +1,12 @@
 $banner-height: 50px
+$dark-background: #2F9088
+$light-background: #4DBA87
 
 .marketing-banner
   height: $banner-height
   width: 100%
   position: fixed
-  background: linear-gradient(to right, #4DBA87, #2F9088)
+  background: repeating-linear-gradient(-45deg, $dark-background, $dark-background 1em, $light-background 1em, $light-background 2em)
   float: left
   line-height: $banner-height
   padding: 0 2em

--- a/docs/src/stylesheets/components/_banner.sass
+++ b/docs/src/stylesheets/components/_banner.sass
@@ -6,7 +6,7 @@ $light-background: #4DBA87
   height: $banner-height
   width: 100%
   position: fixed
-  background: repeating-linear-gradient(-45deg, $dark-background, $dark-background 1em, $light-background 1em, $light-background 2em)
+  background: $bunting
   float: left
   line-height: $banner-height
   padding: 0 2em
@@ -20,12 +20,12 @@ $light-background: #4DBA87
     background-position: bottom right
 
   .banner__description
-    color: #FFFFFF
+    color: $white
     text-align: center
 
     a
-      color: #FFFFFF
-      text-decoration: none
+      color: inherit
+      text-decoration: underline
       display: block
       width: 100%
       height: 100%


### PR DESCRIPTION
This makes the deprecation message on v1 more clear.

<img width="1440" alt="Screenshot 2019-06-25 at 16 56 48" src="https://user-images.githubusercontent.com/6270048/60109198-3b603880-976a-11e9-8bfe-e641bcd64293.png">


<details><summary> old design </summary> <img width="1207" alt="Screenshot 2019-06-25 at 12 50 12" src="https://user-images.githubusercontent.com/6270048/60092617-c7ad3400-9747-11e9-896a-79c0de6f11d8.png"> </details>

At the same time, this also makes sure all installation methods install `vue-instantsearch@1`