### PR TITLE
upgrading version of algoliasearch-helper to improve bundle size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ coverage
 /website/stories
 /website/examples/*
 !/website/examples/index.html
+
+.idea/

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "release:publish": "scripts/release-publish.sh"
   },
   "dependencies": {
-    "algoliasearch-helper": "^2.28.1",
+    "algoliasearch-helper": "3.1.1",
     "instantsearch.js": "^3.6.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -842,7 +842,14 @@ ajv@^6.5.5, ajv@^6.9.1:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-algoliasearch-helper@^2.26.0, algoliasearch-helper@^2.28.1:
+algoliasearch-helper@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.1.1.tgz#4cdfbaed6670d82626ac1fae001ccbf53192f497"
+  integrity sha512-Jkqlp8jezQRixf7sbQ2zFXHpdaT41g9sHBqT6pztv5nfDmg94K+pwesAy6UbxRY78IL54LIaV1FLttMtT+IzzA==
+  dependencies:
+    events "^1.1.1"
+
+algoliasearch-helper@^2.26.0:
   version "2.28.1"
   resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-2.28.1.tgz#90c574ab7b80b8e85bcf9542688f19d547321102"
   integrity sha512-4yg3anWdILD6ZJ/GxWmtu4HgxauSemhSqbe9Cx6SFdPzaMHrccew4IDomMeQlz9RHJwRgi5sEeX//jx2H/PaWg==


### PR DESCRIPTION
The bundle size of algoliasearch-helper has been improved explained in [this](https://github.com/algolia/algoliasearch-helper-js/issues/617#issuecomment-510527506) comment. This pull request upgrades the version in vue-instantsearch for a smaller bundle size.