### PR TITLE
feat(ssr): forward propsData to recreated component

### DIFF
--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -76,14 +76,17 @@ function augmentInstantSearch(instantSearchOptions, searchClient, indexName) {
           // copy over global Vue APIs
           router: componentInstance.$router,
           store: componentInstance.$store,
-          propsData: componentInstance.$options.propsData,
         };
 
-        const extended = componentInstance.$vnode
+        const Extended = componentInstance.$vnode
           ? componentInstance.$vnode.componentOptions.Ctor.extend(options)
-          : Object.assign({}, componentInstance.$options, options);
+          : Vue.component(
+              Object.assign({}, componentInstance.$options, options)
+            );
 
-        app = new Vue(extended);
+        app = new Extended({
+          propsData: componentInstance.$options.propsData,
+        });
 
         app.$options.serverPrefetch = [];
 

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -76,6 +76,7 @@ function augmentInstantSearch(instantSearchOptions, searchClient, indexName) {
           // copy over global Vue APIs
           router: componentInstance.$router,
           store: componentInstance.$store,
+          propsData: componentInstance.$options.propsData,
         };
 
         const extended = componentInstance.$vnode


### PR DESCRIPTION
propsData isn't valid as argument to `.extend`, but you don't need to call `new Vue(comp)`, it's the same as calling `new comp({propsData...})`