### PR TITLE
chore: assign the team automatically as release pr reviewers

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -1,0 +1,4 @@
+/* eslint-disable import/no-commonjs */
+module.exports = {
+  pullRequestTeamReviewer: ['instantsearch-for-websites'],
+};


### PR DESCRIPTION
This PR adds `ship.config.js` to add the team `instantsearch-for-websites` automatically as a reviewer for release PRs generated by Ship.js.