### PR TITLE
feat(vue 3): make highlighter compatible

### DIFF
--- a/src/components/Highlighter.vue
+++ b/src/components/Highlighter.vue
@@ -4,13 +4,25 @@
       v-for="({ value, isHighlighted }, index) in parsedHighlights"
       :class="[isHighlighted && suit('highlighted')]"
       :key="index"
-      :is="isHighlighted ? highlightedTagName : textNode"
+      :is="isHighlighted ? highlightedTagName : TextNode"
     >{{ value }}</component>
   </span>
 </template>
 
 <script>
-import { parseAlgoliaHit } from '../util/parseAlgoliaHit';
+import { parseAlgoliaHit } from "../util/parseAlgoliaHit";
+import * as Vue from "vue";
+
+const TextNode =
+  Vue.version && Vue.version.split(".")[0] === "3"
+    ? (props, context) => context.slots.default()
+    : {
+        functional: true,
+        render(createElement, context) {
+          const slots = context.slots();
+          return slots.default;
+        }
+      };
 
 export default {
   name: 'AisHighlighter',
@@ -33,15 +45,7 @@ export default {
     postTag: { type: String, required: true },
   },
   data() {
-    return {
-      textNode: {
-        functional: true,
-        render(createElement, context) {
-          const slots = context.slots();
-          return slots.default;
-        },
-      },
-    };
+    return { TextNode };
   },
   computed: {
     parsedHighlights() {

--- a/src/components/Highlighter.vue
+++ b/src/components/Highlighter.vue
@@ -10,19 +10,18 @@
 </template>
 
 <script>
-import { parseAlgoliaHit } from "../util/parseAlgoliaHit";
-import * as Vue from "vue";
+import { isVue3 } from 'vue-demi';
+import { parseAlgoliaHit } from '../util/parseAlgoliaHit';
 
-const TextNode =
-  Vue.version && Vue.version.split(".")[0] === "3"
-    ? (props, context) => context.slots.default()
-    : {
-        functional: true,
-        render(createElement, context) {
-          const slots = context.slots();
-          return slots.default;
-        }
-      };
+const TextNode = isVue3
+  ? (props, context) => context.slots.default()
+  : {
+      functional: true,
+      render(createElement, context) {
+        const slots = context.slots();
+        return slots.default;
+      },
+    };
 
 export default {
   name: 'AisHighlighter',


### PR DESCRIPTION
In Vue 3 "functional" components no longer exist and are replaced with functions. Since Vue 2 has `Vue.default.version` and Vue 3 ahas `Vue.version`, this is how we can detect it, however I might move this to a function

docs: https://v3.vuejs.org/guide/migration/functional-components.html