### PR TITLE
chore(vue 3): update `external` at rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -39,15 +39,15 @@ const plugins = [
   filesize(),
 ];
 
+const external = id =>
+  ['algoliasearch-helper', 'instantsearch.js', 'vue', 'mitt', 'vue-demi'].some(
+    dep => id === dep || id.startsWith(`${dep}/`)
+  );
+
 export default [
   {
     input: 'src/instantsearch.js',
-    external: [
-      'algoliasearch-helper',
-      'instantsearch.js/es',
-      'instantsearch.js/es/connectors',
-      'vue',
-    ],
+    external,
     output: [
       {
         sourcemap: true,
@@ -60,12 +60,7 @@ export default [
   },
   {
     input: 'src/instantsearch.js',
-    external: [
-      'algoliasearch-helper',
-      'instantsearch.js/es',
-      'instantsearch.js/es/connectors',
-      'vue',
-    ],
+    external,
     output: [
       {
         sourcemap: true,


### PR DESCRIPTION
## Summary

This PR updates `external` property at the rollup config.
It adds `mitt` and `vue-demi`, and also updates it to be a function so that it can mark things like the following as external:

```
import indexWidget from 'instantsearch.js/es/widgets/index/index';
```