### PR TITLE
feat(vue 3): support createElement for vue 3

### DIFF
--- a/src/components/InstantSearch.js
+++ b/src/components/InstantSearch.js
@@ -1,4 +1,5 @@
 import instantsearch from 'instantsearch.js/es';
+import { h as createElementVue3 } from 'vue';
 import { createInstantSearchComponent } from '../util/createInstantSearchComponent';
 import { warn } from '../util/warn';
 
@@ -87,16 +88,29 @@ export default createInstantSearchComponent({
       }),
     };
   },
-  render(createElement) {
-    return createElement(
-      'div',
-      {
-        class: {
-          [this.suit()]: true,
-          [this.suit('', 'ssr')]: false,
+  render(createElementVue2) {
+    if (createElementVue3) {
+      return createElementVue3(
+        'div',
+        {
+          class: {
+            [this.suit()]: true,
+            [this.suit('', 'ssr')]: false,
+          },
         },
-      },
-      this.$slots.default
-    );
+        this.$slots.default()
+      );
+    } else {
+      return createElementVue2(
+        'div',
+        {
+          class: {
+            [this.suit()]: true,
+            [this.suit('', 'ssr')]: false,
+          },
+        },
+        this.$slots.default
+      );
+    }
   },
 });


### PR DESCRIPTION
Since vue 3, it doesn't expose `createElement` in the `render` function. Instead we must import it from `vue`.

related: https://v3.vuejs.org/guide/migration/render-function-api.html#overview

Also, `this.$slots.default` has been changed to `this.$slots.default()` in vue 3 (https://v3.vuejs.org/api/instance-properties.html#slots)