### PR TITLE
fix(highlight): don't remove whitespace-only nodes

### DIFF
--- a/src/components/Highlighter.vue
+++ b/src/components/Highlighter.vue
@@ -40,7 +40,7 @@ export default {
         functional: true,
         render(createElement, context) {
           const slots = context.slots();
-          return slots.default || ' ';
+          return slots.default;
         },
       },
     };

--- a/src/components/Highlighter.vue
+++ b/src/components/Highlighter.vue
@@ -5,7 +5,7 @@
       :class="[isHighlighted && suit('highlighted')]"
       :key="index"
       :is="isHighlighted ? highlightedTagName : textNode"
-    ><template v-if="value === ' '"> {{ value }} </template><template v-else>{{ value }}</template></component>
+    >{{ value }}</component>
   </span>
 </template>
 

--- a/src/components/Highlighter.vue
+++ b/src/components/Highlighter.vue
@@ -5,9 +5,7 @@
       :class="[isHighlighted && suit('highlighted')]"
       :key="index"
       :is="isHighlighted ? highlightedTagName : textNode"
-    ><template v-if="value === ' '">
-      {{ value }}
-    </template><template v-else>{{ value }}</template></component>
+    ><template v-if="value === ' '"> {{ value }} </template><template v-else>{{ value }}</template></component>
   </span>
 </template>
 

--- a/src/components/Highlighter.vue
+++ b/src/components/Highlighter.vue
@@ -1,13 +1,13 @@
 <template>
-  <span
-    :class="suit()"
-  >
+  <span :class="suit()">
     <component
       v-for="({ value, isHighlighted }, index) in parsedHighlights"
       :class="[isHighlighted && suit('highlighted')]"
       :key="index"
       :is="isHighlighted ? highlightedTagName : textNode"
-    >{{ value }}</component>
+    ><template v-if="value === ' '">
+      {{ value }}
+    </template><template v-else>{{ value }}</template></component>
   </span>
 </template>
 
@@ -40,7 +40,7 @@ export default {
         functional: true,
         render(createElement, context) {
           const slots = context.slots();
-          return slots.default;
+          return slots.default || ' ';
         },
       },
     };

--- a/src/components/__tests__/Highlight.js
+++ b/src/components/__tests__/Highlight.js
@@ -97,6 +97,6 @@ test('retains whitespace nodes', () => {
   });
 
   expect(wrapper.html()).toBe(
-    `<span class="ais-Highlight">con<marquee class="ais-Highlight-highlighted">tent</marquee>   <marquee class="ais-Highlight-highlighted">search</marquee>ing</span>`
+    `<span class="ais-Highlight">con<marquee class="ais-Highlight-highlighted">tent</marquee>  <marquee class="ais-Highlight-highlighted">search</marquee>ing</span>`
   );
 });

--- a/src/components/__tests__/Highlight.js
+++ b/src/components/__tests__/Highlight.js
@@ -97,8 +97,6 @@ test('retains whitespace nodes', () => {
   });
 
   expect(wrapper.html()).toBe(
-    `<span class="ais-Highlight">con<marquee class="ais-Highlight-highlighted">tent</marquee>
-${'       '}
-    <marquee class="ais-Highlight-highlighted">search</marquee>ing</span>`
+    `<span class="ais-Highlight">con<marquee class="ais-Highlight-highlighted">tent</marquee>   <marquee class="ais-Highlight-highlighted">search</marquee>ing</span>`
   );
 });

--- a/src/components/__tests__/Highlight.js
+++ b/src/components/__tests__/Highlight.js
@@ -78,3 +78,27 @@ test('allows usage of dot delimited path to access nested attribute', () => {
 
   expect(wrapper.html()).toMatchSnapshot();
 });
+
+test('retains whitespace nodes', () => {
+  const hit = {
+    _highlightResult: {
+      attr: {
+        value: `con<mark>tent</mark> <mark>search</mark>ing`,
+      },
+    },
+  };
+
+  const wrapper = mount(Highlight, {
+    propsData: {
+      attribute: 'attr',
+      highlightedTagName: 'marquee',
+      hit,
+    },
+  });
+
+  expect(wrapper.html()).toBe(
+    `<span class="ais-Highlight">con<marquee class="ais-Highlight-highlighted">tent</marquee>
+${'       '}
+    <marquee class="ais-Highlight-highlighted">search</marquee>ing</span>`
+  );
+});

--- a/src/util/parseAlgoliaHit.js
+++ b/src/util/parseAlgoliaHit.js
@@ -39,7 +39,10 @@ function parseHighlightedAttribute({ preTag, postTag, highlightedValue = '' }) {
 
       if (splitByPostTag[1] !== '') {
         elements.push({
-          value: splitByPostTag[1],
+          // Vue removes nodes which are just a single space (vuejs/vue#9208),
+          // we replace this by two spaces, which does not have an impact,
+          // unless someone would have `white-space: pre` on the highlights
+          value: splitByPostTag[1] === ' ' ? '  ' : splitByPostTag[1],
           isHighlighted: false,
         });
       }


### PR DESCRIPTION
Vue by default removes nodes which are just whitespace: https://github.com/vuejs/vue/blob/ec78fc8b6d03e59da669be1adf4b4b5abf670a34/dist/vue.common.dev.js#L2527

We need to prevent this, since sometimes between highlights, there is just a space, we need to make the value not "wrapped". We can't make the value always "block" (i don't know the correct name for this), since that would add spaces between "inline" highlights.

fixes #826