### PR TITLE
feat(ssr): forward vuex instance to findResultsState clone

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
     "vue-server-renderer": "^2.6.11",
     "vue-slider-component": "3.0.15",
     "vue-template-compiler": "2.5.18",
-    "vuetify": "1.5.3"
+    "vuetify": "1.5.3",
+    "vuex": "3.5.1"
   },
   "bundlesize": [
     {

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -75,6 +75,7 @@ function augmentInstantSearch(instantSearchOptions, searchClient, indexName) {
           name: 'ais-ssr-root-component',
           // copy over global Vue APIs
           router: componentInstance.$router,
+          store: componentInstance.$store,
         };
 
         const extended = componentInstance.$vnode

--- a/yarn.lock
+++ b/yarn.lock
@@ -15676,6 +15676,11 @@ vuetify@1.5.3:
   resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-1.5.3.tgz#4bdc0a72ade1cd3521dc0c08a363ea40b914443e"
   integrity sha512-4V3i4HwKdt//1vAEiex3DpHsLwX3oHCIx/gpukSYvBGJUgHILUZ5JOEOAQJ1yvMV1w3P+dsmvlmRdthjci5VRg==
 
+vuex@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/vuex/-/vuex-3.5.1.tgz#f1b8dcea649bc25254cf4f4358081dbf5da18b3d"
+  integrity sha512-w7oJzmHQs0FM9LXodfskhw9wgKBiaB+totOdb8sNzbTB2KDCEEwEs29NzBZFh/lmEK1t5tDmM1vtsO7ubG1DFw==
+
 walker@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"


### PR DESCRIPTION
Regardless of whether you _need_ to access it, it's commonly done for otherwise prerendered state. Since Vuex is a core plugin, we must support it like this

stacked PR on #863 