### PR TITLE
fix(server): make vue-server-renderer not a dependency

### DIFF
--- a/examples/nuxt/package.json
+++ b/examples/nuxt/package.json
@@ -14,7 +14,8 @@
     "algoliasearch": "^4.0.1",
     "cross-env": "^5.2.0",
     "nuxt": "^2.4.5",
-    "vue-instantsearch": "file:../../"
+    "vue-instantsearch": "file:../../",
+    "vue-server-renderer": "2.6.11"
   },
   "devDependencies": {}
 }

--- a/examples/nuxt/pages/search.vue
+++ b/examples/nuxt/pages/search.vue
@@ -64,7 +64,6 @@ import {
   createServerRootMixin,
 } from 'vue-instantsearch'; // eslint-disable-line import/no-unresolved
 import algoliasearch from 'algoliasearch/lite';
-import renderToString from 'vue-server-renderer/basic';
 
 const searchClient = algoliasearch(
   'latency',
@@ -73,31 +72,28 @@ const searchClient = algoliasearch(
 
 export default {
   mixins: [
-    createServerRootMixin(
-      {
-        searchClient,
-        indexName: 'instant_search',
-        initialUiState: {
-          instant_search: {
-            query: 'iphone',
-            page: 3,
+    createServerRootMixin({
+      searchClient,
+      indexName: 'instant_search',
+      initialUiState: {
+        instant_search: {
+          query: 'iphone',
+          page: 3,
+        },
+        refinement: {
+          refinementList: {
+            brand: ['Apple'],
           },
-          refinement: {
-            refinementList: {
-              brand: ['Apple'],
-            },
-          },
-          querySuggestions: {
-            query: 'k',
-            page: 2,
-            configure: {
-              hitsPerPage: 5,
-            },
+        },
+        querySuggestions: {
+          query: 'k',
+          page: 2,
+          configure: {
+            hitsPerPage: 5,
           },
         },
       },
-      renderToString
-    ),
+    }),
   ],
   serverPrefetch() {
     return this.instantsearch.findResultsState(this).then(algoliaState => {

--- a/examples/nuxt/pages/search.vue
+++ b/examples/nuxt/pages/search.vue
@@ -64,6 +64,7 @@ import {
   createServerRootMixin,
 } from 'vue-instantsearch'; // eslint-disable-line import/no-unresolved
 import algoliasearch from 'algoliasearch/lite';
+import renderToString from 'vue-server-renderer/basic';
 
 const searchClient = algoliasearch(
   'latency',
@@ -72,28 +73,31 @@ const searchClient = algoliasearch(
 
 export default {
   mixins: [
-    createServerRootMixin({
-      searchClient,
-      indexName: 'instant_search',
-      initialUiState: {
-        instant_search: {
-          query: 'iphone',
-          page: 3,
-        },
-        refinement: {
-          refinementList: {
-            brand: ['Apple'],
+    createServerRootMixin(
+      {
+        searchClient,
+        indexName: 'instant_search',
+        initialUiState: {
+          instant_search: {
+            query: 'iphone',
+            page: 3,
           },
-        },
-        querySuggestions: {
-          query: 'k',
-          page: 2,
-          configure: {
-            hitsPerPage: 5,
+          refinement: {
+            refinementList: {
+              brand: ['Apple'],
+            },
+          },
+          querySuggestions: {
+            query: 'k',
+            page: 2,
+            configure: {
+              hitsPerPage: 5,
+            },
           },
         },
       },
-    }),
+      renderToString
+    ),
   ],
   serverPrefetch() {
     return this.instantsearch.findResultsState(this).then(algoliaState => {

--- a/examples/ssr/package.json
+++ b/examples/ssr/package.json
@@ -14,7 +14,7 @@
     "vue": "^2.6.7",
     "vue-instantsearch": "file:../../",
     "vue-router": "^3.0.2",
-    "vue-server-renderer": "^2.6.7"
+    "vue-server-renderer": "^2.6.11"
   },
   "devDependencies": {
     "@akryum/vue-cli-plugin-ssr": "^0.5.0",

--- a/examples/ssr/src/main.js
+++ b/examples/ssr/src/main.js
@@ -1,5 +1,4 @@
 import Vue from 'vue';
-import renderToString from 'vue-server-renderer/basic';
 import App from './App.vue';
 import { createRouter } from './router';
 import { createServerRootMixin } from 'vue-instantsearch';
@@ -26,78 +25,75 @@ export async function createApp({
 
   const app = new Vue({
     mixins: [
-      createServerRootMixin(
-        {
-          searchClient,
-          indexName: 'instant_search',
-          routing: {
-            router: {
-              read() {
-                const url = context
-                  ? context.url
-                  : typeof window.location === 'object'
-                    ? window.location.href
-                    : '';
-                const search = url.slice(url.indexOf('?'));
+      createServerRootMixin({
+        searchClient,
+        indexName: 'instant_search',
+        routing: {
+          router: {
+            read() {
+              const url = context
+                ? context.url
+                : typeof window.location === 'object'
+                  ? window.location.href
+                  : '';
+              const search = url.slice(url.indexOf('?'));
 
-                return qs.parse(search, {
-                  ignoreQueryPrefix: true,
-                });
-              },
-              write(routeState) {
-                const query = qs.stringify(routeState, {
-                  addQueryPrefix: true,
-                });
+              return qs.parse(search, {
+                ignoreQueryPrefix: true,
+              });
+            },
+            write(routeState) {
+              const query = qs.stringify(routeState, {
+                addQueryPrefix: true,
+              });
 
-                if (typeof history === 'object') {
-                  history.pushState(routeState, null, query);
-                }
-              },
-              createURL(routeState) {
-                const query = qs.stringify(routeState, {
-                  addQueryPrefix: true,
-                });
+              if (typeof history === 'object') {
+                history.pushState(routeState, null, query);
+              }
+            },
+            createURL(routeState) {
+              const query = qs.stringify(routeState, {
+                addQueryPrefix: true,
+              });
 
-                return query;
-              },
-              onUpdate(callback) {
-                if (typeof window !== 'object') {
-                  return;
-                }
-                this._onPopState = event => {
-                  if (this.writeTimer) {
-                    window.clearTimeout(this.writeTimer);
-                    this.writeTimer = undefined;
-                  }
-
-                  const routeState = event.state;
-
-                  // At initial load, the state is read from the URL without update.
-                  // Therefore the state object is not available.
-                  // In this case, we fallback and read the URL.
-                  if (!routeState) {
-                    callback(this.read());
-                  } else {
-                    callback(routeState);
-                  }
-                };
-
-                window.addEventListener('popstate', this._onPopState);
-              },
-              dispose() {
-                if (this._onPopState && typeof window == 'object') {
-                  window.removeEventListener('popstate', this._onPopState);
+              return query;
+            },
+            onUpdate(callback) {
+              if (typeof window !== 'object') {
+                return;
+              }
+              this._onPopState = event => {
+                if (this.writeTimer) {
+                  window.clearTimeout(this.writeTimer);
+                  this.writeTimer = undefined;
                 }
 
-                // we purposely don't write on dispose, to prevent double entries on navigation
-              },
+                const routeState = event.state;
+
+                // At initial load, the state is read from the URL without update.
+                // Therefore the state object is not available.
+                // In this case, we fallback and read the URL.
+                if (!routeState) {
+                  callback(this.read());
+                } else {
+                  callback(routeState);
+                }
+              };
+
+              window.addEventListener('popstate', this._onPopState);
+            },
+            dispose() {
+              if (this._onPopState && typeof window == 'object') {
+                window.removeEventListener('popstate', this._onPopState);
+              }
+
+              // we purposely don't write on dispose, to prevent double entries on navigation
             },
           },
-          // other options, like
-          // stalledSearchDelay: 50
         },
-        renderToString
-      ),
+        // other options, like
+        // stalledSearchDelay: 50
+      }),
     ],
     serverPrefetch() {
       return this.instantsearch.findResultsState(this);

--- a/src/util/__tests__/createServerRootMixin.test.js
+++ b/src/util/__tests__/createServerRootMixin.test.js
@@ -56,7 +56,7 @@ describe('createServerRootMixin', () => {
             ],
           })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"createServerRootMixin requires the \`searchClient\` and \`indexName\` arguments to be passed"`
+        `"createServerRootMixin requires \`searchClient\` and \`indexName\` in the first argument"`
       );
     });
 
@@ -75,7 +75,23 @@ describe('createServerRootMixin', () => {
             ],
           })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"createServerRootMixin requires the \`searchClient\` and \`indexName\` arguments to be passed"`
+        `"createServerRootMixin requires \`searchClient\` and \`indexName\` in the first argument"`
+      );
+    });
+
+    it('requires renderToString', () => {
+      expect(
+        () =>
+          new Vue({
+            mixins: [
+              createServerRootMixin({
+                searchClient: createFakeClient(),
+                indexName: 'instant_search',
+              }),
+            ],
+          })
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"createServerRootMixin requires \\"vue-server-renderer/basic\\" as the second argument\`"`
       );
     });
 

--- a/src/util/__tests__/createServerRootMixin.test.js
+++ b/src/util/__tests__/createServerRootMixin.test.js
@@ -46,13 +46,10 @@ describe('createServerRootMixin', () => {
         () =>
           new Vue({
             mixins: [
-              createServerRootMixin(
-                {
-                  searchClient: undefined,
-                  indexName: 'lol',
-                },
-                _renderToString
-              ),
+              createServerRootMixin({
+                searchClient: undefined,
+                indexName: 'lol',
+              }),
             ],
           })
       ).toThrowErrorMatchingInlineSnapshot(
@@ -65,13 +62,10 @@ describe('createServerRootMixin', () => {
         () =>
           new Vue({
             mixins: [
-              createServerRootMixin(
-                {
-                  searchClient: createFakeClient(),
-                  indexName: undefined,
-                },
-                _renderToString
-              ),
+              createServerRootMixin({
+                searchClient: createFakeClient(),
+                indexName: undefined,
+              }),
             ],
           })
       ).toThrowErrorMatchingInlineSnapshot(
@@ -79,32 +73,13 @@ describe('createServerRootMixin', () => {
       );
     });
 
-    it('requires renderToString', () => {
-      expect(
-        () =>
-          new Vue({
-            mixins: [
-              createServerRootMixin({
-                searchClient: createFakeClient(),
-                indexName: 'instant_search',
-              }),
-            ],
-          })
-      ).toThrowErrorMatchingInlineSnapshot(
-        `"createServerRootMixin requires \\"vue-server-renderer/basic\\" as the second argument\`"`
-      );
-    });
-
     it('creates an instantsearch instance on "data"', () => {
       const app = new Vue({
         mixins: [
-          createServerRootMixin(
-            {
-              searchClient: createFakeClient(),
-              indexName: 'lol',
-            },
-            _renderToString
-          ),
+          createServerRootMixin({
+            searchClient: createFakeClient(),
+            indexName: 'lol',
+          }),
         ],
       });
 
@@ -118,13 +93,10 @@ describe('createServerRootMixin', () => {
     it('provides the instantsearch instance ', () => {
       const App = {
         mixins: [
-          createServerRootMixin(
-            {
-              searchClient: createFakeClient(),
-              indexName: 'myIndexName',
-            },
-            _renderToString
-          ),
+          createServerRootMixin({
+            searchClient: createFakeClient(),
+            indexName: 'myIndexName',
+          }),
         ],
         render(h) {
           return h('div', {}, this.$slots.default);
@@ -166,13 +138,10 @@ describe('createServerRootMixin', () => {
     it('provides findResultsState', () => {
       const app = new Vue({
         mixins: [
-          createServerRootMixin(
-            {
-              searchClient: createFakeClient(),
-              indexName: 'hello',
-            },
-            _renderToString
-          ),
+          createServerRootMixin({
+            searchClient: createFakeClient(),
+            indexName: 'hello',
+          }),
         ],
         render(h) {
           return h(InstantSearchSsr);
@@ -188,13 +157,10 @@ describe('createServerRootMixin', () => {
       const app = {
         mixins: [
           forceIsServerMixin,
-          createServerRootMixin(
-            {
-              searchClient,
-              indexName: 'hello',
-            },
-            _renderToString
-          ),
+          createServerRootMixin({
+            searchClient,
+            indexName: 'hello',
+          }),
         ],
         render(h) {
           return h(InstantSearchSsr, {}, [
@@ -255,13 +221,10 @@ Array [
 
       const app = {
         mixins: [
-          createServerRootMixin(
-            {
-              searchClient: createFakeClient(),
-              indexName: 'hello',
-            },
-            _renderToString
-          ),
+          createServerRootMixin({
+            searchClient: createFakeClient(),
+            indexName: 'hello',
+          }),
         ],
         render(h) {
           return h(InstantSearchSsr, {}, [
@@ -304,13 +267,10 @@ Array [
 
       const app = {
         mixins: [
-          createServerRootMixin(
-            {
-              searchClient: createFakeClient(),
-              indexName: 'movies',
-            },
-            _renderToString
-          ),
+          createServerRootMixin({
+            searchClient: createFakeClient(),
+            indexName: 'movies',
+          }),
         ],
         render(h) {
           return h(InstantSearchSsr, {}, [
@@ -346,13 +306,10 @@ Array [
 
       const app = {
         mixins: [
-          createServerRootMixin(
-            {
-              searchClient: createFakeClient(),
-              indexName: 'hello',
-            },
-            _renderToString
-          ),
+          createServerRootMixin({
+            searchClient: createFakeClient(),
+            indexName: 'hello',
+          }),
         ],
         render(h) {
           return h(InstantSearchSsr, {}, [
@@ -387,13 +344,10 @@ Array [
 
       const app = {
         mixins: [
-          createServerRootMixin(
-            {
-              searchClient: createFakeClient(),
-              indexName: 'hello',
-            },
-            _renderToString
-          ),
+          createServerRootMixin({
+            searchClient: createFakeClient(),
+            indexName: 'hello',
+          }),
         ],
         render(h) {
           return h(InstantSearchSsr, {}, [
@@ -428,13 +382,10 @@ Array [
     it('calls render on widget', () => {
       const app = new Vue({
         mixins: [
-          createServerRootMixin(
-            {
-              searchClient: createFakeClient(),
-              indexName: 'lol',
-            },
-            _renderToString
-          ),
+          createServerRootMixin({
+            searchClient: createFakeClient(),
+            indexName: 'lol',
+          }),
         ],
       });
 
@@ -485,13 +436,10 @@ Object {
     it('has a fake createURL', () => {
       const app = new Vue({
         mixins: [
-          createServerRootMixin(
-            {
-              searchClient: createFakeClient(),
-              indexName: 'lol',
-            },
-            _renderToString
-          ),
+          createServerRootMixin({
+            searchClient: createFakeClient(),
+            indexName: 'lol',
+          }),
         ],
       });
 

--- a/src/util/__tests__/createServerRootMixin.test.js
+++ b/src/util/__tests__/createServerRootMixin.test.js
@@ -46,10 +46,13 @@ describe('createServerRootMixin', () => {
         () =>
           new Vue({
             mixins: [
-              createServerRootMixin({
-                searchClient: undefined,
-                indexName: 'lol',
-              }),
+              createServerRootMixin(
+                {
+                  searchClient: undefined,
+                  indexName: 'lol',
+                },
+                _renderToString
+              ),
             ],
           })
       ).toThrowErrorMatchingInlineSnapshot(
@@ -62,10 +65,13 @@ describe('createServerRootMixin', () => {
         () =>
           new Vue({
             mixins: [
-              createServerRootMixin({
-                searchClient: createFakeClient(),
-                indexName: undefined,
-              }),
+              createServerRootMixin(
+                {
+                  searchClient: createFakeClient(),
+                  indexName: undefined,
+                },
+                _renderToString
+              ),
             ],
           })
       ).toThrowErrorMatchingInlineSnapshot(
@@ -76,10 +82,13 @@ describe('createServerRootMixin', () => {
     it('creates an instantsearch instance on "data"', () => {
       const app = new Vue({
         mixins: [
-          createServerRootMixin({
-            searchClient: createFakeClient(),
-            indexName: 'lol',
-          }),
+          createServerRootMixin(
+            {
+              searchClient: createFakeClient(),
+              indexName: 'lol',
+            },
+            _renderToString
+          ),
         ],
       });
 
@@ -93,10 +102,13 @@ describe('createServerRootMixin', () => {
     it('provides the instantsearch instance ', () => {
       const App = {
         mixins: [
-          createServerRootMixin({
-            searchClient: createFakeClient(),
-            indexName: 'myIndexName',
-          }),
+          createServerRootMixin(
+            {
+              searchClient: createFakeClient(),
+              indexName: 'myIndexName',
+            },
+            _renderToString
+          ),
         ],
         render(h) {
           return h('div', {}, this.$slots.default);
@@ -138,10 +150,13 @@ describe('createServerRootMixin', () => {
     it('provides findResultsState', () => {
       const app = new Vue({
         mixins: [
-          createServerRootMixin({
-            searchClient: createFakeClient(),
-            indexName: 'hello',
-          }),
+          createServerRootMixin(
+            {
+              searchClient: createFakeClient(),
+              indexName: 'hello',
+            },
+            _renderToString
+          ),
         ],
         render(h) {
           return h(InstantSearchSsr);
@@ -157,10 +172,13 @@ describe('createServerRootMixin', () => {
       const app = {
         mixins: [
           forceIsServerMixin,
-          createServerRootMixin({
-            searchClient,
-            indexName: 'hello',
-          }),
+          createServerRootMixin(
+            {
+              searchClient,
+              indexName: 'hello',
+            },
+            _renderToString
+          ),
         ],
         render(h) {
           return h(InstantSearchSsr, {}, [
@@ -221,10 +239,13 @@ Array [
 
       const app = {
         mixins: [
-          createServerRootMixin({
-            searchClient: createFakeClient(),
-            indexName: 'hello',
-          }),
+          createServerRootMixin(
+            {
+              searchClient: createFakeClient(),
+              indexName: 'hello',
+            },
+            _renderToString
+          ),
         ],
         render(h) {
           return h(InstantSearchSsr, {}, [
@@ -267,10 +288,13 @@ Array [
 
       const app = {
         mixins: [
-          createServerRootMixin({
-            searchClient: createFakeClient(),
-            indexName: 'movies',
-          }),
+          createServerRootMixin(
+            {
+              searchClient: createFakeClient(),
+              indexName: 'movies',
+            },
+            _renderToString
+          ),
         ],
         render(h) {
           return h(InstantSearchSsr, {}, [
@@ -306,10 +330,13 @@ Array [
 
       const app = {
         mixins: [
-          createServerRootMixin({
-            searchClient: createFakeClient(),
-            indexName: 'hello',
-          }),
+          createServerRootMixin(
+            {
+              searchClient: createFakeClient(),
+              indexName: 'hello',
+            },
+            _renderToString
+          ),
         ],
         render(h) {
           return h(InstantSearchSsr, {}, [
@@ -344,10 +371,13 @@ Array [
 
       const app = {
         mixins: [
-          createServerRootMixin({
-            searchClient: createFakeClient(),
-            indexName: 'hello',
-          }),
+          createServerRootMixin(
+            {
+              searchClient: createFakeClient(),
+              indexName: 'hello',
+            },
+            _renderToString
+          ),
         ],
         render(h) {
           return h(InstantSearchSsr, {}, [
@@ -382,10 +412,13 @@ Array [
     it('calls render on widget', () => {
       const app = new Vue({
         mixins: [
-          createServerRootMixin({
-            searchClient: createFakeClient(),
-            indexName: 'lol',
-          }),
+          createServerRootMixin(
+            {
+              searchClient: createFakeClient(),
+              indexName: 'lol',
+            },
+            _renderToString
+          ),
         ],
       });
 
@@ -436,10 +469,13 @@ Object {
     it('has a fake createURL', () => {
       const app = new Vue({
         mixins: [
-          createServerRootMixin({
-            searchClient: createFakeClient(),
-            indexName: 'lol',
-          }),
+          createServerRootMixin(
+            {
+              searchClient: createFakeClient(),
+              indexName: 'lol',
+            },
+            _renderToString
+          ),
         ],
       });
 

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -54,10 +54,16 @@ function augmentInstantSearch(instantSearchOptions, searchClient, indexName) {
    * @returns {Promise} result of the search, to save for .hydrate
    */
   search.findResultsState = function(componentInstance) {
-    const _renderToString = require('vue-server-renderer/basic');
+    let _renderToString;
+    try {
+      _renderToString = require('vue-server-renderer/basic');
+    } catch (e) {
+      // error is handled by regular if, in case it's `undefined`
+    }
     if (!_renderToString) {
       throw new Error('you need to install vue-server-renderer');
     }
+
     let app;
 
     return Promise.resolve()

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -1,5 +1,4 @@
 import Vue from 'vue';
-import _renderToString from 'vue-server-renderer/basic';
 import instantsearch from 'instantsearch.js/es';
 import algoliaHelper from 'algoliasearch-helper';
 const { SearchResults, SearchParameters } = algoliaHelper;
@@ -15,7 +14,7 @@ function walkIndex(indexWidget, visit) {
   });
 }
 
-function renderToString(app) {
+function renderToString(app, _renderToString) {
   return new Promise((resolve, reject) =>
     _renderToString(app, (err, res) => {
       if (err) reject(err);
@@ -41,7 +40,12 @@ function searchOnlyWithDerivedHelpers(helper) {
   });
 }
 
-function augmentInstantSearch(instantSearchOptions, searchClient, indexName) {
+function augmentInstantSearch(
+  instantSearchOptions,
+  searchClient,
+  indexName,
+  _renderToString
+) {
   /* eslint-disable no-param-reassign */
 
   const helper = algoliaHelper(searchClient, indexName);
@@ -82,7 +86,7 @@ function augmentInstantSearch(instantSearchOptions, searchClient, indexName) {
           uiState: app.instantsearch._initialUiState,
         });
       })
-      .then(() => renderToString(app))
+      .then(() => renderToString(app, _renderToString))
       .then(() => searchOnlyWithDerivedHelpers(helper))
       .then(() => {
         const results = {};
@@ -224,7 +228,10 @@ function augmentInstantSearch(instantSearchOptions, searchClient, indexName) {
   return search;
 }
 
-export function createServerRootMixin(instantSearchOptions = {}) {
+export function createServerRootMixin(
+  instantSearchOptions = {},
+  _renderToString
+) {
   const { searchClient, indexName } = instantSearchOptions;
 
   if (!searchClient || !indexName) {
@@ -236,7 +243,8 @@ export function createServerRootMixin(instantSearchOptions = {}) {
   const search = augmentInstantSearch(
     instantSearchOptions,
     searchClient,
-    indexName
+    indexName,
+    _renderToString
   );
 
   // put this in the user's root Vue instance

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -236,7 +236,13 @@ export function createServerRootMixin(
 
   if (!searchClient || !indexName) {
     throw new Error(
-      'createServerRootMixin requires the `searchClient` and `indexName` arguments to be passed'
+      'createServerRootMixin requires `searchClient` and `indexName` in the first argument'
+    );
+  }
+
+  if (!_renderToString) {
+    throw new Error(
+      'createServerRootMixin requires "vue-server-renderer/basic" as the second argument`'
     );
   }
 

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -40,12 +40,7 @@ function searchOnlyWithDerivedHelpers(helper) {
   });
 }
 
-function augmentInstantSearch(
-  instantSearchOptions,
-  searchClient,
-  indexName,
-  _renderToString
-) {
+function augmentInstantSearch(instantSearchOptions, searchClient, indexName) {
   /* eslint-disable no-param-reassign */
 
   const helper = algoliaHelper(searchClient, indexName);
@@ -59,7 +54,12 @@ function augmentInstantSearch(
    * @returns {Promise} result of the search, to save for .hydrate
    */
   search.findResultsState = function(componentInstance) {
+    const _renderToString = require('vue-server-renderer/basic');
+    if (!_renderToString) {
+      throw new Error('you need to install vue-server-renderer');
+    }
     let app;
+
     return Promise.resolve()
       .then(() => {
         const options = {
@@ -228,10 +228,7 @@ function augmentInstantSearch(
   return search;
 }
 
-export function createServerRootMixin(
-  instantSearchOptions = {},
-  _renderToString
-) {
+export function createServerRootMixin(instantSearchOptions = {}) {
   const { searchClient, indexName } = instantSearchOptions;
 
   if (!searchClient || !indexName) {
@@ -240,17 +237,10 @@ export function createServerRootMixin(
     );
   }
 
-  if (!_renderToString) {
-    throw new Error(
-      'createServerRootMixin requires "vue-server-renderer/basic" as the second argument`'
-    );
-  }
-
   const search = augmentInstantSearch(
     instantSearchOptions,
     searchClient,
-    indexName,
-    _renderToString
+    indexName
   );
 
   // put this in the user's root Vue instance


### PR DESCRIPTION
this is done by making this dependency-injected to prevent the dependency being required for everyone

this is a breaking change, but I think I'll release it as 3.1.0 and will deprecate 3.0.0 & 3.0.1 as soon as this is merged and released Monday 