### PR TITLE
feat(vue 3): compat for both versions of v-model

### DIFF
--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -219,6 +219,7 @@ export default {
       };
     },
   },
+  emits: ['page-change'],
   methods: {
     refine(page) {
       const p = Math.min(Math.max(page, 0), this.state.nbPages - 1);

--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -78,6 +78,10 @@ export default {
       type: String,
       default: undefined,
     },
+    modelValue: {
+      type: String,
+      default: undefined,
+    },
   },
   data() {
     return {
@@ -86,25 +90,33 @@ export default {
   },
   computed: {
     isControlled() {
-      return typeof this.value !== 'undefined';
+      return (
+        typeof this.value !== 'undefined' ||
+        typeof this.modelValue !== 'undefined'
+      );
+    },
+    model() {
+      return this.value || this.modelValue;
     },
     currentRefinement: {
       get() {
         // if the input is controlled, but not up to date
         // this means it didn't search, and we should pretend it was `set`
-        if (this.isControlled && this.value !== this.localValue) {
+        if (this.isControlled && this.model !== this.localValue) {
           // eslint-disable-next-line vue/no-side-effects-in-computed-properties
-          this.localValue = this.value;
-          this.$emit('input', this.value);
-          this.state.refine(this.value);
+          this.localValue = this.model;
+          this.$emit('input', this.model);
+          this.$emit('update:modelValue', this.model);
+          this.state.refine(this.model);
         }
-        return this.value || this.state.query || '';
+        return this.model || this.state.query || '';
       },
       set(val) {
         this.localValue = val;
         this.state.refine(val);
         if (this.isControlled) {
           this.$emit('input', val);
+          this.$emit('update:modelValue', val);
         }
       },
     },

--- a/src/components/SearchInput.vue
+++ b/src/components/SearchInput.vue
@@ -7,7 +7,8 @@
     @submit.prevent="onFormSubmit"
     @reset.prevent="onFormReset"
   >
-    <!-- :value/@input allows us to pass v-model to the component -->
+    <!-- :value/@input allows us to pass v-model to the component in v2 -->
+    <!-- :modelValue/@update:modelValue allows us to pass v-model to the component in v3 -->
     <input
       type="search"
       autocorrect="off"
@@ -20,10 +21,10 @@
       :placeholder="placeholder"
       :autofocus="autofocus"
       :class="suit('input')"
-      :value="value"
+      :value="value || modelValue"
       @focus="$emit('focus', $event)"
       @blur="$emit('blur', $event)"
-      @input="$emit('input', $event.target.value)"
+      @input="$emit('input', $event.target.value); $emit('update:modelValue', $event.target.value)"
       ref="input"
     >
     <button
@@ -53,7 +54,7 @@
       type="reset"
       :title="resetTitle"
       :class="suit('reset')"
-      :hidden="!value || (showLoadingIndicator && shouldShowLoadingIndicator)"
+      :hidden="(!value && !modelValue) || (showLoadingIndicator && shouldShowLoadingIndicator)"
     >
       <slot name="reset-icon">
         <svg
@@ -153,9 +154,14 @@ export default {
     },
     value: {
       type: String,
-      required: true,
+      required: false,
     },
+    modelValue: {
+      type: String,
+      required: false,
+    }
   },
+  emits: ['input', 'update:modelValue', 'blur', 'focus', 'reset'],
   data() {
     return {
       query: '',
@@ -168,6 +174,7 @@ export default {
     },
     onFormReset() {
       this.$emit('input', '');
+      this.$emit('update:modelValue', '');
       this.$emit('reset');
     },
   },


### PR DESCRIPTION
v-model used to be @input / :value, but is now @update:modelValue / :modelValue. Since those don't overlap, it's possible to support both, by using them as fallback

"emits" is now also required in v3, so I added this to all components emitting

docs: https://v3.vuejs.org/guide/migration/v-model.html