### PR TITLE
feat(middlewares): add middlewares prop to ais-instant-search

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "algoliasearch-helper": "^3.1.0",
-    "instantsearch.js": "^4.16.1"
+    "instantsearch.js": "https://pkg.csb.dev/algolia/instantsearch.js/commit/59ed228e/instantsearch.js"
   },
   "peerDependencies": {
     "algoliasearch": ">= 3.32.0 < 5",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "algoliasearch-helper": "^3.1.0",
-    "instantsearch.js": "https://pkg.csb.dev/algolia/instantsearch.js/commit/59ed228e/instantsearch.js"
+    "instantsearch.js": "^4.20.0"
   },
   "peerDependencies": {
     "algoliasearch": ">= 3.32.0 < 5",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
   "bundlesize": [
     {
       "path": "./dist/vue-instantsearch.js",
-      "maxSize": "52.50 kB"
+      "maxSize": "52.75 kB"
     },
     {
       "path": "./dist/vue-instantsearch.common.js",

--- a/src/components/InstantSearch.js
+++ b/src/components/InstantSearch.js
@@ -69,6 +69,10 @@ export default createInstantSearchComponent({
         return false;
       },
     },
+    middlewares: {
+      type: Array,
+      default: null,
+    },
   },
   data() {
     return {

--- a/src/components/__tests__/InstantSearch-integration.js
+++ b/src/components/__tests__/InstantSearch-integration.js
@@ -1,3 +1,4 @@
+import Vue from 'vue';
 import { mount } from '@vue/test-utils';
 import InstantSearch from '../InstantSearch';
 import { createWidgetMixin } from '../../mixins/widget';
@@ -31,4 +32,63 @@ it('child widgets get added to its parent instantsearch', () => {
   expect(wrapper.vm.instantSearchInstance.mainIndex.getWidgets()).toContain(
     widgetInstance
   );
+});
+
+describe('middlewares', () => {
+  it('subscribes middlewares', async () => {
+    const subscribe = jest.fn();
+    const middleware = () => ({
+      subscribe,
+      unsubscribe: () => {},
+      onStateChange: () => {},
+    });
+
+    mount(InstantSearch, {
+      propsData: {
+        searchClient: createFakeClient(),
+        indexName: 'indexName',
+        middlewares: [middleware],
+      },
+    });
+    await Vue.nextTick();
+
+    expect(subscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('subscribes newly added middleware', async () => {
+    const subscribe1 = jest.fn();
+    const unsubscribe1 = jest.fn();
+    const middleware1 = () => ({
+      subscribe: subscribe1,
+      unsubscribe: unsubscribe1,
+      onStateChange: () => {},
+    });
+
+    const wrapper = mount(InstantSearch, {
+      propsData: {
+        searchClient: createFakeClient(),
+        indexName: 'indexName',
+        middlewares: [middleware1],
+      },
+    });
+    await Vue.nextTick();
+    expect(subscribe1).toHaveBeenCalledTimes(1);
+
+    const subscribe2 = jest.fn();
+    const unsubscribe2 = jest.fn();
+    const middleware2 = () => ({
+      subscribe: subscribe2,
+      unsubscribe: unsubscribe2,
+      onStateChange: () => {},
+    });
+    wrapper.setProps({
+      middlewares: [middleware1, middleware2],
+    });
+    await Vue.nextTick();
+
+    expect(subscribe1).toHaveBeenCalledTimes(1);
+    expect(subscribe2).toHaveBeenCalledTimes(1);
+    expect(unsubscribe1).toHaveBeenCalledTimes(0);
+    expect(unsubscribe2).toHaveBeenCalledTimes(0);
+  });
 });

--- a/src/util/createInstantSearchComponent.js
+++ b/src/util/createInstantSearchComponent.js
@@ -37,6 +37,12 @@ export const createInstantSearchComponent = component =>
         middlewares: {
           immediate: true,
           handler(next, prev) {
+            (prev || [])
+              .filter(middleware => (next || []).indexOf(middleware) === -1)
+              .forEach(middlewareToRemove => {
+                this.instantSearchInstance.unuse(middlewareToRemove);
+              });
+
             (next || [])
               .filter(middleware => (prev || []).indexOf(middleware) === -1)
               .forEach(middlewareToAdd => {

--- a/src/util/createInstantSearchComponent.js
+++ b/src/util/createInstantSearchComponent.js
@@ -34,6 +34,16 @@ export const createInstantSearchComponent = component =>
           // private InstantSearch.js API:
           this.instantSearchInstance._searchFunction = searchFunction;
         },
+        middlewares: {
+          immediate: true,
+          handler(next, prev) {
+            (next || [])
+              .filter(middleware => (prev || []).indexOf(middleware) === -1)
+              .forEach(middlewareToAdd => {
+                this.instantSearchInstance.use(middlewareToAdd);
+              });
+          },
+        },
       },
       created() {
         const searchClient = this.instantSearchInstance.client;

--- a/stories/RelevantSort.stories.js
+++ b/stories/RelevantSort.stories.js
@@ -19,9 +19,20 @@ storiesOf('ais-relevant-sort', module)
     template: `
       <ais-relevant-sort>
         <template slot="text" slot-scope="{ isRelevantSorted }">
-          {{ isRelevantSorted
-               ? 'We removed some search results to show you the most relevant ones'
-               : 'Currently showing all results' }}
+          <template v-if="isRelevantSorted">
+            We removed some search results to show you the most relevant ones
+          </template>
+          <template>
+            Currently showing all results
+          </template>
+        </template>
+        <template slot="button" slot-scope="{ isRelevantSorted }">
+          <template v-if="isRelevantSorted">
+            See all results
+          </template>
+          <template>
+            See relevant results
+          </template>
         </template>
       </ais-relevant-sort>
     `,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7892,10 +7892,9 @@ instantsearch.css@7.3.1:
   resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.3.1.tgz#7ab74a8f355091ae040947a9cf5438f379026622"
   integrity sha512-/kaMDna5D+Q9mImNBHEhb9HgHATDOFKYii7N1Iwvrj+lmD9gBJLqVhUw67gftq2O0QI330pFza+CRscIwB1wQQ==
 
-instantsearch.js@^4.16.1:
-  version "4.16.1"
-  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.16.1.tgz#78e00d2256c89693a94f58ebfc5f0864953b7ec8"
-  integrity sha512-NfwNOb+Ftj7Y+h6lW7iCd5SXWKIHQZ981ldSddEHbgTexbdJEyxgWhaF8c3HajCySp8wZPD2gj9KpNQy/BsUgQ==
+"instantsearch.js@https://pkg.csb.dev/algolia/instantsearch.js/commit/59ed228e/instantsearch.js":
+  version "4.19.0"
+  resolved "https://pkg.csb.dev/algolia/instantsearch.js/commit/59ed228e/instantsearch.js#15cd97e6339856e7386023baa60c797826a4cfd3"
   dependencies:
     "@types/googlemaps" "^3.39.6"
     algoliasearch-helper "^3.4.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7892,9 +7892,10 @@ instantsearch.css@7.3.1:
   resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.3.1.tgz#7ab74a8f355091ae040947a9cf5438f379026622"
   integrity sha512-/kaMDna5D+Q9mImNBHEhb9HgHATDOFKYii7N1Iwvrj+lmD9gBJLqVhUw67gftq2O0QI330pFza+CRscIwB1wQQ==
 
-"instantsearch.js@https://pkg.csb.dev/algolia/instantsearch.js/commit/59ed228e/instantsearch.js":
-  version "4.19.0"
-  resolved "https://pkg.csb.dev/algolia/instantsearch.js/commit/59ed228e/instantsearch.js#15cd97e6339856e7386023baa60c797826a4cfd3"
+instantsearch.js@^4.20.0:
+  version "4.20.0"
+  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.20.0.tgz#e7ed763a8380384ff59a88f3b56a01c5dedf0fca"
+  integrity sha512-fO3oqt/WEsUvdx8LB9Fm/MH9pLbl3gHV3ALnFOvbwdIpg+HRe5zZv3C/bE8E0SuTbZo2C6Fxg6rC0MEMTxNVGA==
   dependencies:
     "@types/googlemaps" "^3.39.6"
     algoliasearch-helper "^3.4.4"


### PR DESCRIPTION
## Summary

This PR adds `middlewares` prop to `<ais-instant-search>`.

<details>
<summary><i>ignore this. we're using `unuse` method.</i></summary>
Writing Vue code, users will expect `middlewares` prop to be reactive. Currently this PR handles newly added middlewares.

However, removed ones in the prop are not being handled at the moment.

1. In which case will people want to remove middlewares in the middle of their app's lifecycle?
2. We don't have an API to remove middleware from InstantSearch. We can manually call `middlewareToRemove.unsubscribe()`, but `instantSearchInstance` [still loops over](https://github.com/algolia/instantsearch.js/blob/master/src/lib/InstantSearch.ts#L580-L584) `this.middleware` to notify state changes, etc. So we need to have a proper API to support this reactive behavior in Vue.js (or other flavors).

Until we have an answer or usecase for (1), why don't we ship the current version first (not supporting removed middlewares)?

Do you think it will cause confusion?
</details>