### PR TITLE
chore(release): v2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [2.2.2](https://github.com/algolia/vue-instantsearch/compare/v2.2.1...v2.2.2) (2019-07-11)
+
+
+### Bug Fixes
+
+* **highlight:** change expected tag to replace ([#679](https://github.com/algolia/vue-instantsearch/issues/679)) ([4aa06fb](https://github.com/algolia/vue-instantsearch/commit/4aa06fb))
+
+
+
 # [2.2.1](https://github.com/algolia/vue-instantsearch/compare/v2.1.0...v2.2.1) (2019-05-21)
 
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "autocomplete"
   ],
   "license": "MIT",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
This bumps InstantSearch to 3.5.4 to fix the highlighting bug