### PR TITLE
feat(vue 3): prevent error by migrating events to mitt

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "dependencies": {
     "algoliasearch-helper": "^3.1.0",
     "instantsearch.js": "^4.20.0",
-    "vue-demi": "npm:@eunjae-lee/vue-demi@0.9.3"
+    "vue-demi": "npm:@eunjae-lee/vue-demi@0.9.3",
+    "mitt": "^2.1.0"
   },
   "peerDependencies": {
     "algoliasearch": ">= 3.32.0 < 5",

--- a/src/mixins/panel.js
+++ b/src/mixins/panel.js
@@ -1,4 +1,4 @@
-import Vue from 'vue';
+import mitt from 'mitt';
 
 export const PANEL_EMITTER_NAMESPACE = 'instantSearchPanelEmitter';
 export const PANEL_CHANGE_EVENT = 'PANEL_CHANGE_EVENT';
@@ -9,9 +9,7 @@ export const createPanelProviderMixin = () => ({
       type: Object,
       required: false,
       default() {
-        return new Vue({
-          name: 'PanelProvider',
-        });
+        return mitt();
       },
     },
   },
@@ -26,12 +24,12 @@ export const createPanelProviderMixin = () => ({
     };
   },
   created() {
-    this.emitter.$on(PANEL_CHANGE_EVENT, value => {
+    this.emitter.on(PANEL_CHANGE_EVENT, value => {
       this.updateCanRefine(value);
     });
   },
   beforeDestroy() {
-    this.emitter.$destroy();
+    this.emitter.all.clear();
   },
   methods: {
     updateCanRefine(value) {
@@ -46,7 +44,7 @@ export const createPanelConsumerMixin = ({ mapStateToCanRefine }) => ({
       from: PANEL_EMITTER_NAMESPACE,
       default() {
         return {
-          $emit: () => {},
+          emit: () => {},
         };
       },
     },
@@ -69,8 +67,7 @@ export const createPanelConsumerMixin = ({ mapStateToCanRefine }) => ({
         const nextCanRefine = mapStateToCanRefine(nextState);
 
         if (!this.hasAlreadyEmitted || previousCanRefine !== nextCanRefine) {
-          this.emitter.$emit(PANEL_CHANGE_EVENT, nextCanRefine);
-
+          this.emitter.emit(PANEL_CHANGE_EVENT, nextCanRefine);
           this.hasAlreadyEmitted = true;
         }
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10123,6 +10123,11 @@ mississippi@^2.0.0:
     stream-each "^1.1.0"
     through2 "^2.0.0"
 
+mitt@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-2.1.0.tgz#f740577c23176c6205b121b2973514eade1b2230"
+  integrity sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg==
+
 mixin-deep@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"


### PR DESCRIPTION
Mitt is quite small, so doesn't have a big impact on bundlesize.

see https://v3.vuejs.org/guide/migration/events-api.html

This doesn't make it incompatible with Vue 2