### PR TITLE
fix(vue 3): provide default value for injected data

### DIFF
--- a/src/mixins/widget.js
+++ b/src/mixins/widget.js
@@ -11,7 +11,10 @@ export const createWidgetMixin = ({ connector } = {}) => ({
         );
       },
     },
-    getProvidedParentIndex: '$_ais_getParentIndex',
+    getProvidedParentIndex: {
+      from: '$_ais_getParentIndex',
+      default: undefined,
+    },
   },
   data() {
     return {


### PR DESCRIPTION
## Summary

This PR adds default value for `getProvidedParentIndex`. Without default value, we get this warning messages:

```
[Vue warn]: injection "$_ais_getParentIndex" not found. 
```