### PR TITLE
feat(vue 3): rename beforeDestroy to beforeUnmount

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     },
     {
       "path": "./dist/vue3/cjs/index.js",
-      "maxSize": "18.00 kB"
+      "maxSize": "18.25 kB"
     }
   ],
   "resolutions": {

--- a/src/mixins/panel.js
+++ b/src/mixins/panel.js
@@ -1,3 +1,4 @@
+import { isVue3 } from 'vue-demi';
 import mitt from 'mitt';
 
 export const PANEL_EMITTER_NAMESPACE = 'instantSearchPanelEmitter';
@@ -28,7 +29,7 @@ export const createPanelProviderMixin = () => ({
       this.updateCanRefine(value);
     });
   },
-  beforeDestroy() {
+  [isVue3 ? 'beforeUnmount' : 'beforeDestroy']() {
     this.emitter.all.clear();
   },
   methods: {

--- a/src/mixins/widget.js
+++ b/src/mixins/widget.js
@@ -1,3 +1,4 @@
+import { isVue3 } from 'vue-demi';
 import { warn } from '../util/warn';
 
 export const createWidgetMixin = ({ connector } = {}) => ({
@@ -50,7 +51,7 @@ Read more on using connectors: https://alg.li/vue-custom`
       );
     }
   },
-  beforeDestroy() {
+  [isVue3 ? 'beforeUnmount' : 'beforeDestroy']() {
     if (this.widget) {
       this.getParentIndex().removeWidgets([this.widget]);
     }

--- a/src/util/createInstantSearchComponent.js
+++ b/src/util/createInstantSearchComponent.js
@@ -1,7 +1,7 @@
 import { createSuitMixin } from '../mixins/suit';
 import { version } from '../../package.json'; // rollup does pick only what needed from json
 import { _objectSpread } from './polyfills';
-import { version as vueVersion } from 'vue-demi';
+import { isVue3, version as vueVersion } from 'vue-demi';
 
 export const createInstantSearchComponent = component =>
   _objectSpread(
@@ -68,7 +68,7 @@ export const createInstantSearchComponent = component =>
           }
         });
       },
-      beforeDestroy() {
+      [isVue3 ? 'beforeUnmount' : 'beforeDestroy']() {
         if (this.instantSearchInstance.started) {
           this.instantSearchInstance.dispose();
         }


### PR DESCRIPTION
## Summary

This PR renames `beforeDestroy` to `beforeUnmount` in case of Vue3 because it's been renamed.

https://v3.vuejs.org/guide/migration/introduction.html#other-minor-changes