### PR TITLE
chore(examples): add design for empty result at e-commerce demo

### DIFF
--- a/examples/ecommerce/src/App.vue
+++ b/examples/ecommerce/src/App.vue
@@ -289,7 +289,7 @@
             </div>
           </ais-hits>
 
-          <no-result />
+          <no-results />
 
           <footer class="container-footer">
             <ais-pagination :padding="2">
@@ -462,7 +462,7 @@ import { simple as simpleMapping } from 'instantsearch.js/es/lib/stateMappings';
 import VueSlider from 'vue-slider-component';
 import cx from 'classnames';
 import ClearRefinements from './widgets/ClearRefinements.vue';
-import NoResult from './widgets/NoResult.vue';
+import NoResults from './widgets/NoResults.vue';
 import { formatNumber } from './utils';
 
 import './Theme.css';
@@ -474,7 +474,7 @@ export default {
   components: {
     VueSlider,
     ClearRefinements,
-    NoResult
+    NoResults
   },
   created() {
     this.onKeyUp = event => {

--- a/examples/ecommerce/src/App.vue
+++ b/examples/ecommerce/src/App.vue
@@ -5,7 +5,11 @@
       index-name="instant_search"
       :routing="routing"
     >
-      <ais-configure :attributesToSnippet="['description:10']" snippetEllipsisText="…"/>
+      <ais-configure
+        :attributesToSnippet="['description:10']"
+        snippetEllipsisText="…"
+        removeWordsIfNoResults="allOptional"
+      />
 
       <header class="header" id="header">
         <p class="header-logo">
@@ -285,6 +289,8 @@
             </div>
           </ais-hits>
 
+          <no-result />
+
           <footer class="container-footer">
             <ais-pagination :padding="2">
               <div
@@ -456,6 +462,7 @@ import { simple as simpleMapping } from 'instantsearch.js/es/lib/stateMappings';
 import VueSlider from 'vue-slider-component';
 import cx from 'classnames';
 import ClearRefinements from './widgets/ClearRefinements.vue';
+import NoResult from './widgets/NoResult.vue';
 import { formatNumber } from './utils';
 
 import './Theme.css';
@@ -466,7 +473,8 @@ import './widgets/PriceSlider.css';
 export default {
   components: {
     VueSlider,
-    ClearRefinements
+    ClearRefinements,
+    NoResult
   },
   created() {
     this.onKeyUp = event => {

--- a/examples/ecommerce/src/widgets/NoResult.vue
+++ b/examples/ecommerce/src/widgets/NoResult.vue
@@ -1,0 +1,107 @@
+<template>
+  <div
+    v-if="state && state.results && state.results.nbHits === 0"
+    class="app-NoResult"
+  >
+    <div class="hits-empty-state">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        width="138"
+        height="138"
+        class="hits-empty-state-image"
+      >
+        <defs>
+          <linearGradient id="c" x1="50%" x2="50%" y1="100%" y2="0%">
+            <stop offset="0%" stop-color="#F5F5FA" />
+            <stop offset="100%" stop-color="#FFF" />
+          </linearGradient>
+          <path
+            id="b"
+            d="M68.71 114.25a45.54 45.54 0 1 1 0-91.08 45.54 45.54 0 0 1 0 91.08z"
+          />
+          <filter
+            id="a"
+            width="140.6%"
+            height="140.6%"
+            x="-20.3%"
+            y="-15.9%"
+            filterUnits="objectBoundingBox"
+          >
+            <feOffset dy="4" in="SourceAlpha" result="shadowOffsetOuter1" />
+            <feGaussianBlur
+              in="shadowOffsetOuter1"
+              result="shadowBlurOuter1"
+              stdDeviation="5.5"
+            />
+            <feColorMatrix
+              in="shadowBlurOuter1"
+              result="shadowMatrixOuter1"
+              values="0 0 0 0 0.145098039 0 0 0 0 0.17254902 0 0 0 0 0.380392157 0 0 0 0.15 0"
+            />
+            <feOffset dy="2" in="SourceAlpha" result="shadowOffsetOuter2" />
+            <feGaussianBlur
+              in="shadowOffsetOuter2"
+              result="shadowBlurOuter2"
+              stdDeviation="1.5"
+            />
+            <feColorMatrix
+              in="shadowBlurOuter2"
+              result="shadowMatrixOuter2"
+              values="0 0 0 0 0.364705882 0 0 0 0 0.392156863 0 0 0 0 0.580392157 0 0 0 0.2 0"
+            />
+            <feMerge>
+              <feMergeNode in="shadowMatrixOuter1" />
+              <feMergeNode in="shadowMatrixOuter2" />
+            </feMerge>
+          </filter>
+        </defs>
+        <g fill="none" fill-rule="evenodd">
+          <circle
+            cx="68.85"
+            cy="68.85"
+            r="68.85"
+            fill="#5468FF"
+            opacity=".07"
+          />
+          <circle
+            cx="68.85"
+            cy="68.85"
+            r="52.95"
+            fill="#5468FF"
+            opacity=".08"
+          />
+          <use fill="#000" filter="url(#a)" xlink:href="#b" />
+          <use fill="url(#c)" xlink:href="#b" />
+          <path
+            d="M76.01 75.44c5-5 5.03-13.06.07-18.01a12.73 12.73 0 0 0-18 .07c-5 4.99-5.03 13.05-.07 18a12.73 12.73 0 0 0 18-.06zm2.5 2.5a16.28 16.28 0 0 1-23.02.09A16.29 16.29 0 0 1 55.57 55a16.28 16.28 0 0 1 23.03-.1 16.28 16.28 0 0 1-.08 23.04zm1.08-1.08l-2.15 2.16 8.6 8.6 2.16-2.15-8.6-8.6z"
+            fill="#5369FF"
+          />
+        </g>
+      </svg>
+
+      <p class="hits-empty-state-title">
+        Sorry, we can&apos;t find any matches to your query!
+      </p>
+      <p class="hits-empty-state-description">
+        {{
+          state.results.getRefinements().length > 0
+            ? 'Try to reset your applied filters.'
+            : 'Please try another query.'
+        }}
+      </p>
+    </div>
+  </div>
+</template>
+
+<script>
+import { connectHits } from 'instantsearch.js/es/connectors';
+import { createWidgetMixin } from 'vue-instantsearch';
+
+export default {
+  name: 'AppNoResult',
+  mixins: [
+    createWidgetMixin({ connector: connectHits }),
+  ]
+};
+</script>

--- a/examples/ecommerce/src/widgets/NoResults.vue
+++ b/examples/ecommerce/src/widgets/NoResults.vue
@@ -89,6 +89,29 @@
             : 'Please try another query.'
         }}
       </p>
+
+      <ais-clear-refinements>
+        <template slot="resetLabel">
+          <div class="clear-filters">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="11"
+              height="11"
+              viewBox="0 0 11 11"
+            >
+              <g fill="none" fill-rule="evenodd">
+                <path d="M0 0h11v11H0z" />
+                <path
+                  fill="#000"
+                  fill-rule="nonzero"
+                  d="M8.26 2.75a3.896 3.896 0 1 0 1.102 3.262l.007-.056a.49.49 0 0 1 .485-.456c.253 0 .451.206.437.457 0 0 .012-.109-.006.061a4.813 4.813 0 1 1-1.348-3.887v-.987a.458.458 0 1 1 .917.002v2.062a.459.459 0 0 1-.459.459H7.334a.458.458 0 1 1-.002-.917h.928z"
+                />
+              </g>
+            </svg>
+            Clear filters
+          </div>
+        </template>
+      </ais-clear-refinements>
     </div>
   </div>
 </template>

--- a/examples/ecommerce/src/widgets/NoResults.vue
+++ b/examples/ecommerce/src/widgets/NoResults.vue
@@ -1,7 +1,6 @@
 <template>
   <div
     v-if="state && state.results && state.results.nbHits === 0"
-    class="app-NoResult"
   >
     <div class="hits-empty-state">
       <svg
@@ -99,7 +98,7 @@ import { connectHits } from 'instantsearch.js/es/connectors';
 import { createWidgetMixin } from 'vue-instantsearch';
 
 export default {
-  name: 'AppNoResult',
+  name: 'AppNoResults',
   mixins: [
     createWidgetMixin({ connector: connectHits }),
   ]


### PR DESCRIPTION
This adds the empty state when no hits are returned by the engine. It doesn't change the SFFV no results design.

related to: https://github.com/algolia/instantsearch.js/pull/3894
based on: https://github.com/algolia/react-instantsearch/pull/2601

## Implementation

If no filter are applied, the empty message asks the user to change the query. If there are filters applied, the empty message shows a different message and offers the user to clear the filters.

I added `removeWordsIfNoResults` to `allOptional` so that results are returned most of the time.

## Preview

- [Preview with only query leading to empty results](https://deploy-preview-690--vue-instantsearch.netlify.com/examples/ecommerce/index.html?query=hellll)
- [Preview with filters leading to empty results](https://deploy-preview-690--vue-instantsearch.netlify.com/examples/ecommerce/index.html?query=ddddasdfasd&hierarchicalMenu%5BhierarchicalCategories.lvl0%5D%5B0%5D=Cameras%20%26%20Camcorders)
- [Default preview](https://deploy-preview-690--vue-instantsearch.netlify.com/examples/ecommerce/index.html)

## Related

- [Desktop design](https://app.zeplin.io/project/5acc8becfc0c980068fc12cc/screen/5d133b0a7695220487ab06e7)
- [Mobile design](https://app.zeplin.io/project/5acc8becfc0c980068fc12cc/screen/5d133b6fc0b0e869459947ca)