### PR TITLE
feat(widgets): introduce `ConfigureRelatedItems` as experimental

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
     camelcase: [
       'error',
       {
-        allow: ['^\\$_ais'],
+        allow: ['^\\$_ais', '^EXPERIMENTAL_'],
       },
     ],
   },

--- a/.storybook/styles.css
+++ b/.storybook/styles.css
@@ -126,3 +126,52 @@ button:not([class^='ais-']) {
 button:not([class^='ais-']):disabled {
   border-color: #c4c8d8;
 }
+
+/* Related items */
+
+.related-items {
+  display: flex;
+  align-items: center;
+}
+
+.related-items .ais-Hits-list {
+  margin-left: 0;
+  margin-right: 1rem;
+}
+
+.ais-RelatedHits-item-image {
+  height: 150px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem;
+  background-color: #fff;
+}
+
+.ais-RelatedHits-item-image img {
+  max-width: 100%;
+  max-height: 120px;
+}
+
+.ais-RelatedHits-item-title {
+  text-align: center;
+  padding: 1rem;
+}
+
+.ais-RelatedHits-item-title h4 {
+  margin: 0;
+}
+
+.ais-RelatedHits-button {
+  height: 40px;
+  width: 40px;
+  border-radius: 3px;
+  background-color: #dfe2ee;
+  border: none;
+  color: #3a4570;
+  cursor: pointer;
+}
+
+.ais-RelatedHits-button[disabled] {
+  cursor: not-allowed;
+}

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "algoliasearch-helper": "^3.0.0",
-    "instantsearch.js": "^4.0.1"
+    "instantsearch.js": "^4.1.0"
   },
   "peerDependencies": {
     "algoliasearch": "^3.30.0",
@@ -111,7 +111,7 @@
   "bundlesize": [
     {
       "path": "./dist/vue-instantsearch.js",
-      "maxSize": "46.25 kB"
+      "maxSize": "46.50 kB"
     },
     {
       "path": "./dist/vue-instantsearch.esm.js",

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,11 +1,15 @@
 import Vue from 'vue';
 import InstantSearch from '../instantsearch';
 
+const renderlessComponents = ['AisExperimentalConfigureRelatedItems'];
+
 it('should have `name` the same as the suit class name everywhere', () => {
   Vue.component = jest.fn();
   Vue.use(InstantSearch);
 
-  const allInstalledComponents = Vue.component.mock.calls;
+  const allInstalledComponents = Vue.component.mock.calls.filter(
+    ([installedName]) => !renderlessComponents.includes(installedName)
+  );
   const components = allInstalledComponents.map(
     ([installedName, { name, mixins }]) => {
       let suitClass = `Error! ${name} is missing the suit classes`;

--- a/src/components/ConfigureRelatedItems.js
+++ b/src/components/ConfigureRelatedItems.js
@@ -1,0 +1,36 @@
+import { createWidgetMixin } from '../mixins/widget';
+import { EXPERIMENTAL_connectConfigureRelatedItems } from 'instantsearch.js/es/connectors';
+
+export default {
+  inheritAttrs: false,
+  name: 'AisExperimentalConfigureRelatedItems',
+  mixins: [
+    createWidgetMixin({ connector: EXPERIMENTAL_connectConfigureRelatedItems }),
+  ],
+  props: {
+    hit: {
+      type: Object,
+      required: true,
+    },
+    matchingPatterns: {
+      type: Object,
+      required: true,
+    },
+    transformSearchParameters: {
+      type: Function,
+      required: false,
+    },
+  },
+  computed: {
+    widgetParams() {
+      return {
+        hit: this.hit,
+        matchingPatterns: this.matchingPatterns,
+        transformSearchParameters: this.transformSearchParameters,
+      };
+    },
+  },
+  render() {
+    return null;
+  },
+};

--- a/src/components/__tests__/ConfigureRelatedItems.js
+++ b/src/components/__tests__/ConfigureRelatedItems.js
@@ -1,0 +1,31 @@
+import { mount } from '@vue/test-utils';
+import ConfigureRelatedItems from '../ConfigureRelatedItems';
+
+jest.mock('../../mixins/widget');
+
+it('accepts options from props', () => {
+  const props = {
+    hit: { objectID: '1' },
+    matchingPatterns: {},
+    transformSearchParameters: x => x,
+  };
+
+  const wrapper = mount(ConfigureRelatedItems, {
+    propsData: props,
+  });
+
+  expect(wrapper.vm.widgetParams).toEqual(props);
+});
+
+it('renders nothing', () => {
+  const props = {
+    hit: { objectID: '1' },
+    matchingPatterns: {},
+  };
+
+  const wrapper = mount(ConfigureRelatedItems, {
+    propsData: props,
+  });
+
+  expect(wrapper.html()).toBeUndefined();
+});

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -5,6 +5,9 @@ export {
 } from './components/ClearRefinements.vue';
 export { default as AisConfigure } from './components/Configure';
 export {
+  default as AisExperimentalConfigureRelatedItems,
+} from './components/ConfigureRelatedItems';
+export {
   default as AisCurrentRefinements,
 } from './components/CurrentRefinements.vue';
 export {

--- a/stories/ConfigureRelatedItems.stories.js
+++ b/stories/ConfigureRelatedItems.stories.js
@@ -1,0 +1,100 @@
+import { storiesOf } from '@storybook/vue';
+import algoliasearch from 'algoliasearch';
+
+storiesOf('ais-configure-related-items', module).add('default', () => ({
+  template: `
+  <div>
+    <ais-instant-search :search-client="searchClient" index-name="instant_search">
+      <ais-index index-name="instant_search">
+        <ais-configure :hitsPerPage="1"/>
+        <ais-search-box />
+
+        <ais-hits>
+          <template slot="item" slot-scope="{ item }">
+            <div :ref="setReferenceHit(item)">
+              <div
+                class="playground-hits-image"
+                :style="{ backgroundImage: 'url(' + item.image + ')' }"
+              />
+              <div class="playground-hits-desc">
+                <p>
+                  <ais-highlight attribute="name" :hit="item" />
+                </p>
+                <p>Rating: {{ item.rating }}✭</p>
+                <p>Price: {{ item.price }}$</p>
+              </div>
+            </div>
+          </template>
+        </ais-hits>
+      </ais-index>
+
+      <ais-index index-name="instant_search" v-if="hit">
+        <h2>Related items</h2>
+
+        <ais-configure :hitsPerPage="4"/>
+        <ais-experimental-configure-related-items :hit="hit" :matchingPatterns="matchingPatterns" />
+
+        <div class="related-items">
+          <ais-pagination>
+            <div slot-scope="{ currentRefinement, isFirstPage, refine }">
+              <button
+                class="ais-RelatedHits-button"
+                :disabled="isFirstPage"
+                @click="refine(currentRefinement - 1)"
+              >
+                ←
+              </button>
+            </div>
+          </ais-pagination>
+
+          <ais-hits>
+            <template slot="item" slot-scope="{ item }">
+              <div class="ais-RelatedHits-item-image">
+                <img :src="item.image" alt="item.name" />
+              </div>
+              <div class="ais-RelatedHits-item-title">
+                <h4>
+                  <ais-highlight attribute="name" :hit="item" />
+                </h4>
+              </div>
+            </template>
+          </ais-hits>
+
+          <ais-pagination>
+            <div slot-scope="{ currentRefinement, isLastPage, refine }">
+              <button
+                class="ais-RelatedHits-button"
+                :disabled="isLastPage"
+                @click="refine(currentRefinement + 1)"
+              >
+                →
+              </button>
+            </div>
+          </ais-pagination>
+        </div>
+      </ais-index>
+    </ais-instant-search>
+  </div>
+  `,
+  data() {
+    return {
+      searchClient: algoliasearch(
+        'latency',
+        '6be0576ff61c053d5f9a3225e2a90f76'
+      ),
+      hit: null,
+      matchingPatterns: {
+        brand: { score: 3 },
+        type: { score: 10 },
+        categories: { score: 2 },
+      },
+    };
+  },
+  methods: {
+    setReferenceHit(item) {
+      if (!this.hit || this.hit.objectID !== item.objectID) {
+        this.hit = item;
+      }
+    },
+  },
+}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -6595,10 +6595,10 @@ instantsearch.css@7.3.1:
   resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.3.1.tgz#7ab74a8f355091ae040947a9cf5438f379026622"
   integrity sha512-/kaMDna5D+Q9mImNBHEhb9HgHATDOFKYii7N1Iwvrj+lmD9gBJLqVhUw67gftq2O0QI330pFza+CRscIwB1wQQ==
 
-instantsearch.js@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.0.1.tgz#be6b8b915324eb87c269277a550d353351e12682"
-  integrity sha512-ZGzfVKH8ly1LbOBzzEWYJp0BFExGGNqaq+Fhxrnv3sYw3yEc4OY1v40OTMY1y+DDnwZXiIrG3H1UdnovzZrAPg==
+instantsearch.js@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.1.0.tgz#c608317841a37cefa5f0ef83361a568aa7daf11a"
+  integrity sha512-UWm0vLQLwM47shQK/9OkAjYVXEl+zD91PlLv3Tnr1xl1WzFeXZRrSq1Eqxlyef7ifz2gXbVSWxs/AOmXesZvdw==
   dependencies:
     algoliasearch-helper "^3.0.0"
     classnames "^2.2.5"


### PR DESCRIPTION
This PR introduces a new experimental widget: `ais-experimental-configure-related-items`.

Combined with the `ais-hits` component, this widget allows to create related items experiences as seen in e-commerce and media use cases:

![Example](https://user-images.githubusercontent.com/6137112/69717292-12bedf00-110c-11ea-9a47-8ddd7c8ed2a6.png)

<details>

<summary>See more examples</summary>

![Example](https://user-images.githubusercontent.com/6137112/69970627-d54cbe00-151e-11ea-85bc-04304077f78e.png)

![Example](https://user-images.githubusercontent.com/6270048/67220965-ff449800-f42a-11e9-9896-2db8adb9b786.png)

</details>

## Result

- [Usage](https://github.com/algolia/vue-instantsearch/blob/dbc633f92a26ccc232a9cc66c89dfa3714e7f4f5/stories/ConfigureRelatedItems.stories.js)
- [Story](https://deploy-preview-751--vue-instantsearch.netlify.com/stories/?selectedKind=ais-configure-related-items&selectedStory=default&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybooks%2Fstorybook-addon-knobs)

## Implementation

The widget is render-less (it doesn't render anything), which means that no data is exposed to its scope.

## Impact

- Slight bundle size increase

## Related

- Widgets in InstantSearch.js: algolia/instantsearch.js#4233
- Widgets in React InstantSearch: algolia/react-instantsearch#2880