### PR TITLE
feat(vue 3): support inject without `this`

### DIFF
--- a/src/mixins/widget.js
+++ b/src/mixins/widget.js
@@ -11,12 +11,7 @@ export const createWidgetMixin = ({ connector } = {}) => ({
         );
       },
     },
-    getParentIndex: {
-      from: '$_ais_getParentIndex',
-      default() {
-        return () => this.instantSearchInstance.mainIndex;
-      },
-    },
+    getProvidedParentIndex: '$_ais_getParentIndex',
   },
   data() {
     return {
@@ -72,6 +67,11 @@ Read more on using connectors: https://alg.li/vue-custom`
     },
   },
   methods: {
+    getParentIndex() {
+      return (
+        this.getProvidedParentIndex() || this.instantSearchInstance.mainIndex
+      );
+    },
     updateState(state = {}, isFirstRender) {
       if (!isFirstRender) {
         // Avoid updating the state on first render

--- a/src/mixins/widget.js
+++ b/src/mixins/widget.js
@@ -68,9 +68,9 @@ Read more on using connectors: https://alg.li/vue-custom`
   },
   methods: {
     getParentIndex() {
-      return (
-        this.getProvidedParentIndex() || this.instantSearchInstance.mainIndex
-      );
+      return this.getProvidedParentIndex
+        ? this.getProvidedParentIndex()
+        : this.instantSearchInstance.mainIndex;
     },
     updateState(state = {}, isFirstRender) {
       if (!isFirstRender) {


### PR DESCRIPTION
Vue 3 doesn't bind `this` when calling `default()` of a injected variable.

https://github.com/vuejs/vue-next/blob/540e26f49c09edf09b6a60ac2a978fdec52686bf/packages/runtime-core/src/apiInject.ts#L62-L64