### PR TITLE
fix(range-input): fix range input min and max values fallbacks

### DIFF
--- a/src/components/RangeInput.vue
+++ b/src/components/RangeInput.vue
@@ -122,8 +122,12 @@ export default {
       const { min: minRange, max: maxRange } = this.state.range;
 
       return {
-        min: minValue !== -Infinity && minValue !== minRange ? minValue : null,
-        max: maxValue !== Infinity && maxValue !== maxRange ? maxValue : null,
+        min:
+          minValue !== -Infinity && minValue !== minRange
+            ? minValue
+            : undefined,
+        max:
+          maxValue !== Infinity && maxValue !== maxRange ? maxValue : undefined,
       };
     },
   },


### PR DESCRIPTION
When calculating the range in `RangeInput.vue` the `min` and `max` values can fallback to `null`, which is not handled by the `connectRange` connector from `InstantSearch.js` (it expect either `undefined` or an empty string if the `min`/`max` value is not set).

See detailed report in https://github.com/algolia/vue-instantsearch/issues/833

This PR updates the fallback to `undefined` so the contract with `connectRange` is respected.

Fixes #833