### PR TITLE
chore(vue 3): enable unit tests for Vue 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
       - run:
           name: Install Vue3
           command: |
-            yarn remove vue
+            yarn remove vue vue-template-compiler
             yarn add vue@3.0.0 -D -E
       - run:
           name: Switch to Vue3 mode

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
       - run:
           name: Install Vue3
           command: |
-            yarn remove vue vue-template-compiler
+            yarn remove vue
             yarn add vue@3.0.0 -D -E
       - run:
           name: Switch to Vue3 mode

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,8 +64,10 @@ jobs:
       - run:
           name: Install Vue3
           command: |
-            yarn remove vue
-            yarn add vue@3.0.0 -D -E
+            yarn remove vue vue-jest vue-template-compiler babel-preset-es2015
+            yarn add vue@3.0.6 vue-jest@5.0.0-alpha.10 vue-loader@16.1.2 jest@26.6.3 babel-jest@25.2.6 @babel/preset-env@7.14.5 -D -E
+            rm .babelrc
+            echo "// eslint-disable-next-line import/no-commonjs\nmodule.exports = {\n  presets: ['@babel/preset-env'],\n};" > babel.config.js
       - run:
           name: Switch to Vue3 mode
           command: yarn vue-demi-switch 3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,10 @@ jobs:
             yarn remove vue vue-jest vue-template-compiler babel-preset-es2015
             yarn add vue@3.0.6 vue-jest@5.0.0-alpha.10 vue-loader@16.1.2 jest@26.6.3 babel-jest@25.2.6 @babel/preset-env@7.14.5 -D -E
             rm .babelrc
-            echo "// eslint-disable-next-line import/no-commonjs\nmodule.exports = {\n  presets: ['@babel/preset-env'],\n};" > babel.config.js
+            echo "// eslint-disable-next-line import/no-commonjs" > babel.config.js
+            echo "module.exports = {" >> babel.config.js
+            echo "  presets: ['@babel/preset-env']," >> babel.config.js
+            echo "};" >> babel.config.js
       - run:
           name: Switch to Vue3 mode
           command: yarn vue-demi-switch 3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,13 +39,36 @@ jobs:
           name: Build & Test packages size
           command: yarn test:build
 
-  test_unit:
+  test_unit_vue2:
     <<: *defaults
     steps:
       - checkout
       - run: *install_yarn_version
       - restore_cache: *restore_yarn_cache
       - run: *run_yarn_install
+      - save_cache: *save_yarn_cache
+      - run:
+          name: Lint & Code styles
+          command: yarn lint
+      - run:
+          name: Unit Tests
+          command: yarn test --maxWorkers=4
+
+  test_unit_vue3:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: *install_yarn_version
+      - restore_cache: *restore_yarn_cache
+      - run: *run_yarn_install
+      - run:
+          name: Install Vue3
+          command: |
+            yarn remove vue
+            yarn add vue@3.0.0 -D -E
+      - run:
+          name: Switch to Vue3 mode
+          command: yarn vue-demi-switch 3
       - save_cache: *save_yarn_cache
       - run:
           name: Lint & Code styles
@@ -85,7 +108,8 @@ workflows:
   ci:
     jobs:
       - test_build
-      - test_unit
+      - test_unit_vue2
+      - test_unit_vue3
       - test_e2e
   release_if_needed:
     jobs:

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,5 @@
-import Vue from 'vue';
+import { isVue2, Vue2 } from 'vue-demi';
 
-Vue.config.productionTip = false;
+if (isVue2) {
+  Vue2.config.productionTip = false;
+}

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@storybook/vue": "3.4.11",
     "@vue/compiler-sfc": "3.0.11",
     "@vue/test-utils": "1.0.0-beta.25",
+    "@vue/test-utils2": "npm:@vue/test-utils@2.0.0-rc.6",
     "@wdio/cli": "^5.11.13",
     "@wdio/jasmine-framework": "^5.11.0",
     "@wdio/local-runner": "^5.11.13",

