### PR TITLE
fix(ssr): allow getWidgetState to be empty for createURL

### DIFF
--- a/src/util/__tests__/createServerRootMixin.test.js
+++ b/src/util/__tests__/createServerRootMixin.test.js
@@ -433,35 +433,78 @@ Object {
       );
     });
 
-    it('has a fake createURL', () => {
-      const app = new Vue({
-        mixins: [
-          createServerRootMixin({
-            searchClient: createFakeClient(),
-            indexName: 'lol',
-          }),
-        ],
+    describe('createURL', () => {
+      it('returns # if instantsearch has no routing', () => {
+        const app = new Vue({
+          mixins: [
+            createServerRootMixin({
+              searchClient: createFakeClient(),
+              indexName: 'lol',
+            }),
+          ],
+        });
+
+        const widget = {
+          init: jest.fn(),
+          render: jest.fn(),
+        };
+
+        const instantSearchInstance = app.$data.instantsearch;
+
+        instantSearchInstance.hydrate({
+          lol: createSerializedState(),
+        });
+
+        instantSearchInstance.__forceRender(
+          widget,
+          instantSearchInstance.mainIndex
+        );
+
+        const renderArgs = widget.render.mock.calls[0][0];
+
+        expect(renderArgs.createURL()).toBe('#');
       });
 
-      const widget = {
-        init: jest.fn(),
-        render: jest.fn(),
-      };
+      it('allows for widgets without getWidgetState', () => {
+        const app = new Vue({
+          mixins: [
+            createServerRootMixin({
+              searchClient: createFakeClient(),
+              indexName: 'lol',
+            }),
+          ],
+        });
 
-      const instantSearchInstance = app.$data.instantsearch;
+        const widget = {
+          init: jest.fn(),
+          render: jest.fn(),
+          getWidgetState(uiState) {
+            return uiState;
+          },
+        };
 
-      instantSearchInstance.hydrate({
-        lol: createSerializedState(),
+        const widgetWithoutGetWidgetState = {
+          init: jest.fn(),
+          render: jest.fn(),
+        };
+
+        const instantSearchInstance = app.$data.instantsearch;
+
+        instantSearchInstance.hydrate({
+          lol: createSerializedState(),
+        });
+
+        instantSearchInstance.addWidgets([widget, widgetWithoutGetWidgetState]);
+
+        instantSearchInstance.__forceRender(
+          widget,
+          instantSearchInstance.mainIndex
+        );
+
+        const renderArgs = widget.render.mock.calls[0][0];
+
+        expect(renderArgs.createURL()).toBe('#');
       });
-
-      instantSearchInstance.__forceRender(
-        widget,
-        instantSearchInstance.mainIndex
-      );
-
-      const renderArgs = widget.render.mock.calls[0][0];
-
-      expect(renderArgs.createURL()).toBe('#');
     });
   });
 });

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -167,7 +167,7 @@ function augmentInstantSearch(instantSearchOptions, searchClient, indexName) {
           .getWidgets()
           .filter(w => w.$$type !== 'ais.index')
           .reduce((uiState, w) => {
-            if (!widget.getWidgetState) {
+            if (!w.getWidgetState) {
               return uiState;
             }
 


### PR DESCRIPTION
The check was on the widget itself, instead of on the current iteration. 

See this for original code which didn't have the issue:

https://github.com/algolia/instantsearch.js/blob/ada37ae054275d46cc2edaee0081562b6c35cbc8/src/widgets/index/index.ts#L101-L115