### PR TITLE
fix(ssr): fix missing scopedResults during render

### DIFF
--- a/src/util/__tests__/createServerRootMixin.test.js
+++ b/src/util/__tests__/createServerRootMixin.test.js
@@ -414,6 +414,13 @@ Array [
         {
           helper: expect.any(Object),
           results: expect.any(Object),
+          scopedResults: expect.arrayContaining([
+            expect.objectContaining({
+              helper: expect.any(Object),
+              indexId: expect.any(String),
+              results: expect.any(Object),
+            }),
+          ]),
           state: expect.any(Object),
           instantSearchInstance: expect.any(Object),
         },
@@ -423,6 +430,13 @@ Object {
   "helper": Any<Object>,
   "instantSearchInstance": Any<Object>,
   "results": Any<Object>,
+  "scopedResults": ArrayContaining [
+    ObjectContaining {
+      "helper": Any<Object>,
+      "indexId": Any<String>,
+      "results": Any<Object>,
+    },
+  ],
   "searchMetadata": Object {
     "isSearchStalled": false,
   },

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -178,9 +178,27 @@ function augmentInstantSearch(instantSearchOptions, searchClient, indexName) {
           }, {}),
       });
 
+    function resolveScopedResultsFromWidgets(widgets) {
+      const indexWidgets = widgets.filter(w => w.$$type === 'ais.index');
+
+      return indexWidgets.reduce(
+        (scopedResults, current) =>
+          scopedResults.concat(
+            {
+              indexId: current.getIndexId(),
+              results: search.__initialSearchResults[current.getIndexId()],
+              helper: current.getHelper(),
+            },
+            ...resolveScopedResultsFromWidgets(current.getWidgets())
+          ),
+        []
+      );
+    }
+
     widget.render({
       helper: localHelper,
       results,
+      scopedResults: resolveScopedResultsFromWidgets([parent]),
       state,
       templatesConfig: {},
       createURL,


### PR DESCRIPTION
The `scopedResults` object was missing when rendering the widget on server-side, crashing the widgets that were relying on it (like 
`AisCurrentRefinements` for example).

This PR fixes this by recalculating the scoped results and adding them to the render options (for this we're using the same method as in InstantSearch.js https://github.com/algolia/instantsearch.js/blob/68b20f487fcd54fd7dec11b4c494b6aa94a18516/src/widgets/index/index.ts#L154-L167)

Fixes #829