### PR TITLE
feat: Expose `createSuitMixin` for easy class reuse in custom components

### DIFF
--- a/src/instantsearch.js
+++ b/src/instantsearch.js
@@ -1,3 +1,4 @@
+export { createSuitMixin } from './mixins/suit';
 export { createWidgetMixin } from './mixins/widget';
 export * from './widgets';
 export { plugin as default } from './plugin';


### PR DESCRIPTION
While using the `createWidgetMixin`, there is no easy way to reproduce all the DOM classes typically generated for widget components; the mixin used internally is not exposed for consumption in production environments.

Would like to be able to leverage the same pattern when wrapping additional template around existing components.