--- a/src/components/__tests__/Autocomplete.js
+++ b/src/components/__tests__/Autocomplete.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import Autocomplete from '../Autocomplete.vue';
 import { __setState } from '../../mixins/widget';
 jest.mock('../../mixins/widget');

--- a/src/components/__tests__/Breadcrumb.js
+++ b/src/components/__tests__/Breadcrumb.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import { __setState } from '../../mixins/widget';
 import Breadcrumb from '../Breadcrumb.vue';
 

--- a/src/components/__tests__/ClearRefinements.js
+++ b/src/components/__tests__/ClearRefinements.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import { __setState } from '../../mixins/widget';
 import ClearRefinements from '../ClearRefinements.vue';
 

--- a/src/components/__tests__/Configure.js
+++ b/src/components/__tests__/Configure.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import { __setState } from '../../mixins/widget';
 import Configure from '../Configure';
 

--- a/src/components/__tests__/ConfigureRelatedItems.js
+++ b/src/components/__tests__/ConfigureRelatedItems.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import ConfigureRelatedItems from '../ConfigureRelatedItems';
 
 jest.mock('../../mixins/widget');

--- a/src/components/__tests__/CurrentRefinements.js
+++ b/src/components/__tests__/CurrentRefinements.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import CurrentRefinements from '../CurrentRefinements.vue';
 import { __setState } from '../../mixins/widget';
 

--- a/src/components/__tests__/HierarchicalMenu.js
+++ b/src/components/__tests__/HierarchicalMenu.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import { __setState } from '../../mixins/widget';
 import HierarchicalMenu from '../HierarchicalMenu.vue';
 

--- a/src/components/__tests__/Highlight.js
+++ b/src/components/__tests__/Highlight.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import Highlight from '../Highlight.vue';
 
 jest.unmock('instantsearch.js/es');

--- a/src/components/__tests__/Hits.js
+++ b/src/components/__tests__/Hits.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import { __setState } from '../../mixins/widget';
 import Hits from '../Hits.vue';
 

--- a/src/components/__tests__/HitsPerPage.js
+++ b/src/components/__tests__/HitsPerPage.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import { __setState } from '../../mixins/widget';
 import HitsPerPage from '../HitsPerPage.vue';
 

--- a/src/components/__tests__/Index-integration.js
+++ b/src/components/__tests__/Index-integration.js
@@ -1,5 +1,5 @@
 jest.unmock('instantsearch.js/es');
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import Index from '../Index';
 import instantsearch from 'instantsearch.js/es';
 import { createWidgetMixin } from '../../mixins/widget';

--- a/src/components/__tests__/Index.js
+++ b/src/components/__tests__/Index.js
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import Index from '../Index';
 import { __setWidget } from '../../mixins/widget';
 jest.mock('../../mixins/widget');

--- a/src/components/__tests__/InfiniteHits.js
+++ b/src/components/__tests__/InfiniteHits.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import { __setState } from '../../mixins/widget';
 import InfiniteHits from '../InfiniteHits.vue';
 

--- a/src/components/__tests__/InstantSearch-integration.js
+++ b/src/components/__tests__/InstantSearch-integration.js
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import InstantSearch from '../InstantSearch';
 import { createWidgetMixin } from '../../mixins/widget';
 import { createFakeClient } from '../../util/testutils/client';

--- a/src/components/__tests__/InstantSearch.js
+++ b/src/components/__tests__/InstantSearch.js
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import instantsearch from 'instantsearch.js/es';
 import InstantSearch from '../InstantSearch';
 import { version } from '../../../package.json';

--- a/src/components/__tests__/InstantSearchSsr.js
+++ b/src/components/__tests__/InstantSearchSsr.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import instantsearch from 'instantsearch.js/es';
 import Vue from 'vue';
 import InstantSearchSsr from '../InstantSearchSsr';

--- a/src/components/__tests__/Menu.js
+++ b/src/components/__tests__/Menu.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import { __setState } from '../../mixins/widget';
 import Menu from '../Menu.vue';
 

