### PR TITLE
chore(hits): expose results prop to slots

### DIFF
--- a/src/components/Hits.vue
+++ b/src/components/Hits.vue
@@ -5,6 +5,7 @@
   >
     <slot
       :items="items"
+      :results="state.results"
       :insights="state.insights"
     >
       <ol :class="suit('list')">
@@ -17,6 +18,7 @@
             name="item"
             :item="item"
             :index="itemIndex"
+            :results="state.results"
             :insights="state.insights"
           >objectID: {{ item.objectID }}, index: {{ itemIndex }}</slot>
         </li>

--- a/src/components/__tests__/Hits.js
+++ b/src/components/__tests__/Hits.js
@@ -8,6 +8,15 @@ const defaultState = {
   hits: [{ objectID: 'one' }, { objectID: 'two' }],
 };
 
+const defaultStateWithResults = {
+  ...defaultState,
+  results: {
+    hits: [{ objectID: 'one' }, { objectID: 'two' }],
+    page: 0,
+    hitsPerPage: 16,
+  },
+};
+
 it('accepts an escapeHTML prop', () => {
   __setState({
     ...defaultState,
@@ -99,4 +108,38 @@ it('exposes insights prop to the item slot', () => {
     eventName: 'Add to cart',
     objectIDs: ['two'],
   });
+});
+
+it('exposes results prop to the default slot', () => {
+  __setState({
+    ...defaultStateWithResults,
+  });
+
+  const wrapper = mount(Hits, {
+    scopedSlots: {
+      default: `
+        <template slot-scope="{ results }">
+          {{ results }}
+        </template>
+      `,
+    },
+  });
+  expect(wrapper.html()).toMatchSnapshot();
+});
+
+it('exposes results prop to the item slot', () => {
+  __setState({
+    ...defaultStateWithResults,
+  });
+
+  const wrapper = mount(Hits, {
+    scopedSlots: {
+      item: `
+        <div slot-scope="{ results }">
+          {{ results }}
+        </div>
+      `,
+    },
+  });
+  expect(wrapper.html()).toMatchSnapshot();
 });

--- a/src/components/__tests__/__snapshots__/Hits.js.snap
+++ b/src/components/__tests__/__snapshots__/Hits.js.snap
@@ -1,5 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`exposes results prop to the default slot 1`] = `
+
+<div class="ais-Hits">
+  {
+  "hits": [
+    {
+      "objectID": "one"
+    },
+    {
+      "objectID": "two"
+    }
+  ],
+  "page": 0,
+  "hitsPerPage": 16
+}
+</div>
+
+`;
+
+exports[`exposes results prop to the item slot 1`] = `
+
+<div class="ais-Hits">
+  <ol class="ais-Hits-list">
+    <li class="ais-Hits-item">
+      <div>
+        {
+  "hits": [
+    {
+      "objectID": "one"
+    },
+    {
+      "objectID": "two"
+    }
+  ],
+  "page": 0,
+  "hitsPerPage": 16
+}
+      </div>
+    </li>
+    <li class="ais-Hits-item">
+      <div>
+        {
+  "hits": [
+    {
+      "objectID": "one"
+    },
+    {
+      "objectID": "two"
+    }
+  ],
+  "page": 0,
+  "hitsPerPage": 16
+}
+      </div>
+    </li>
+  </ol>
+</div>
+
+`;
+
 exports[`renders correctly 1`] = `
 
 <div class="ais-Hits">


### PR DESCRIPTION
## Summary

This PR exposes `results` prop to `default` and `item` slot at `Hits` component.