### PR TITLE
fix(ssr): correctly pass scopedResults.results

### DIFF
--- a/src/util/__tests__/createServerRootMixin.test.js
+++ b/src/util/__tests__/createServerRootMixin.test.js
@@ -718,35 +718,35 @@ Array [
 
       expect(renderArgs).toMatchInlineSnapshot(
         {
-          helper: expect.any(Object),
-          results: expect.any(Object),
+          helper: expect.anything(),
+          results: expect.anything(),
           scopedResults: expect.arrayContaining([
             expect.objectContaining({
-              helper: expect.any(Object),
+              helper: expect.anything(),
               indexId: expect.any(String),
-              results: expect.any(Object),
+              results: expect.anything(),
             }),
           ]),
-          state: expect.any(Object),
-          instantSearchInstance: expect.any(Object),
+          state: expect.anything(),
+          instantSearchInstance: expect.anything(),
         },
         `
 Object {
   "createURL": [Function],
-  "helper": Any<Object>,
-  "instantSearchInstance": Any<Object>,
-  "results": Any<Object>,
+  "helper": Anything,
+  "instantSearchInstance": Anything,
+  "results": Anything,
   "scopedResults": ArrayContaining [
     ObjectContaining {
-      "helper": Any<Object>,
+      "helper": Anything,
       "indexId": Any<String>,
-      "results": Any<Object>,
+      "results": Anything,
     },
   ],
   "searchMetadata": Object {
     "isSearchStalled": false,
   },
-  "state": Any<Object>,
+  "state": Anything,
   "templatesConfig": Object {},
 }
 `

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -180,7 +180,10 @@ function augmentInstantSearch(instantSearchOptions, searchClient, indexName) {
     widget.render({
       helper: localHelper,
       results,
-      scopedResults: parent.getScopedResults(),
+      scopedResults: parent.getScopedResults().map(result => ({
+        ...result,
+        results: search.__initialSearchResults[result.indexId],
+      })),
       state,
       templatesConfig: {},
       createURL: parent.createURL,


### PR DESCRIPTION
We retrieve the scoped results from the parent index in the initial render on server & client, however since the index widget doesn't have its results from a search query yet, `getResults` (used inside getScopedResults) will be `null` (derivedHelper && derivedHelper.lastResults).

The solution is to augment the retrieved scoped results with the actual search results from __initialResults, like done for `results`.

fixes #940