### PR TITLE
feat(ssr): forward router instance to findResultsState clone

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "vue-jest": "2.6.0",
     "vue-json-tree": "0.3.3",
     "vue-loader": "14.2.2",
-    "vue-router": "^3.4.3",
+    "vue-router": "3.4.3",
     "vue-server-renderer": "^2.6.11",
     "vue-slider-component": "3.0.15",
     "vue-template-compiler": "2.5.18",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "vue-jest": "2.6.0",
     "vue-json-tree": "0.3.3",
     "vue-loader": "14.2.2",
+    "vue-router": "^3.4.3",
     "vue-server-renderer": "^2.6.11",
     "vue-slider-component": "3.0.15",
     "vue-template-compiler": "2.5.18",

--- a/src/util/__tests__/createServerRootMixin.test.js
+++ b/src/util/__tests__/createServerRootMixin.test.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import { mount } from '@vue/test-utils';
 import _renderToString from 'vue-server-renderer/basic';
+import Router from 'vue-router';
 import { createServerRootMixin } from '../createServerRootMixin';
 import InstantSearchSsr from '../../components/InstantSearchSsr';
 import Configure from '../../components/Configure';
@@ -212,6 +213,54 @@ Array [
   },
 ]
 `);
+    });
+
+    it('forwards router', async () => {
+      const searchClient = createFakeClient();
+
+      const router = new Router({});
+
+      // there are two renders of App, each with an assertion
+      expect.assertions(2);
+
+      const App = Vue.component('App', {
+        mixins: [
+          forceIsServerMixin,
+          createServerRootMixin({
+            searchClient,
+            indexName: 'hello',
+          }),
+        ],
+        data() {
+          expect(this.$router).toBe(router);
+          return {};
+        },
+        render(h) {
+          return h(InstantSearchSsr, {}, [
+            h(Configure, {
+              attrs: {
+                hitsPerPage: 100,
+              },
+            }),
+            h(SearchBox),
+          ]);
+        },
+        serverPrefetch() {
+          return this.instantsearch.findResultsState(this);
+        },
+      });
+
+      Vue.use(Router);
+
+      const wrapper = new Vue({
+        mixins: [forceIsServerMixin],
+        router,
+        render(h) {
+          return h(App);
+        },
+      });
+
+      await renderToString(wrapper);
     });
   });
 

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -74,9 +74,7 @@ function augmentInstantSearch(instantSearchOptions, searchClient, indexName) {
           _base: undefined,
           name: 'ais-ssr-root-component',
           // copy over global Vue APIs
-          router: componentInstance._routerRoot
-            ? componentInstance._routerRoot._router
-            : undefined,
+          router: componentInstance.$router,
         };
 
         const extended = componentInstance.$vnode

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -73,6 +73,10 @@ function augmentInstantSearch(instantSearchOptions, searchClient, indexName) {
           fetch: undefined,
           _base: undefined,
           name: 'ais-ssr-root-component',
+          // copy over global Vue APIs
+          router: componentInstance._routerRoot
+            ? componentInstance._routerRoot._router
+            : undefined,
         };
 
         const extended = componentInstance.$vnode

--- a/yarn.lock
+++ b/yarn.lock
@@ -15612,7 +15612,7 @@ vue-property-decorator@^8.0.0:
   dependencies:
     vue-class-component "^7.0.1"
 
-vue-router@^3.4.3:
+vue-router@3.4.3:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.4.3.tgz#fa93768616ee338aa174f160ac965167fa572ffa"
   integrity sha512-BADg1mjGWX18Dpmy6bOGzGNnk7B/ZA0RxuA6qedY/YJwirMfKXIDzcccmHbQI0A6k5PzMdMloc0ElHfyOoX35A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -15612,6 +15612,11 @@ vue-property-decorator@^8.0.0:
   dependencies:
     vue-class-component "^7.0.1"
 
+vue-router@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.4.3.tgz#fa93768616ee338aa174f160ac965167fa572ffa"
+  integrity sha512-BADg1mjGWX18Dpmy6bOGzGNnk7B/ZA0RxuA6qedY/YJwirMfKXIDzcccmHbQI0A6k5PzMdMloc0ElHfyOoX35A==
+
 vue-server-renderer@^2.6.11:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/vue-server-renderer/-/vue-server-renderer-2.6.11.tgz#be8c9abc6aacc309828a755c021a05fc474b4bc3"


### PR DESCRIPTION
in our guide for routing with vue router, you need to access the Vue Router instance. The most straightforward way for that is to move the construction of the server mixin into `data()`. `router` is useful for creating an instantsearch router compatible with vueRouter