### PR TITLE
feat(core): expose source files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "license": "MIT",
   "version": "2.5.0",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "main": "dist/vue-instantsearch.common.js",
   "module": "dist/vue-instantsearch.esm.js",
@@ -138,5 +139,6 @@
       "jest-watch-typeahead/filename",
       "jest-watch-typeahead/testname"
     ]
-  }
+  },
+  "sideEffects": false
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   ],
   "main": "dist/vue-instantsearch.common.js",
   "module": "dist/vue-instantsearch.esm.js",
+  "sideEffects": false,
   "repository": "https://github.com/algolia/vue-instantsearch",
   "scripts": {
     "build": "rollup -c",
@@ -139,6 +140,5 @@
       "jest-watch-typeahead/filename",
       "jest-watch-typeahead/testname"
     ]
-  },
-  "sideEffects": false
+  }
 }


### PR DESCRIPTION
This should allow people who are using Webpack, which doesn't correctly work with "non-fully-used" single files to still import only what's needed.

The size of tree-shaking vue-instantsearch isn't too different from the whole bundle, because the biggest parts are the InstantSearch class & the algoliasearch-helper. Luckily this will be better in the next major version.

see #725 (fixes part of it as it gives a workaround, but ideally it wouldn't be necessary)