### PR TITLE
feat(widget:toggle-refinement): allow multiple values for "on" and "off"

### DIFF
--- a/src/components/ToggleRefinement.vue
+++ b/src/components/ToggleRefinement.vue
@@ -55,12 +55,12 @@ export default {
       required: true,
     },
     on: {
-      type: [String, Number, Boolean],
+      type: [String, Number, Boolean, Array],
       required: false,
       default: true,
     },
     off: {
-      type: [String, Number, Boolean],
+      type: [String, Number, Boolean, Array],
       required: false,
       // explicit otherwise Vue coerces the default value
       // to false because of the `Boolean` prop type

--- a/stories/ToggleRefinement.stories.js
+++ b/stories/ToggleRefinement.stories.js
@@ -20,6 +20,15 @@ storiesOf('ais-toggle-refinement', module)
       />
     `,
   }))
+  .add('with an on value (with multiple values)', () => ({
+    template: `
+      <ais-toggle-refinement
+        attribute="brand"
+        label="Brands starting with \"i\""
+        :on="['Samsung', 'Metra']"
+      />
+    `,
+  }))
   .add('with an off value', () => ({
     template: `
       <ais-toggle-refinement

--- a/stories/ToggleRefinement.stories.js
+++ b/stories/ToggleRefinement.stories.js
@@ -24,7 +24,7 @@ storiesOf('ais-toggle-refinement', module)
     template: `
       <ais-toggle-refinement
         attribute="brand"
-        label="Brands starting with \"i\""
+        label="Metra or Samsung"
         :on="['Samsung', 'Metra']"
       />
     `,


### PR DESCRIPTION
Hi :wave: 

This PR is for the proposal https://github.com/algolia/instantsearch.js/pull/4420, which allow multiple values for `on` and `off` props.

Thanks!