### PR TITLE
fix(ssr): forward slots of the AisInstantSearchSsr component

### DIFF
--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -90,6 +90,7 @@ function augmentInstantSearch(instantSearchOptions, searchClient, indexName) {
 
         // https://stackoverflow.com/a/48195006/3185307
         app.$slots = componentInstance.$slots;
+        app.$scopedSlots = componentInstance.$scopedSlots;
 
         app.$options.serverPrefetch = [];
 

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -88,6 +88,9 @@ function augmentInstantSearch(instantSearchOptions, searchClient, indexName) {
           propsData: componentInstance.$options.propsData,
         });
 
+        // https://stackoverflow.com/a/48195006/3185307
+        app.$slots = componentInstance.$slots;
+
         app.$options.serverPrefetch = [];
 
         app.instantsearch.helper = helper;

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -90,7 +90,7 @@ function augmentInstantSearch(instantSearchOptions, searchClient, indexName) {
 
         // https://stackoverflow.com/a/48195006/3185307
         app.$slots = componentInstance.$slots;
-        app.$scopedSlots = componentInstance.$scopedSlots;
+
         app.$root = componentInstance.$root;
 
         app.$options.serverPrefetch = [];

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -91,6 +91,7 @@ function augmentInstantSearch(instantSearchOptions, searchClient, indexName) {
         // https://stackoverflow.com/a/48195006/3185307
         app.$slots = componentInstance.$slots;
         app.$scopedSlots = componentInstance.$scopedSlots;
+        app.$root = componentInstance.$root;
 
         app.$options.serverPrefetch = [];
 
@@ -163,6 +164,12 @@ function augmentInstantSearch(instantSearchOptions, searchClient, indexName) {
     const localHelper = parent.getHelper();
 
     const results = search.__initialSearchResults[parent.getIndexId()];
+
+    // this happens when a different InstantSearch gets rendered initially,
+    // after the hydrate finished. There's thus no initial results available.
+    if (!results) {
+      return;
+    }
 
     const state = results._state;
 


### PR DESCRIPTION
The clone created in findResultsState also manually needs to forward slots, or the data won't be available.