### PR TITLE
 feat(ais-dynamic-widgets): add implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
   "bundlesize": [
     {
       "path": "./dist/vue-instantsearch.js",
-      "maxSize": "53.50 kB"
+      "maxSize": "54 kB"
     },
     {
       "path": "./dist/vue-instantsearch.common.js",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "algoliasearch-helper": "^3.1.0",
-    "instantsearch.js": "^4.24.0"
+    "instantsearch.js": "^4.25.0"
   },
   "peerDependencies": {
     "algoliasearch": ">= 3.32.0 < 5",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "algoliasearch-helper": "^3.1.0",
-    "instantsearch.js": "^4.20.0"
+    "instantsearch.js": "^4.22.0"
   },
   "peerDependencies": {
     "algoliasearch": ">= 3.32.0 < 5",
@@ -114,7 +114,7 @@
   "bundlesize": [
     {
       "path": "./dist/vue-instantsearch.js",
-      "maxSize": "53.00 kB"
+      "maxSize": "53.50 kB"
     },
     {
       "path": "./dist/vue-instantsearch.common.js",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     },
     {
       "path": "./dist/vue-instantsearch.common.js",
-      "maxSize": "16.50 kB"
+      "maxSize": "16.75 kB"
     }
   ],
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "algoliasearch-helper": "^3.1.0",
-    "instantsearch.js": "^4.22.0"
+    "instantsearch.js": "^4.24.0"
   },
   "peerDependencies": {
     "algoliasearch": ">= 3.32.0 < 5",

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -34,6 +34,8 @@ it('should have `name` the same as the suit class name everywhere', () => {
     expect(installedName).toBe(name);
     if (name === 'AisInstantSearchSsr') {
       expect(suitClass).toBe(`ais-InstantSearch`);
+    } else if (name === 'AisExperimentalDynamicWidgets') {
+      expect(suitClass).toBe(`ais-DynamicWidgets`);
     } else {
       expect(suitClass).toBe(`ais-${name.substr(3)}`);
     }

--- a/src/components/DynamicWidgets.js
+++ b/src/components/DynamicWidgets.js
@@ -37,7 +37,7 @@ export default {
   props: {
     transformItems: {
       type: Function,
-      required: true,
+      default: undefined,
     },
   },
   render(createElement) {

--- a/src/components/DynamicWidgets.js
+++ b/src/components/DynamicWidgets.js
@@ -59,7 +59,8 @@ export default {
 
     // by default, render everything, but hidden so that the routing doesn't disappear
     if (!this.state) {
-      const allComponents = Array.from(components.values());
+      const allComponents = [];
+      components.forEach(component => allComponents.push(component));
 
       return createElement(
         'div',

--- a/src/components/DynamicWidgets.js
+++ b/src/components/DynamicWidgets.js
@@ -7,10 +7,7 @@ function getVueAttribute(vnode) {
     if (vnode.componentOptions.propsData.attribute) {
       return vnode.componentOptions.propsData.attribute;
     }
-    if (
-      vnode.componentOptions &&
-      Array.isArray(vnode.componentOptions.propsData.attributes)
-    ) {
+    if (Array.isArray(vnode.componentOptions.propsData.attributes)) {
       return vnode.componentOptions.propsData.attributes[0];
     }
   }

--- a/src/components/DynamicWidgets.js
+++ b/src/components/DynamicWidgets.js
@@ -58,8 +58,7 @@ export default {
 
     // by default, render everything, but hidden so that the routing doesn't disappear
     if (!this.state) {
-      const allComponents = [];
-      components.forEach(vnode => allComponents.push(vnode));
+      const allComponents = Array.from(components.values());
 
       return createElement(
         'div',

--- a/src/components/DynamicWidgets.js
+++ b/src/components/DynamicWidgets.js
@@ -2,13 +2,14 @@ import { createWidgetMixin } from '../mixins/widget';
 import { EXPERIMENTAL_connectDynamicWidgets } from 'instantsearch.js/es/connectors';
 import { createSuitMixin } from '../mixins/suit';
 
-function getVueAttribute(vnode) {
-  if (vnode.componentOptions && vnode.componentOptions.propsData) {
-    if (vnode.componentOptions.propsData.attribute) {
-      return vnode.componentOptions.propsData.attribute;
+function getWidgetAttribute(vnode) {
+  const props = vnode.componentOptions && vnode.componentOptions.propsData;
+  if (props) {
+    if (props.attribute) {
+      return props.attribute;
     }
-    if (Array.isArray(vnode.componentOptions.propsData.attributes)) {
-      return vnode.componentOptions.propsData.attributes[0];
+    if (Array.isArray(props.attributes)) {
+      return props.attributes[0];
     }
   }
 
@@ -20,7 +21,7 @@ function getVueAttribute(vnode) {
   if (Array.isArray(children)) {
     // return first child with a truthy attribute
     return children.reduce(
-      (acc, curr) => acc || getVueAttribute(curr),
+      (acc, curr) => acc || getWidgetAttribute(curr),
       undefined
     );
   }
@@ -43,7 +44,7 @@ export default {
   render(createElement) {
     const components = new Map();
     (this.$slots.default || []).forEach(vnode => {
-      const attribute = getVueAttribute(vnode);
+      const attribute = getWidgetAttribute(vnode);
       if (attribute) {
         components.set(
           attribute,

--- a/src/components/DynamicWidgets.js
+++ b/src/components/DynamicWidgets.js
@@ -1,0 +1,89 @@
+import { createWidgetMixin } from '../mixins/widget';
+import { EXPERIMENTAL_connectDynamicWidgets } from 'instantsearch.js/es/connectors';
+import { createSuitMixin } from '../mixins/suit';
+
+function getVueAttribute(vnode) {
+  if (vnode.componentOptions && vnode.componentOptions.propsData) {
+    if (vnode.componentOptions.propsData.attribute) {
+      return vnode.componentOptions.propsData.attribute;
+    }
+    if (
+      vnode.componentOptions &&
+      Array.isArray(vnode.componentOptions.propsData.attributes)
+    ) {
+      return vnode.componentOptions.propsData.attributes[0];
+    }
+  }
+
+  const children =
+    vnode.componentOptions && vnode.componentOptions.children
+      ? vnode.componentOptions.children
+      : vnode.children;
+
+  if (Array.isArray(children)) {
+    // return first child with a truthy attribute
+    return children.reduce(
+      (acc, curr) => acc || getVueAttribute(curr),
+      undefined
+    );
+  }
+
+  return undefined;
+}
+
+export default {
+  name: 'AisExperimentalDynamicWidgets',
+  mixins: [
+    createWidgetMixin({ connector: EXPERIMENTAL_connectDynamicWidgets }),
+    createSuitMixin({ name: 'DynamicWidgets' }),
+  ],
+  props: {
+    transformItems: {
+      type: Function,
+      required: true,
+    },
+  },
+  render(createElement) {
+    const components = new Map();
+    (this.$slots.default || []).forEach(vnode => {
+      const attribute = getVueAttribute(vnode);
+      if (attribute) {
+        components.set(
+          attribute,
+          createElement(
+            'div',
+            { key: attribute, class: [this.suit('widget')] },
+            [vnode]
+          )
+        );
+      }
+    });
+
+    // by default, render everything, but hidden so that the routing doesn't disappear
+    if (!this.state) {
+      const allComponents = [];
+      components.forEach(vnode => allComponents.push(vnode));
+
+      return createElement(
+        'div',
+        { attrs: { hidden: true }, class: [this.suit()] },
+        allComponents
+      );
+    }
+
+    return createElement(
+      'div',
+      { class: [this.suit()] },
+      this.state.attributesToRender.map(attribute => components.get(attribute))
+    );
+  },
+  computed: {
+    widgetParams() {
+      return {
+        transformItems: this.transformItems,
+        // we do not pass "widgets" to the connector, since Vue is in charge of rendering
+        widgets: [],
+      };
+    },
+  },
+};

--- a/src/components/__tests__/DynamicWidgets.js
+++ b/src/components/__tests__/DynamicWidgets.js
@@ -1,0 +1,178 @@
+import { createLocalVue, mount } from '@vue/test-utils';
+import DynamicWidgets from '../DynamicWidgets';
+import { __setState } from '../../mixins/widget';
+import { plugin } from '../../plugin';
+jest.mock('../../mixins/widget');
+
+it('renders all children without state', () => {
+  const localVue = createLocalVue();
+
+  localVue.use(plugin);
+
+  __setState(null);
+
+  const wrapper = mount(DynamicWidgets, {
+    localVue,
+    propsData: {
+      transformItems: items => items,
+    },
+    slots: {
+      default: `
+      <ais-refinement-list attribute="test1"/>
+      <ais-refinement-list attribute="test2"/>
+      <ais-panel>
+        <ais-hierarchical-menu :attributes="['test3', 'test3']" />
+      </ais-panel>
+      `,
+    },
+  });
+
+  // the inner widgets don't render anything because state is falsy, but they are mounted
+  expect(wrapper.html()).toMatchInlineSnapshot(`
+
+<div hidden="hidden"
+     class="ais-DynamicWidgets"
+>
+  <div class="ais-DynamicWidgets-widget">
+  </div>
+  <div class="ais-DynamicWidgets-widget">
+  </div>
+  <div class="ais-DynamicWidgets-widget">
+    <div class="ais-Panel">
+      <div class="ais-Panel-body">
+      </div>
+    </div>
+  </div>
+</div>
+
+`);
+});
+
+it('renders nothing without children', () => {
+  __setState({
+    attributesToRender: [],
+  });
+
+  const wrapper = mount(DynamicWidgets, {
+    propsData: {
+      transformItems: items => items,
+    },
+  });
+  expect(wrapper.html()).toMatchInlineSnapshot(`
+
+<div class="ais-DynamicWidgets">
+</div>
+
+`);
+});
+
+it('renders nothing with empty items', () => {
+  const localVue = createLocalVue();
+
+  localVue.use(plugin);
+
+  __setState({
+    attributesToRender: [],
+    items: [],
+  });
+
+  const wrapper = mount(DynamicWidgets, {
+    localVue,
+    propsData: {
+      transformItems: items => items,
+    },
+    slots: {
+      default: `<ais-refinement-list attribute="test1"/>`,
+    },
+  });
+
+  expect(wrapper.html()).toMatchInlineSnapshot(`
+
+<div class="ais-DynamicWidgets">
+</div>
+
+`);
+});
+
+it('renders attributesToRender 1', () => {
+  const localVue = createLocalVue();
+
+  localVue.use(plugin);
+
+  __setState({
+    attributesToRender: ['test1'],
+    items: [],
+  });
+
+  localVue.component('test-component', {
+    props: { attribute: { type: String } },
+    render(h) {
+      return h('div', {}, this.attribute);
+    },
+  });
+
+  const wrapper = mount(DynamicWidgets, {
+    localVue,
+    propsData: {
+      transformItems: items => items,
+    },
+    slots: {
+      default: `
+        <test-component attribute="test1" />
+        <ais-refinement-list attribute="test2" />
+      `,
+    },
+  });
+
+  expect(wrapper.html()).toMatchInlineSnapshot(`
+
+<div class="ais-DynamicWidgets">
+  <div class="ais-DynamicWidgets-widget">
+    <div>
+      test1
+    </div>
+  </div>
+</div>
+
+`);
+});
+
+it('renders attributesToRender 2', () => {
+  const localVue = createLocalVue();
+
+  localVue.use(plugin);
+
+  __setState({
+    attributesToRender: ['test2'],
+    items: [],
+  });
+
+  localVue.component('test-component', {
+    props: { attribute: { type: String } },
+    render(h) {
+      return h('div', {}, this.attribute);
+    },
+  });
+
+  const wrapper = mount(DynamicWidgets, {
+    localVue,
+    propsData: {
+      transformItems: items => items,
+    },
+    slots: {
+      default: `
+        <test-component attribute="test1" />
+        <ais-refinement-list attribute="test2" />
+      `,
+    },
+  });
+
+  expect(wrapper.html()).toMatchInlineSnapshot(`
+
+<div class="ais-DynamicWidgets">
+  <div class="ais-DynamicWidgets-widget">
+  </div>
+</div>
+
+`);
+});

--- a/src/components/__tests__/DynamicWidgets.js
+++ b/src/components/__tests__/DynamicWidgets.js
@@ -115,7 +115,7 @@ it('renders nothing without children', () => {
 `);
 });
 
-it('renders nothing with empty items', () => {
+it('renders nothing with empty attributesToRender', () => {
   const localVue = createLocalVue();
 
   localVue.use(plugin);
@@ -134,7 +134,6 @@ it('renders nothing with empty items', () => {
     },
     stubs: {
       'ais-refinement-list': MockRefinementList,
-      'ais-menu': MockMenu,
     },
   });
 

--- a/src/components/__tests__/DynamicWidgets.js
+++ b/src/components/__tests__/DynamicWidgets.js
@@ -4,6 +4,39 @@ import { __setState } from '../../mixins/widget';
 import { plugin } from '../../plugin';
 jest.mock('../../mixins/widget');
 
+const MockRefinementList = {
+  props: { attribute: { type: String } },
+  render(h) {
+    return h('div', {
+      attrs: {
+        'widget-name': 'ais-refinement-list',
+        attribute: this.attribute,
+      },
+    });
+  },
+};
+
+const MockMenu = {
+  props: { attribute: { type: String } },
+  render(h) {
+    return h('div', {
+      attrs: { 'widget-name': 'ais-menu', attribute: this.attribute },
+    });
+  },
+};
+
+const MockHierarchicalMenu = {
+  props: { attributes: { type: Array } },
+  render(h) {
+    return h('div', {
+      attrs: {
+        'widget-name': 'ais-hierarchical-menu',
+        attributes: this.attributes,
+      },
+    });
+  },
+};
+
 it('renders all children without state', () => {
   const localVue = createLocalVue();
 
@@ -19,27 +52,43 @@ it('renders all children without state', () => {
     slots: {
       default: `
       <ais-refinement-list attribute="test1"/>
-      <ais-refinement-list attribute="test2"/>
+      <ais-menu attribute="test2"/>
       <ais-panel>
-        <ais-hierarchical-menu :attributes="['test3', 'test3']" />
+        <ais-hierarchical-menu :attributes="['test3', 'test4']" />
       </ais-panel>
       `,
     },
+    stubs: {
+      'ais-refinement-list': MockRefinementList,
+      'ais-menu': MockMenu,
+      'ais-hierarchical-menu': MockHierarchicalMenu,
+    },
   });
 
-  // the inner widgets don't render anything because state is falsy, but they are mounted
   expect(wrapper.html()).toMatchInlineSnapshot(`
 
 <div hidden="hidden"
      class="ais-DynamicWidgets"
 >
   <div class="ais-DynamicWidgets-widget">
+    <div widget-name="ais-refinement-list"
+         attribute="test1"
+    >
+    </div>
   </div>
   <div class="ais-DynamicWidgets-widget">
+    <div widget-name="ais-menu"
+         attribute="test2"
+    >
+    </div>
   </div>
   <div class="ais-DynamicWidgets-widget">
     <div class="ais-Panel">
       <div class="ais-Panel-body">
+        <div widget-name="ais-hierarchical-menu"
+             attributes="test3,test4"
+        >
+        </div>
       </div>
     </div>
   </div>
@@ -73,7 +122,6 @@ it('renders nothing with empty items', () => {
 
   __setState({
     attributesToRender: [],
-    items: [],
   });
 
   const wrapper = mount(DynamicWidgets, {
@@ -84,6 +132,10 @@ it('renders nothing with empty items', () => {
     slots: {
       default: `<ais-refinement-list attribute="test1"/>`,
     },
+    stubs: {
+      'ais-refinement-list': MockRefinementList,
+      'ais-menu': MockMenu,
+    },
   });
 
   expect(wrapper.html()).toMatchInlineSnapshot(`
@@ -94,21 +146,13 @@ it('renders nothing with empty items', () => {
 `);
 });
 
-it('renders attributesToRender 1', () => {
+it('renders attributesToRender (menu)', () => {
   const localVue = createLocalVue();
 
   localVue.use(plugin);
 
   __setState({
     attributesToRender: ['test1'],
-    items: [],
-  });
-
-  localVue.component('test-component', {
-    props: { attribute: { type: String } },
-    render(h) {
-      return h('div', {}, this.attribute);
-    },
   });
 
   const wrapper = mount(DynamicWidgets, {
@@ -118,9 +162,13 @@ it('renders attributesToRender 1', () => {
     },
     slots: {
       default: `
-        <test-component attribute="test1" />
+        <ais-menu attribute="test1" />
         <ais-refinement-list attribute="test2" />
       `,
+    },
+    stubs: {
+      'ais-refinement-list': MockRefinementList,
+      'ais-menu': MockMenu,
     },
   });
 
@@ -128,8 +176,9 @@ it('renders attributesToRender 1', () => {
 
 <div class="ais-DynamicWidgets">
   <div class="ais-DynamicWidgets-widget">
-    <div>
-      test1
+    <div widget-name="ais-menu"
+         attribute="test1"
+    >
     </div>
   </div>
 </div>
@@ -137,20 +186,146 @@ it('renders attributesToRender 1', () => {
 `);
 });
 
-it('renders attributesToRender 2', () => {
+it('renders attributesToRender (refinement list)', () => {
   const localVue = createLocalVue();
 
   localVue.use(plugin);
 
   __setState({
     attributesToRender: ['test2'],
-    items: [],
   });
 
-  localVue.component('test-component', {
-    props: { attribute: { type: String } },
-    render(h) {
-      return h('div', {}, this.attribute);
+  const wrapper = mount(DynamicWidgets, {
+    localVue,
+    propsData: {
+      transformItems: items => items,
+    },
+    slots: {
+      default: `
+        <ais-menu attribute="test1" />
+        <ais-refinement-list attribute="test2" />
+      `,
+    },
+    stubs: {
+      'ais-refinement-list': MockRefinementList,
+      'ais-menu': MockMenu,
+    },
+  });
+
+  expect(wrapper.html()).toMatchInlineSnapshot(`
+
+<div class="ais-DynamicWidgets">
+  <div class="ais-DynamicWidgets-widget">
+    <div widget-name="ais-refinement-list"
+         attribute="test2"
+    >
+    </div>
+  </div>
+</div>
+
+`);
+});
+
+it('renders attributesToRender (panel)', () => {
+  const localVue = createLocalVue();
+
+  localVue.use(plugin);
+
+  __setState({
+    attributesToRender: ['test2'],
+  });
+
+  const wrapper = mount(DynamicWidgets, {
+    localVue,
+    propsData: {
+      transformItems: items => items,
+    },
+    slots: {
+      default: `
+        <ais-menu attribute="test1" />
+        <ais-panel>
+          <ais-refinement-list attribute="test2" />
+        </ais-panel>
+      `,
+    },
+    stubs: {
+      'ais-refinement-list': MockRefinementList,
+      'ais-menu': MockMenu,
+    },
+  });
+
+  expect(wrapper.html()).toMatchInlineSnapshot(`
+
+<div class="ais-DynamicWidgets">
+  <div class="ais-DynamicWidgets-widget">
+    <div class="ais-Panel">
+      <div class="ais-Panel-body">
+        <div widget-name="ais-refinement-list"
+             attribute="test2"
+        >
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+`);
+});
+
+it('renders attributesToRender (hierarchical menu)', () => {
+  const localVue = createLocalVue();
+
+  localVue.use(plugin);
+
+  __setState({
+    attributesToRender: ['test1'],
+  });
+
+  const wrapper = mount(DynamicWidgets, {
+    localVue,
+    propsData: {
+      transformItems: items => items,
+    },
+    slots: {
+      default: `
+        <ais-hierarchical-menu :attributes="['test1','test2']" />
+        <ais-menu attribute="test3" />
+        <ais-panel>
+          <ais-refinement-list attribute="test4" />
+        </ais-panel>
+      `,
+    },
+    stubs: {
+      'ais-refinement-list': MockRefinementList,
+      'ais-menu': MockMenu,
+      'ais-hierarchical-menu': MockHierarchicalMenu,
+    },
+  });
+
+  expect(wrapper.html()).toMatchInlineSnapshot(`
+
+<div class="ais-DynamicWidgets">
+  <div class="ais-DynamicWidgets-widget">
+    <div widget-name="ais-hierarchical-menu"
+         attributes="test1,test2"
+    >
+    </div>
+  </div>
+</div>
+
+`);
+});
+
+it('updates DOM when attributesToRender changes', () => {
+  const localVue = createLocalVue();
+
+  localVue.use(plugin);
+
+  let attributesToRender = ['test1'];
+
+  __setState({
+    get attributesToRender() {
+      return attributesToRender;
     },
   });
 
@@ -161,9 +336,17 @@ it('renders attributesToRender 2', () => {
     },
     slots: {
       default: `
-        <test-component attribute="test1" />
-        <ais-refinement-list attribute="test2" />
+        <ais-hierarchical-menu :attributes="['test1','test2']" />
+        <ais-menu attribute="test3" />
+        <ais-panel>
+          <ais-refinement-list attribute="test4" />
+        </ais-panel>
       `,
+    },
+    stubs: {
+      'ais-refinement-list': MockRefinementList,
+      'ais-menu': MockMenu,
+      'ais-hierarchical-menu': MockHierarchicalMenu,
     },
   });
 
@@ -171,6 +354,54 @@ it('renders attributesToRender 2', () => {
 
 <div class="ais-DynamicWidgets">
   <div class="ais-DynamicWidgets-widget">
+    <div widget-name="ais-hierarchical-menu"
+         attributes="test1,test2"
+    >
+    </div>
+  </div>
+</div>
+
+`);
+
+  attributesToRender = ['test3'];
+
+  wrapper.vm.$forceUpdate();
+
+  expect(wrapper.html()).toMatchInlineSnapshot(`
+
+<div class="ais-DynamicWidgets">
+  <div class="ais-DynamicWidgets-widget">
+    <div widget-name="ais-menu"
+         attribute="test3"
+    >
+    </div>
+  </div>
+</div>
+
+`);
+
+  attributesToRender = ['test1', 'test4'];
+
+  wrapper.vm.$forceUpdate();
+
+  expect(wrapper.html()).toMatchInlineSnapshot(`
+
+<div class="ais-DynamicWidgets">
+  <div class="ais-DynamicWidgets-widget">
+    <div widget-name="ais-hierarchical-menu"
+         attributes="test1,test2"
+    >
+    </div>
+  </div>
+  <div class="ais-DynamicWidgets-widget">
+    <div class="ais-Panel">
+      <div class="ais-Panel-body">
+        <div widget-name="ais-refinement-list"
+             attribute="test4"
+        >
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/src/components/__tests__/DynamicWidgets.js
+++ b/src/components/__tests__/DynamicWidgets.js
@@ -406,4 +406,15 @@ it('updates DOM when attributesToRender changes', () => {
 </div>
 
 `);
+
+  attributesToRender = [];
+
+  wrapper.vm.$forceUpdate();
+
+  expect(wrapper.html()).toMatchInlineSnapshot(`
+
+<div class="ais-DynamicWidgets">
+</div>
+
+`);
 });

--- a/src/components/__tests__/DynamicWidgets.js
+++ b/src/components/__tests__/DynamicWidgets.js
@@ -99,7 +99,7 @@ it('renders all children without state', () => {
 
 it('renders nothing without children', () => {
   __setState({
-    attributesToRender: [],
+    attributesToRender: ['something-that-does-not-show'],
   });
 
   const wrapper = mount(DynamicWidgets, {

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -43,3 +43,4 @@ export {
 } from './components/ToggleRefinement.vue';
 export { default as AisVoiceSearch } from './components/VoiceSearch.vue';
 export { default as AisRelevantSort } from './components/RelevantSort.vue';
+export { default as AisDynamicWidgets } from './components/DynamicWidgets';

--- a/stories/DynamicWidgets.stories.js
+++ b/stories/DynamicWidgets.stories.js
@@ -1,0 +1,36 @@
+import { previewWrapper } from './utils';
+import { storiesOf } from '@storybook/vue';
+
+storiesOf('ais-dynamic-widgets', module)
+  .addDecorator(previewWrapper())
+  .add('simple usage', () => ({
+    template: `
+    <ais-experimental-dynamic-widgets :transform-items="transformItems">
+      <ais-refinement-list attribute="brand"></ais-refinement-list>
+      <ais-menu attribute="categories"></ais-menu>
+      <ais-panel>
+        <template slot="header">hierarchy</template>
+        <ais-hierarchical-menu :attributes="hierarchicalCategories"></ais-hierarchical-menu>
+      </ais-panel>
+    </ais-experimental-dynamic-widgets>`,
+    data() {
+      return {
+        hierarchicalCategories: [
+          'hierarchicalCategories.lvl0',
+          'hierarchicalCategories.lvl1',
+          'hierarchicalCategories.lvl2',
+        ],
+      };
+    },
+    methods: {
+      transformItems(_attributes, { results }) {
+        if (results._state.query === 'dog') {
+          return ['categories'];
+        }
+        if (results._state.query === 'lego') {
+          return ['categories', 'brand'];
+        }
+        return ['brand', 'hierarchicalCategories.lvl0', 'categories'];
+      },
+    },
+  }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -698,10 +698,10 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/googlemaps@^3.39.6":
-  version "3.39.7"
-  resolved "https://registry.npmjs.org/@types/googlemaps/-/googlemaps-3.39.7.tgz#70c1af22839976cfd462858c882b54f3006f0b08"
-  integrity sha512-U8ZjnjfGiZXzun8jIDOZ/5Gt5Ky07B9pBhFbgzten1S364bnuueFsCt5e5V7Wn55o26NkLWgc6becL+j401bRw==
+"@types/google.maps@^3.45.3":
+  version "3.45.6"
+  resolved "https://registry.yarnpkg.com/@types/google.maps/-/google.maps-3.45.6.tgz#441a7bc76424243b307596fc8d282a435a979ebd"
+  integrity sha512-BzGzxs8UXFxeP8uN/0nRgGbsbpYQxSCKsv/7S8OitU7wwhfFcqQSm5aAcL1nbwueMiJ/VVmIZKPq69s0kX5W+Q==
 
 "@types/hogan.js@^3.0.0":
   version "3.0.0"
@@ -1161,10 +1161,10 @@ algoliasearch-helper@^3.1.0:
   dependencies:
     events "^1.1.1"
 
-algoliasearch-helper@^3.4.5:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.5.3.tgz#fbf8b328bc103efdefde59a7d25eaffe85b2490f"
-  integrity sha512-DtSlOKAJ6TGkQD6u58g6/ABdMmHf3pAj6xVL5hJF+D4z9ldDRf/f5v6puNIxGOlJRwGVvFGyz34beYNqhLDUbQ==
+algoliasearch-helper@^3.5.4:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.5.4.tgz#21b20ab8a258daa9dde9aef2daa5e8994cd66077"
+  integrity sha512-t+FLhXYnPZiwjYe5ExyN962HQY8mi3KwRju3Lyf6OBgtRdx30d6mqvtClXf5NeBihH45Xzj6t4Y5YyvAI432XA==
   dependencies:
     events "^1.1.1"
 
@@ -7897,19 +7897,18 @@ instantsearch.css@7.3.1:
   resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.3.1.tgz#7ab74a8f355091ae040947a9cf5438f379026622"
   integrity sha512-/kaMDna5D+Q9mImNBHEhb9HgHATDOFKYii7N1Iwvrj+lmD9gBJLqVhUw67gftq2O0QI330pFza+CRscIwB1wQQ==
 
-instantsearch.js@^4.24.0:
-  version "4.24.0"
-  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.24.0.tgz#220777b0083adb7b912f738b512ecf379dabea85"
-  integrity sha512-iJ0ieGPPQDxSuobo+TuF2ktSnWAoXBpIP/kQ7HwAiFzLGXCemwOOLN85Z4d7+XbIxUJ+jwN0HQt4WMRO8wQHww==
+instantsearch.js@^4.25.0:
+  version "4.25.0"
+  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.25.0.tgz#0c631479afa0826af0adee120dc2bbb68e1caeb3"
+  integrity sha512-146u/zlu+lHjMgykKnvYr5yvM4xB/CHN8jmf5872gYNfjoZlmQ6GAoYwrgRjQrbLAbIZ6hhpXkDhwmoptmvUgQ==
   dependencies:
-    "@types/googlemaps" "^3.39.6"
+    "@types/google.maps" "^3.45.3"
     "@types/hogan.js" "^3.0.0"
-    algoliasearch-helper "^3.4.5"
+    algoliasearch-helper "^3.5.4"
     classnames "^2.2.5"
     events "^1.1.0"
     hogan.js "^3.0.2"
     preact "^10.0.0"
-    prop-types "^15.5.10"
     qs "^6.5.1"
 
 interpret@^1.0.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -703,6 +703,11 @@
   resolved "https://registry.npmjs.org/@types/googlemaps/-/googlemaps-3.39.7.tgz#70c1af22839976cfd462858c882b54f3006f0b08"
   integrity sha512-U8ZjnjfGiZXzun8jIDOZ/5Gt5Ky07B9pBhFbgzten1S364bnuueFsCt5e5V7Wn55o26NkLWgc6becL+j401bRw==
 
+"@types/hogan.js@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/hogan.js/-/hogan.js-3.0.0.tgz#bf26560f39a38224ab6d0491b06f72c8fbe0953d"
+  integrity sha512-djkvb/AN43c3lIGCojNQ1FBS9VqqKhcTns5RQnHw4xBT/csy0jAssAsOiJ8NfaaioZaeKYE7XkVRxE5NeSZcaA==
+
 "@types/http-cache-semantics@*":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz#9140779736aa2655635ee756e2467d787cfe8a2a"
@@ -1156,10 +1161,10 @@ algoliasearch-helper@^3.1.0:
   dependencies:
     events "^1.1.1"
 
-algoliasearch-helper@^3.4.4:
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.4.4.tgz#f2eb46bc4d2f6fed82c7201b8ac4ce0a1988ae67"
-  integrity sha512-OjyVLjykaYKCMxxRMZNiwLp8CS310E0qAeIY2NaublcmLAh8/SL19+zYHp7XCLtMem2ZXwl3ywMiA32O9jszuw==
+algoliasearch-helper@^3.4.5:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.5.3.tgz#fbf8b328bc103efdefde59a7d25eaffe85b2490f"
+  integrity sha512-DtSlOKAJ6TGkQD6u58g6/ABdMmHf3pAj6xVL5hJF+D4z9ldDRf/f5v6puNIxGOlJRwGVvFGyz34beYNqhLDUbQ==
   dependencies:
     events "^1.1.1"
 
@@ -7892,13 +7897,14 @@ instantsearch.css@7.3.1:
   resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.3.1.tgz#7ab74a8f355091ae040947a9cf5438f379026622"
   integrity sha512-/kaMDna5D+Q9mImNBHEhb9HgHATDOFKYii7N1Iwvrj+lmD9gBJLqVhUw67gftq2O0QI330pFza+CRscIwB1wQQ==
 
-instantsearch.js@^4.22.0:
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.22.0.tgz#d28c7a2be6b399736f8f2edd6f59d474a0f661a4"
-  integrity sha512-IPjg/EwhDqFpvCJC1g3DF+i2cAr3SQZ9JPFhuKWC2apnGNfiFkPIQKvHx1pFTQm7FlZe262Xcpqi1ag1KVPGpA==
+instantsearch.js@^4.24.0:
+  version "4.24.0"
+  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.24.0.tgz#220777b0083adb7b912f738b512ecf379dabea85"
+  integrity sha512-iJ0ieGPPQDxSuobo+TuF2ktSnWAoXBpIP/kQ7HwAiFzLGXCemwOOLN85Z4d7+XbIxUJ+jwN0HQt4WMRO8wQHww==
   dependencies:
     "@types/googlemaps" "^3.39.6"
-    algoliasearch-helper "^3.4.4"
+    "@types/hogan.js" "^3.0.0"
+    algoliasearch-helper "^3.4.5"
     classnames "^2.2.5"
     events "^1.1.0"
     hogan.js "^3.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7892,10 +7892,10 @@ instantsearch.css@7.3.1:
   resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.3.1.tgz#7ab74a8f355091ae040947a9cf5438f379026622"
   integrity sha512-/kaMDna5D+Q9mImNBHEhb9HgHATDOFKYii7N1Iwvrj+lmD9gBJLqVhUw67gftq2O0QI330pFza+CRscIwB1wQQ==
 
-instantsearch.js@^4.20.0:
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.20.0.tgz#e7ed763a8380384ff59a88f3b56a01c5dedf0fca"
-  integrity sha512-fO3oqt/WEsUvdx8LB9Fm/MH9pLbl3gHV3ALnFOvbwdIpg+HRe5zZv3C/bE8E0SuTbZo2C6Fxg6rC0MEMTxNVGA==
+instantsearch.js@^4.22.0:
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.22.0.tgz#d28c7a2be6b399736f8f2edd6f59d474a0f661a4"
+  integrity sha512-IPjg/EwhDqFpvCJC1g3DF+i2cAr3SQZ9JPFhuKWC2apnGNfiFkPIQKvHx1pFTQm7FlZe262Xcpqi1ag1KVPGpA==
   dependencies:
     "@types/googlemaps" "^3.39.6"
     algoliasearch-helper "^3.4.4"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Adds a new widget _ais-experimental-dynamic-widgets_ that can be used to conditionally render other widgets. This condition is based on the search results, by default results.facetOrdering.facet.values, but can be overridden using transformItems

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

```vue
<template>
  <ais-experimental-dynamic-widgets :transform-items="transformItems">
    <ais-refinement-list attribute="test1" />
    <ais-menu attribute="test2" />
    <ais-panel>
      <ais-hierarchical-menu :attributes="hierarchicalAttributes" />
    </ais-panel>
  </ais-experimental-dynamic-widgets>
</template>

<script>
export default {
  data() {
    return {
      hierarchicalAttributes: ["test3", "unused"],
    };
  },
  methods(_attributes, { results }) {
    // modified if you want to use userData instead of facet ordering
    return results.userData[0].ordering;
  },
};
</script>
```


See also:

- https://github.com/algolia/instantsearch.js/pull/4687
- DX-1665