### PR TITLE
feat(vue 3): make render function of JS files compatible

### DIFF
--- a/src/components/Configure.js
+++ b/src/components/Configure.js
@@ -1,6 +1,7 @@
 import { createWidgetMixin } from '../mixins/widget';
 import { createSuitMixin } from '../mixins/suit';
 import { connectConfigure } from 'instantsearch.js/es/connectors';
+import * as Vue from 'vue';
 
 export default {
   inheritAttrs: false,
@@ -17,17 +18,22 @@ export default {
     },
   },
   render(createElement) {
-    if (!this.state || !this.$scopedSlots.default) {
+    const slot =
+      'default' in this.$slots
+        ? this.$slots.default
+        : this.$scopedSlots.default;
+
+    if (!this.state || !slot) {
       return null;
     }
 
-    return createElement(
+    return (Vue.h || createElement)(
       'div',
       {
         class: this.suit(),
       },
       [
-        this.$scopedSlots.default({
+        slot({
           refine: this.state.refine,
           searchParameters: this.state.widgetParams.searchParameters,
         }),

--- a/src/components/Configure.js
+++ b/src/components/Configure.js
@@ -1,7 +1,7 @@
 import { createWidgetMixin } from '../mixins/widget';
 import { createSuitMixin } from '../mixins/suit';
 import { connectConfigure } from 'instantsearch.js/es/connectors';
-import * as Vue from 'vue';
+import { isVue3, h } from 'vue-demi';
 
 export default {
   inheritAttrs: false,
@@ -18,16 +18,13 @@ export default {
     },
   },
   render(createElement) {
-    const slot =
-      'default' in this.$slots
-        ? this.$slots.default
-        : this.$scopedSlots.default;
+    const slot = isVue3 ? this.$slots.default : this.$scopedSlots.default;
 
     if (!this.state || !slot) {
       return null;
     }
 
-    return (Vue.h || createElement)(
+    return (isVue3 ? h : createElement)(
       'div',
       {
         class: this.suit(),

--- a/src/components/Index.js
+++ b/src/components/Index.js
@@ -1,6 +1,7 @@
 import { createSuitMixin } from '../mixins/suit';
 import { createWidgetMixin } from '../mixins/widget';
 import indexWidget from 'instantsearch.js/es/widgets/index/index';
+import * as Vue from 'vue';
 
 // wrapped in a dummy function, since indexWidget doesn't render
 const connectIndex = () => indexWidget;
@@ -28,8 +29,14 @@ export default {
       required: false,
     },
   },
-  render(createElement) {
-    return createElement('div', {}, this.$slots.default);
+  render(h) {
+    return (Vue.h || h)(
+      'div',
+      {},
+      typeof this.$slots.default === 'function'
+        ? this.$slots.default()
+        : this.$slots.default
+    );
   },
   computed: {
     widgetParams() {

--- a/src/components/Index.js
+++ b/src/components/Index.js
@@ -1,7 +1,7 @@
 import { createSuitMixin } from '../mixins/suit';
 import { createWidgetMixin } from '../mixins/widget';
 import indexWidget from 'instantsearch.js/es/widgets/index/index';
-import * as Vue from 'vue';
+import { isVue3, h } from 'vue-demi';
 
 // wrapped in a dummy function, since indexWidget doesn't render
 const connectIndex = () => indexWidget;
@@ -29,13 +29,11 @@ export default {
       required: false,
     },
   },
-  render(h) {
-    return (Vue.h || h)(
+  render(createElement) {
+    return (isVue3 ? h : createElement)(
       'div',
       {},
-      typeof this.$slots.default === 'function'
-        ? this.$slots.default()
-        : this.$slots.default
+      isVue3 ? this.$slots.default() : this.$slots.default
     );
   },
   computed: {

--- a/src/components/InstantSearch.js
+++ b/src/components/InstantSearch.js
@@ -1,6 +1,7 @@
 import instantsearch from 'instantsearch.js/es';
 import { createInstantSearchComponent } from '../util/createInstantSearchComponent';
 import { warn } from '../util/warn';
+import * as Vue from 'vue';
 
 const oldApiWarning = `Vue InstantSearch: You used the prop api-key or app-id.
 These have been replaced by search-client.
@@ -87,8 +88,8 @@ export default createInstantSearchComponent({
       }),
     };
   },
-  render(createElement) {
-    return createElement(
+  render(h) {
+    return (Vue.h || h)(
       'div',
       {
         class: {
@@ -96,7 +97,9 @@ export default createInstantSearchComponent({
           [this.suit('', 'ssr')]: false,
         },
       },
-      this.$slots.default
+      typeof this.$slots.default === 'function'
+        ? this.$slots.default()
+        : this.$slots.default
     );
   },
 });

--- a/src/components/InstantSearch.js
+++ b/src/components/InstantSearch.js
@@ -1,7 +1,7 @@
 import instantsearch from 'instantsearch.js/es';
 import { createInstantSearchComponent } from '../util/createInstantSearchComponent';
 import { warn } from '../util/warn';
-import * as Vue from 'vue';
+import { isVue3, h } from 'vue-demi';
 
 const oldApiWarning = `Vue InstantSearch: You used the prop api-key or app-id.
 These have been replaced by search-client.
@@ -88,8 +88,8 @@ export default createInstantSearchComponent({
       }),
     };
   },
-  render(h) {
-    return (Vue.h || h)(
+  render(createElement) {
+    return (isVue3 ? h : createElement)(
       'div',
       {
         class: {
@@ -97,9 +97,7 @@ export default createInstantSearchComponent({
           [this.suit('', 'ssr')]: false,
         },
       },
-      typeof this.$slots.default === 'function'
-        ? this.$slots.default()
-        : this.$slots.default
+      isVue3 ? this.$slots.default() : this.$slots.default
     );
   },
 });

--- a/src/components/InstantSearchSsr.js
+++ b/src/components/InstantSearchSsr.js
@@ -1,4 +1,5 @@
 import { createInstantSearchComponent } from '../util/createInstantSearchComponent';
+import * as Vue from 'vue';
 
 export default createInstantSearchComponent({
   name: 'AisInstantSearchSsr',
@@ -14,8 +15,8 @@ export default createInstantSearchComponent({
       instantSearchInstance: this.$_ais_ssrInstantSearchInstance,
     };
   },
-  render(createElement) {
-    return createElement(
+  render(h) {
+    return (Vue.h || h)(
       'div',
       {
         class: {
@@ -23,7 +24,9 @@ export default createInstantSearchComponent({
           [this.suit('', 'ssr')]: true,
         },
       },
-      this.$slots.default
+      typeof this.$slots.default === 'function'
+        ? this.$slots.default()
+        : this.$slots.default
     );
   },
 });

--- a/src/components/InstantSearchSsr.js
+++ b/src/components/InstantSearchSsr.js
@@ -1,5 +1,5 @@
 import { createInstantSearchComponent } from '../util/createInstantSearchComponent';
-import * as Vue from 'vue';
+import { isVue3, h } from 'vue-demi';
 
 export default createInstantSearchComponent({
   name: 'AisInstantSearchSsr',
@@ -15,8 +15,8 @@ export default createInstantSearchComponent({
       instantSearchInstance: this.$_ais_ssrInstantSearchInstance,
     };
   },
-  render(h) {
-    return (Vue.h || h)(
+  render(createElement) {
+    return (isVue3 ? h : createElement)(
       'div',
       {
         class: {
@@ -24,9 +24,7 @@ export default createInstantSearchComponent({
           [this.suit('', 'ssr')]: true,
         },
       },
-      typeof this.$slots.default === 'function'
-        ? this.$slots.default()
-        : this.$slots.default
+      isVue3 ? this.$slots.default() : this.$slots.default
     );
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -15561,10 +15561,10 @@ vue-class-component@^7.0.1:
   resolved "https://registry.yarnpkg.com/vue-class-component/-/vue-class-component-7.0.1.tgz#7af2225c600667c7042b60712eefdf41dfc6de63"
   integrity sha512-YIihdl7YmceEOjSwcxLhCXCNA3TKC2FStuMcjtuzhUAgw5x5d1T5gZTmVQHGyOaQsaKffL4GlZzYN3dlMYl53w==
 
-"vue-demi@npm:@eunjae-lee/vue-demi@0.9.2":
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/@eunjae-lee/vue-demi/-/vue-demi-0.9.2.tgz#234bb04c3cd0a5c85894cf8f2ac9a9bdb183d315"
-  integrity sha512-6q6RPme8/ZXscocbnMGc/xC+cKDgKLL36OaT15y0wBt/iIfXFrircucBatCIustAxSNtxTMRXHqEri3nS/pw4w==
+"vue-demi@npm:@eunjae-lee/vue-demi@0.9.3":
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/@eunjae-lee/vue-demi/-/vue-demi-0.9.3.tgz#40bc053a7089845a3eea7da224d08237afbaeedc"
+  integrity sha512-EYogDQ9qjQqAIHEDIBk7lyO/w8Q1Efu91F2s/qMOZMB+xDuR0thfSsst/dA6beuynqHfVLqGM+prvpPk8cs3Mw==
 
 vue-eslint-parser@^2.0.3:
   version "2.0.3"


### PR DESCRIPTION
createElement is no longer passed to the `render`, you need to import it statically. Unfortunately they didn't also add this export in v2 already

see: https://v3.vuejs.org/guide/migration/render-function-api.html