### PR TITLE
chore: update vue-slider story

### DIFF
--- a/stories/RangeInput.stories.js
+++ b/stories/RangeInput.stories.js
@@ -85,6 +85,7 @@ storiesOf('ais-range-input', module)
           <vue-slider
             :min="minRange"
             :max="maxRange"
+            :lazy="true"
             :value="[
               minValue !== null ? minValue : minRange,
               maxValue !== null ? maxValue : maxRange,


### PR DESCRIPTION
This PR adds `:lazy="true"` to a vue-slider story.
The option prevents from triggering too unnecessary queries while dragging.