### PR TITLE
feat(vue 3): support both defineComponent and component

### DIFF
--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -1,4 +1,7 @@
-import Vue from 'vue';
+import {
+  component as defineComponentVue2,
+  defineComponent as defineComponentVue3,
+} from 'vue';
 import instantsearch from 'instantsearch.js/es';
 import algoliaHelper from 'algoliasearch-helper';
 const { SearchResults, SearchParameters } = algoliaHelper;
@@ -53,7 +56,9 @@ function defaultCloneComponent(componentInstance) {
 
   const Extended = componentInstance.$vnode
     ? componentInstance.$vnode.componentOptions.Ctor.extend(options)
-    : Vue.component(Object.assign({}, componentInstance.$options, options));
+    : (defineComponentVue3 || defineComponentVue2)(
+        Object.assign({}, componentInstance.$options, options)
+      );
 
   const app = new Extended({
     propsData: componentInstance.$options.propsData,

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -1,9 +1,6 @@
-import {
-  component as defineComponentVue2,
-  defineComponent as defineComponentVue3,
-} from 'vue';
 import instantsearch from 'instantsearch.js/es';
 import algoliaHelper from 'algoliasearch-helper';
+import { isVue3, defineComponent, Vue2 } from 'vue-demi';
 const { SearchResults, SearchParameters } = algoliaHelper;
 import { warn } from './warn';
 
@@ -56,7 +53,7 @@ function defaultCloneComponent(componentInstance) {
 
   const Extended = componentInstance.$vnode
     ? componentInstance.$vnode.componentOptions.Ctor.extend(options)
-    : (defineComponentVue3 || defineComponentVue2)(
+    : (isVue3 ? defineComponent : Vue2.component)(
         Object.assign({}, componentInstance.$options, options)
       );
 


### PR DESCRIPTION
Since Vue 3, it seems `defineComponent()` should be used instead of `Vue.component()`.
I haven't got to testing the ssr, but at least this change unblocks the error with the default export.

related: https://v3.vuejs.org/api/global-api.html#definecomponent