### PR TITLE
fix(ssr): clearer error message when using ssr without the component

### DIFF
--- a/src/mixins/widget.js
+++ b/src/mixins/widget.js
@@ -25,6 +25,11 @@ export const createWidgetMixin = ({ connector } = {}) => ({
 
       const { hydrated, started } = this.instantSearchInstance;
       if ((!started && hydrated) || this.$isServer) {
+        if (typeof this.instantSearchInstance.__forceRender !== 'function') {
+          throw new Error(
+            'You are using server side rendering with <ais-instant-search> instead of <ais-instant-search-server>.'
+          );
+        }
         this.instantSearchInstance.__forceRender(this.widget);
       }
     } else if (connector !== true) {


### PR DESCRIPTION
fixes #697

We are patching the InstantSearch instance in SSR, but you could be using the code for SSR without using the patched InstantSearch instance.

The error being thrown then is confusing, since it just complains about a missing property.

We have no differential error management with short & long error messages in prod/dev here yet, so I tried to be between both (not too long), this still has a .03kb difference in the bundle, so I updated the limits