### PR TITLE
fix: fix crash in mapStateToCanRefine when state is empty

### DIFF
--- a/src/components/Breadcrumb.vue
+++ b/src/components/Breadcrumb.vue
@@ -58,7 +58,7 @@ export default {
   mixins: [
     createWidgetMixin({ connector: connectBreadcrumb }),
     createPanelConsumerMixin({
-      mapStateToCanRefine: state => state.canRefine,
+      mapStateToCanRefine: state => Boolean(state.canRefine),
     }),
     createSuitMixin({ name: 'Breadcrumb' }),
   ],

--- a/src/components/ClearRefinements.vue
+++ b/src/components/ClearRefinements.vue
@@ -31,7 +31,7 @@ export default {
   mixins: [
     createWidgetMixin({ connector: connectClearRefinements }),
     createPanelConsumerMixin({
-      mapStateToCanRefine: state => state.hasRefinements,
+      mapStateToCanRefine: state => Boolean(state.hasRefinements),
     }),
     createSuitMixin({ name: 'ClearRefinements' }),
   ],

--- a/src/components/CurrentRefinements.vue
+++ b/src/components/CurrentRefinements.vue
@@ -65,7 +65,8 @@ export default {
     createSuitMixin({ name: 'CurrentRefinements' }),
     createWidgetMixin({ connector: connectCurrentRefinements }),
     createPanelConsumerMixin({
-      mapStateToCanRefine: state => state.items.length > 0,
+      mapStateToCanRefine: state =>
+        Boolean(state.items && state.items.length > 0),
     }),
   ],
   props: {

--- a/src/components/HierarchicalMenu.vue
+++ b/src/components/HierarchicalMenu.vue
@@ -45,7 +45,8 @@ import { createPanelConsumerMixin } from '../mixins/panel';
 import HierarchicalMenuList from './HierarchicalMenuList.vue';
 import { createSuitMixin } from '../mixins/suit';
 
-const mapStateToCanRefine = state => state.items.length > 0;
+const mapStateToCanRefine = state =>
+  Boolean(state.items && state.items.length > 0);
 
 export default {
   name: 'AisHierarchicalMenu',

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -56,7 +56,7 @@ export default {
     createSuitMixin({ name: 'Menu' }),
     createWidgetMixin({ connector: connectMenu }),
     createPanelConsumerMixin({
-      mapStateToCanRefine: state => state.canRefine,
+      mapStateToCanRefine: state => Boolean(state.canRefine),
     }),
   ],
   props: {

--- a/src/components/MenuSelect.vue
+++ b/src/components/MenuSelect.vue
@@ -48,7 +48,7 @@ export default {
     createSuitMixin({ name: 'MenuSelect' }),
     createWidgetMixin({ connector: connectMenu }),
     createPanelConsumerMixin({
-      mapStateToCanRefine: state => state.canRefine,
+      mapStateToCanRefine: state => Boolean(state.canRefine),
     }),
   ],
   props: {

--- a/src/components/RefinementList.vue
+++ b/src/components/RefinementList.vue
@@ -111,7 +111,7 @@ export default {
     createSuitMixin({ name: 'RefinementList' }),
     createWidgetMixin({ connector: connectRefinementList }),
     createPanelConsumerMixin({
-      mapStateToCanRefine: state => state.canRefine,
+      mapStateToCanRefine: state => Boolean(state.canRefine),
     }),
   ],
   props: {

--- a/src/components/ToggleRefinement.vue
+++ b/src/components/ToggleRefinement.vue
@@ -34,7 +34,7 @@ import { createWidgetMixin } from '../mixins/widget';
 import { createPanelConsumerMixin } from '../mixins/panel';
 import { createSuitMixin } from '../mixins/suit';
 
-const mapStateToCanRefine = state => Boolean(state.value.count);
+const mapStateToCanRefine = state => Boolean(state.value && state.value.count);
 
 export default {
   name: 'AisToggleRefinement',


### PR DESCRIPTION
Since #871 `mapStateToCanRefine` can be called with an empty object. It was triggering some crashes if we where trying to access some deep properties from `state` in it.

This fix address two things on this:
* Add some checks for the existence of each level in the `state` object.
* Cast the return value so are sure to return a `Boolean`.

TODO: Tests are missing, I'm not sure on how to test this, any idea @Haroenv ?

fixes #874