--- a/src/components/__tests__/MenuSelect.js
+++ b/src/components/__tests__/MenuSelect.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import MenuSelect from '../MenuSelect.vue';
 import { __setState } from '../../mixins/widget';
 

--- a/src/components/__tests__/NumericMenu.js
+++ b/src/components/__tests__/NumericMenu.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import { __setState } from '../../mixins/widget';
 import NumericMenu from '../NumericMenu.vue';
 

--- a/src/components/__tests__/Pagination.js
+++ b/src/components/__tests__/Pagination.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import { __setState } from '../../mixins/widget';
 import Pagination from '../Pagination.vue';
 

--- a/src/components/__tests__/Panel.js
+++ b/src/components/__tests__/Panel.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import Panel from '../Panel.vue';
 
 describe('default render', () => {

--- a/src/components/__tests__/PoweredBy.js
+++ b/src/components/__tests__/PoweredBy.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import PoweredBy from '../PoweredBy.vue';
 jest.mock('../../mixins/widget');
 

--- a/src/components/__tests__/QueryRuleContext.js
+++ b/src/components/__tests__/QueryRuleContext.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import QueryRuleContext from '../QueryRuleContext';
 import { __setState } from '../../mixins/widget';
 

--- a/src/components/__tests__/QueryRuleCustomData.js
+++ b/src/components/__tests__/QueryRuleCustomData.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import QueryRuleCustomData from '../QueryRuleCustomData.vue';
 import { __setState } from '../../mixins/widget';
 

--- a/src/components/__tests__/RangeInput.js
+++ b/src/components/__tests__/RangeInput.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import { __setState } from '../../mixins/widget';
 import RangeInput from '../RangeInput.vue';
 

--- a/src/components/__tests__/RatingMenu.js
+++ b/src/components/__tests__/RatingMenu.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import RatingMenu from '../RatingMenu.vue';
 import { __setState } from '../../mixins/widget';
 

--- a/src/components/__tests__/RefinementList.js
+++ b/src/components/__tests__/RefinementList.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import RefinementList from '../RefinementList.vue';
 import { __setState } from '../../mixins/widget';
 

--- a/src/components/__tests__/RelevantSort.js
+++ b/src/components/__tests__/RelevantSort.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import RelevantSort from '../RelevantSort.vue';
 import { __setState } from '../../mixins/widget';
 jest.mock('../../mixins/widget');

--- a/src/components/__tests__/SearchBox.js
+++ b/src/components/__tests__/SearchBox.js
@@ -1,5 +1,5 @@
 import SearchBox from '../SearchBox.vue';
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import { __setState } from '../../mixins/widget';
 jest.mock('../../mixins/widget');
 

--- a/src/components/__tests__/Snippet.js
+++ b/src/components/__tests__/Snippet.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import Snippet from '../Snippet.vue';
 
 jest.unmock('instantsearch.js/es');

--- a/src/components/__tests__/SortBy.js
+++ b/src/components/__tests__/SortBy.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import { __setState } from '../../mixins/widget';
 import SortBy from '../SortBy.vue';
 

--- a/src/components/__tests__/StateResults.js
+++ b/src/components/__tests__/StateResults.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import StateResults from '../StateResults.vue';
 import { __setState } from '../../mixins/widget';
 jest.mock('../../mixins/widget');

--- a/src/components/__tests__/Stats.js
+++ b/src/components/__tests__/Stats.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 
 import Stats from '../Stats.vue';
 

--- a/src/components/__tests__/ToggleRefinement.js
+++ b/src/components/__tests__/ToggleRefinement.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import { __setState } from '../../mixins/widget';
 import Toggle from '../ToggleRefinement.vue';
 

--- a/src/components/__tests__/VoiceSearch.js
+++ b/src/components/__tests__/VoiceSearch.js
@@ -1,5 +1,5 @@
 import VoiceSearch from '../VoiceSearch.vue';
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import { __setState } from '../../mixins/widget';
 jest.mock('../../mixins/widget');
 

--- a/src/components/__tests__/__Template.js
+++ b/src/components/__tests__/__Template.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import Template from '../__Template.vue';
 import { __setState } from '../../mixins/widget';
 jest.mock('../../mixins/widget');

--- a/src/mixins/__tests__/panel.test.js
+++ b/src/mixins/__tests__/panel.test.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import mitt from 'mitt';
 import {
   createPanelProviderMixin,

--- a/src/mixins/__tests__/panel.test.js
+++ b/src/mixins/__tests__/panel.test.js
@@ -1,4 +1,4 @@
-import { mount, createLocalVue } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 import mitt from 'mitt';
 import {
   createPanelProviderMixin,
@@ -15,10 +15,9 @@ const createFakeEmitter = () => ({
   },
 });
 
-const createFakeComponent = localVue =>
-  localVue.component('Test', {
-    render: () => null,
-  });
+const createFakeComponent = () => ({
+  render: () => null,
+});
 
 describe('createPanelProviderMixin', () => {
   it('provides the emitter', () => {
@@ -32,9 +31,8 @@ describe('createPanelProviderMixin', () => {
   });
 
   it('registers to PANEL_CHANGE_EVENT on created', () => {
-    const localVue = createLocalVue();
     const emitter = createFakeEmitter();
-    const Test = createFakeComponent(localVue);
+    const Test = createFakeComponent();
 
     mount(Test, {
       mixins: [createPanelProviderMixin()],
@@ -51,9 +49,8 @@ describe('createPanelProviderMixin', () => {
   });
 
   it('clears the Vue instance on beforeDestroy', () => {
-    const LocalVue = createLocalVue();
     const emitter = createFakeEmitter();
-    const Test = createFakeComponent(LocalVue);
+    const Test = createFakeComponent();
 
     const wrapper = mount(Test, {
       mixins: [createPanelProviderMixin()],
@@ -68,9 +65,8 @@ describe('createPanelProviderMixin', () => {
   });
 
   it('updates canRefine on PANEL_CHANGE_EVENT', () => {
-    const LocalVue = createLocalVue();
     const emitter = mitt();
-    const Test = createFakeComponent(LocalVue);
+    const Test = createFakeComponent();
     const next = false;
 
     const wrapper = mount(Test, {
@@ -92,9 +88,8 @@ describe('createPanelConsumerMixin', () => {
   const mapStateToCanRefine = state => state.attributeName;
 
   it('emits PANEL_CHANGE_EVENT on `state.attributeName` change', () => {
-    const localVue = createLocalVue();
     const emitter = createFakeEmitter();
-    const Test = createFakeComponent(localVue);
+    const Test = createFakeComponent();
 
     const wrapper = mount(Test, {
       mixins: [
@@ -123,9 +118,8 @@ describe('createPanelConsumerMixin', () => {
   });
 
   it('emits once when both values are set', () => {
-    const localVue = createLocalVue();
     const emitter = createFakeEmitter();
-    const Test = createFakeComponent(localVue);
+    const Test = createFakeComponent();
 
     const wrapper = mount(Test, {
       mixins: [
@@ -153,9 +147,8 @@ describe('createPanelConsumerMixin', () => {
   });
 
   it('emits once on init of the component', () => {
-    const localVue = createLocalVue();
     const emitter = createFakeEmitter();
-    const Test = createFakeComponent(localVue);
+    const Test = createFakeComponent();
 
     const wrapper = mount(Test, {
       mixins: [
@@ -177,9 +170,8 @@ describe('createPanelConsumerMixin', () => {
   });
 
   it('do not emit when the next value is not set', () => {
-    const localVue = createLocalVue();
     const emitter = createFakeEmitter();
-    const Test = createFakeComponent(localVue);
+    const Test = createFakeComponent();
 
     const wrapper = mount(Test, {
       mixins: [
@@ -205,9 +197,8 @@ describe('createPanelConsumerMixin', () => {
   });
 
   it('do not emit when the previous and next value are equal', () => {
-    const localVue = createLocalVue();
     const emitter = createFakeEmitter();
-    const Test = createFakeComponent(localVue);
+    const Test = createFakeComponent();
 
     const wrapper = mount(Test, {
       mixins: [

--- a/src/mixins/__tests__/suit.test.js
+++ b/src/mixins/__tests__/suit.test.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import { createSuitMixin } from '../suit';
 
 const createFakeComponent = () => ({

--- a/src/mixins/__tests__/suit.test.js
+++ b/src/mixins/__tests__/suit.test.js
@@ -1,14 +1,12 @@
-import { mount, createLocalVue } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 import { createSuitMixin } from '../suit';
 
-const createFakeComponent = localVue =>
-  localVue.component('Test', {
-    render: () => null,
-  });
+const createFakeComponent = () => ({
+  render: () => null,
+});
 
 it('exposes the regular suit function for this widget', () => {
-  const localVue = createLocalVue();
-  const Test = createFakeComponent(localVue);
+  const Test = createFakeComponent();
 
   const wrapper = mount(Test, {
     mixins: [createSuitMixin({ name: 'Test' })],
@@ -22,13 +20,12 @@ it('exposes the regular suit function for this widget', () => {
 });
 
 it('allows overriding from the `class-names` prop', () => {
-  const localVue = createLocalVue();
-  const Test = localVue.component('Test', {
+  const Test = {
     props: {
       classNames: { type: Object },
     },
     render: () => null,
-  });
+  };
 
   const wrapper = mount(Test, {
     propsData: {

--- a/src/mixins/__tests__/widget.test.js
+++ b/src/mixins/__tests__/widget.test.js
@@ -1,10 +1,9 @@
-import { mount, createLocalVue } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 import { createWidgetMixin } from '../widget';
 
-const createFakeComponent = localVue =>
-  localVue.component('Test', {
-    render: () => null,
-  });
+const createFakeComponent = () => ({
+  render: () => null,
+});
 
 const createFakeInstance = () => ({
   addWidgets: jest.fn(),
@@ -20,9 +19,8 @@ const createFakeIndexWidget = () => ({
 
 describe('on root index', () => {
   it('adds a widget on create', () => {
-    const localVue = createLocalVue();
     const instance = createFakeInstance();
-    const Test = createFakeComponent(localVue);
+    const Test = createFakeComponent();
 
     const widget = { render: () => {} };
     const factory = jest.fn(() => widget);
@@ -47,9 +45,8 @@ describe('on root index', () => {
   });
 
   it('removes a widget on destroy', () => {
-    const localVue = createLocalVue();
     const instance = createFakeInstance();
-    const Test = createFakeComponent(localVue);
+    const Test = createFakeComponent();
 
     const widget = {
       render: () => {},
@@ -79,9 +76,8 @@ describe('on root index', () => {
   });
 
   it('updates widget on widget params change', () => {
-    const localVue = createLocalVue();
     const instance = createFakeInstance();
-    const Test = createFakeComponent(localVue);
+    const Test = createFakeComponent();
 
     const widget = {
       render: () => {},
@@ -132,9 +128,8 @@ describe('on root index', () => {
   });
 
   it('updates local state on connector render', () => {
-    const localVue = createLocalVue();
     const instance = createFakeInstance();
-    const Test = createFakeComponent(localVue);
+    const Test = createFakeComponent();
 
     const widget = { render: () => {} };
     const factory = jest.fn(() => widget);
@@ -174,10 +169,9 @@ describe('on root index', () => {
 
 describe('on child index', () => {
   it('adds a widget on create', () => {
-    const localVue = createLocalVue();
     const instance = createFakeInstance();
     const indexWidget = createFakeIndexWidget();
-    const Test = createFakeComponent(localVue);
+    const Test = createFakeComponent();
 
     const widget = { render: () => {} };
     const factory = jest.fn(() => widget);
@@ -203,10 +197,9 @@ describe('on child index', () => {
   });
 
   it('removes a widget on destroy', () => {
-    const localVue = createLocalVue();
     const instance = createFakeInstance();
     const indexWidget = createFakeIndexWidget();
-    const Test = createFakeComponent(localVue);
+    const Test = createFakeComponent();
 
     const widget = {
       render: () => {},
@@ -237,10 +230,9 @@ describe('on child index', () => {
   });
 
   it('updates widget on widget params change', () => {
-    const localVue = createLocalVue();
     const instance = createFakeInstance();
     const indexWidget = createFakeIndexWidget();
-    const Test = createFakeComponent(localVue);
+    const Test = createFakeComponent();
 
     const widget = {
       render: () => {},
@@ -292,10 +284,9 @@ describe('on child index', () => {
   });
 
   it('updates local state on connector render', () => {
-    const localVue = createLocalVue();
     const instance = createFakeInstance();
     const indexWidget = createFakeIndexWidget();
-    const Test = createFakeComponent(localVue);
+    const Test = createFakeComponent();
 
     const widget = { render: () => {} };
     const factory = jest.fn(() => widget);

--- a/src/mixins/__tests__/widget.test.js
+++ b/src/mixins/__tests__/widget.test.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import { createWidgetMixin } from '../widget';
 
 const createFakeComponent = () => ({

--- a/src/util/__tests__/createServerRootMixin.test.js
+++ b/src/util/__tests__/createServerRootMixin.test.js
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { mount } from '@vue/test-utils';
+import { mount } from '../../../test/utils';
 import _renderToString from 'vue-server-renderer/basic';
 import Router from 'vue-router';
 import Vuex from 'vuex';

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -2,7 +2,7 @@ import { isVue3 } from 'vue-demi';
 
 export const mount = isVue3
   ? (component, options = {}) => {
-      const { propsData, mixins, ...restOptions } = options;
+      const { propsData, mixins, provide, ...restOptions } = options;
       // If we `import` this, it will try to import Vue3-only APIs like `defineComponent`,
       // and jest will fail. So we need to `require` it.
       const wrapper = require('@vue/test-utils2').mount(component, {
@@ -10,6 +10,7 @@ export const mount = isVue3
         props: propsData,
         global: {
           mixins,
+          provide,
         },
       });
       wrapper.destroy = () => wrapper.unmount();

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -13,7 +13,7 @@ export const mount = isVue3
           provide,
         },
       });
-      wrapper.destroy = () => wrapper.unmount();
+      wrapper.destroy = wrapper.unmount;
       return wrapper;
     }
   : require('@vue/test-utils').mount;

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -1,13 +1,14 @@
 import { isVue3 } from 'vue-demi';
-import { mount as mount1 } from '@vue/test-utils';
-import { mount as mount2 } from '@vue/test-utils2';
+import { mount as mountVue2 } from '@vue/test-utils';
 
 export const mount = isVue3
   ? (component, options = {}) => {
       const { propsData, ...restOptions } = options;
-      return mount2(component, {
+      // If we `import` this, it will try to import Vue3-only APIs like `defineComponent`,
+      // and jest will fail. So we need to `require` it.
+      return require('@vue/test-utils2').mount(component, {
         ...restOptions,
         props: propsData,
       });
     }
-  : mount1;
+  : mountVue2;

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -1,0 +1,13 @@
+import { isVue3 } from 'vue-demi';
+import { mount as mount1 } from '@vue/test-utils';
+import { mount as mount2 } from '@vue/test-utils2';
+
+export const mount = isVue3
+  ? (component, options = {}) => {
+      const { propsData, ...restOptions } = options;
+      return mount2(component, {
+        ...restOptions,
+        props: propsData,
+      });
+    }
+  : mount1;

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -1,14 +1,18 @@
 import { isVue3 } from 'vue-demi';
-import { mount as mountVue2 } from '@vue/test-utils';
 
 export const mount = isVue3
   ? (component, options = {}) => {
-      const { propsData, ...restOptions } = options;
+      const { propsData, mixins, ...restOptions } = options;
       // If we `import` this, it will try to import Vue3-only APIs like `defineComponent`,
       // and jest will fail. So we need to `require` it.
-      return require('@vue/test-utils2').mount(component, {
+      const wrapper = require('@vue/test-utils2').mount(component, {
         ...restOptions,
         props: propsData,
+        global: {
+          mixins,
+        },
       });
+      wrapper.destroy = () => wrapper.unmount();
+      return wrapper;
     }
-  : mountVue2;
+  : require('@vue/test-utils').mount;

--- a/yarn.lock
+++ b/yarn.lock
@@ -147,10 +147,10 @@
   dependencies:
     "@babel/types" "^7.0.0"
 
-"@babel/helper-validator-identifier@^7.12.11":
-  version "7.12.11"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
-  integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
+"@babel/helper-validator-identifier@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz#d0f0e277c512e0c938277faa85a3968c9a44c0e8"
+  integrity sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==
 
 "@babel/highlight@^7.0.0":
   version "7.0.0"
@@ -167,9 +167,9 @@
   integrity sha512-RgJhNdRinpO8zibnoHbzTTexNs4c8ROkXFBanNDZTLHjwbdLk8J5cJSKulx/bycWTLYmKVNCkxRtVCoJnqPk+g==
 
 "@babel/parser@^7.12.0", "@babel/parser@^7.13.9":
-  version "7.13.15"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.15.tgz#8e66775fb523599acb6a289e12929fa5ab0954d8"
-  integrity sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ==
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.5.tgz#4cd2f346261061b2518873ffecdf1612cb032829"
+  integrity sha512-TM8C+xtH/9n1qzX+JNHi7AN2zHMTiPUtspO0ZdHflW8KaskkALhMmuMHb4bCmNdv9VAPzJX3/bXqkVLnAvsPfg==
 
 "@babel/runtime@^7.6.3", "@babel/runtime@^7.9.6":
   version "7.10.2"
@@ -212,12 +212,11 @@
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.12.0", "@babel/types@^7.13.0":
-  version "7.13.14"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.13.14.tgz#c35a4abb15c7cd45a2746d78ab328e362cbace0d"
-  integrity sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.5.tgz#3bb997ba829a2104cedb20689c4a5b8121d383ff"
+  integrity sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.12.11"
-    lodash "^4.17.19"
+    "@babel/helper-validator-identifier" "^7.14.5"
     to-fast-properties "^2.0.0"
 
 "@icons/material@^0.2.4":
@@ -865,6 +864,11 @@
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.11.tgz#20d22dd0da7d358bb21c17f9bde8628152642c77"
   integrity sha512-b+zB8A2so8eCE0JsxjL24J7vdGl8rzPQ09hZNhystm+KqSbKcAej1A+Hbva1rCMmTTqA+hFnUSDc5kouEo0JzA==
+
+"@vue/test-utils2@npm:@vue/test-utils@2.0.0-rc.6":
+  version "2.0.0-rc.6"
+  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-2.0.0-rc.6.tgz#d0aac24d20450d379e183f70542c0822670b8783"
+  integrity sha512-0cnQBVH589PwgqWpyv1fgCAz+9Ram/MsvN3ZEAEVXi1aPuhUa22EudGc0WezQ9PKwR+L40NrBmt3JBXE2tSRRQ==
 
 "@vue/test-utils@1.0.0-beta.25":
   version "1.0.0-beta.25"
@@ -9633,7 +9637,7 @@ lodash@4.17.19, lodash@4.x, lodash@>4.17.4, lodash@^4.0.1, lodash@^4.13.1, lodas
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
-lodash@^4.0.0, lodash@^4.17.19:
+lodash@^4.0.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -10456,10 +10460,10 @@ nan@^2.9.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766"
   integrity sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==
 
-nanoid@^3.1.22:
-  version "3.1.22"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.22.tgz#b35f8fb7d151990a8aebd5aa5015c03cf726f844"
-  integrity sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==
+nanoid@^3.1.23:
+  version "3.1.23"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.23.tgz#f744086ce7c2bc47ee0a8472574d5c78e4183a81"
+  integrity sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -11835,9 +11839,9 @@ postcss-modules@^0.6.4:
     string-hash "^1.1.1"
 
 postcss-modules@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-modules/-/postcss-modules-4.0.0.tgz#2bc7f276ab88f3f1b0fadf6cbd7772d43b5f3b9b"
-  integrity sha512-ghS/ovDzDqARm4Zj6L2ntadjyQMoyJmi0JkLlYtH2QFLrvNlxH5OAVRPWPeKilB0pY7SbuhO173KOWkPAxRJcw==
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/postcss-modules/-/postcss-modules-4.1.3.tgz#c4c4c41d98d97d24c70e88dacfc97af5a4b3e21d"
+  integrity sha512-dBT39hrXe4OAVYJe/2ZuIZ9BzYhOe7t+IhedYeQ2OxKwDpAGlkEN/fR0fGnrbx4BvgbMReRX4hCubYK9cE/pJQ==
   dependencies:
     generic-names "^2.0.1"
     icss-replace-symbols "^1.1.0"
@@ -11906,7 +11910,7 @@ postcss-selector-parser@^2.0.0, postcss-selector-parser@^2.2.2, postcss-selector
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4:
+postcss-selector-parser@^6.0.2:
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz#56075a1380a04604c38b063ea7767a129af5c2b3"
   integrity sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==
@@ -11914,6 +11918,14 @@ postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4:
     cssesc "^3.0.0"
     indexes-of "^1.0.1"
     uniq "^1.0.1"
+    util-deprecate "^1.0.2"
+
+postcss-selector-parser@^6.0.4:
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz#2c5bba8174ac2f6981ab631a42ab0ee54af332ea"
+  integrity sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==
+  dependencies:
+    cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
 postcss-svgo@^2.1.1:
@@ -11988,13 +12000,13 @@ postcss@^6.0.0, postcss@^6.0.17, postcss@^6.0.8:
     supports-color "^5.4.0"
 
 postcss@^8.1.10:
-  version "8.2.10"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.10.tgz#ca7a042aa8aff494b334d0ff3e9e77079f6f702b"
-  integrity sha512-b/h7CPV7QEdrqIxtAf2j31U5ef05uBDuvoXv6L51Q4rcS1jdlXAVKJv+atCFdUXYl9dyTHGyoMzIepwowRJjFw==
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.3.4.tgz#41ece1c43f2f7c74dc7d90144047ce052757b822"
+  integrity sha512-/tZY0PXExXXnNhKv3TOvZAOUYRyuqcCbBm2c17YMDK0PlVII3K7/LKdt3ScHL+hhouddjUWi+1sKDf9xXW+8YA==
   dependencies:
     colorette "^1.2.2"
-    nanoid "^3.1.22"
-    source-map "^0.6.1"
+    nanoid "^3.1.23"
+    source-map-js "^0.6.2"
 
 posthtml-attrs-parser@^0.1.1:
   version "0.1.1"
@@ -14395,6 +14407,11 @@ source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
   integrity sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==
+
+source-map-js@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
+  integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
 
 source-map-resolve@^0.5.0, source-map-resolve@^0.5.1:
   version "0.5.2"


### PR DESCRIPTION
## Summary

This PR makes CircleCI run linting and unit tests for Vue 3.

This PR is intended to enable CircleCI job and the environmental tasks. The failing unit tests will be taken care of in separate PRs.


* ref: https://github.com/lmiller1990/vtu-next-demo

### TODOs

These are the most recurring examples of errors:

1. widget mixin (seems to be broken in many cases)
2. different attribute order (not sure how to fix it yet ↓)
```
    -     <option value
    -             class="ais-MenuSelect-option"
    +     <option class="ais-MenuSelect-option"
    +             value
```
3. different dom outputs (cause not identified)
```
    -       <span>
    -         Apple
    -       </span>
    +       Apple (50)
```
4. using `h` from Vue2
```
  ● createServerRootMixin › hydrate › sets helper & mainHelper

    TypeError: h is not a function

      658 |         render(h) {
      659 |           return h(InstantSearchSsr, {}, [
    > 660 |             h(Configure, {
```
5. using `Vue` constructor

