### PR TITLE
test(vue 3): replace slot-scope with v-slot

### DIFF
--- a/src/components/StateResults.vue
+++ b/src/components/StateResults.vue
@@ -9,7 +9,7 @@
       </p>
       <p>
         Fill in the slot, and get access to the following things on the
-        <code>slot-scope</code>:
+        <code>v-slot</code>:
       </p>
       <pre>results: {{ Object.keys(state.results) }}</pre>
       <pre>state: {{ Object.keys(state.state) }}</pre>

--- a/src/components/StateResults.vue
+++ b/src/components/StateResults.vue
@@ -8,8 +8,7 @@
         Use this component to have a different layout based on a certain state.
       </p>
       <p>
-        Fill in the slot, and get access to the following things on the
-        <code>v-slot</code>:
+        Fill in the slot, and get access to the following things:
       </p>
       <pre>results: {{ Object.keys(state.results) }}</pre>
       <pre>state: {{ Object.keys(state.state) }}</pre>

--- a/src/components/__tests__/Breadcrumb.js
+++ b/src/components/__tests__/Breadcrumb.js
@@ -214,33 +214,37 @@ describe('panel', () => {
 });
 
 describe('custom default render', () => {
-  const defaultScopedSlot = `
-    <ul
-      slot-scope="{ items, canRefine, refine, createURL }"
-      :class="[!canRefine && 'noRefinement']"
-    >
-      <li
-        v-for="(item, index) in items"
-        :key="item.label"
-      >
-        <a
-          :href="createURL(item.value)"
-          @click.prevent="refine(item.value)"
+  const defaultSlot = `
+    <template v-slot="{ items, canRefine, refine, createURL }">
+      <ul :class="[!canRefine && 'noRefinement']">
+        <li
+          v-for="(item, index) in items"
+          :key="item.label"
         >
-          {{ item.label }}
-        </a>
-      </li>
-    </ul>
+          <a
+            :href="createURL(item.value)"
+            @click.prevent="refine(item.value)"
+          >
+            {{ item.label }}
+          </a>
+        </li>
+      </ul>
+    </template>
   `;
 
   it('renders correctly', () => {
     __setState({ ...defaultState });
 
-    const wrapper = mount(Breadcrumb, {
-      propsData: defaultProps,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { Breadcrumb },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <Breadcrumb v-bind="props">
+          ${defaultSlot}
+        </Breadcrumb>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -253,11 +257,16 @@ describe('custom default render', () => {
       canRefine: false,
     });
 
-    const wrapper = mount(Breadcrumb, {
-      propsData: defaultProps,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { Breadcrumb },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <Breadcrumb v-bind="props">
+          ${defaultSlot}
+        </Breadcrumb>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -269,11 +278,16 @@ describe('custom default render', () => {
       createURL: value => `/${value}`,
     });
 
-    const wrapper = mount(Breadcrumb, {
-      propsData: defaultProps,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { Breadcrumb },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <Breadcrumb v-bind="props">
+          ${defaultSlot}
+        </Breadcrumb>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -287,11 +301,16 @@ describe('custom default render', () => {
       refine,
     });
 
-    const wrapper = mount(Breadcrumb, {
-      propsData: defaultProps,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { Breadcrumb },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <Breadcrumb v-bind="props">
+          ${defaultSlot}
+        </Breadcrumb>
+      `,
     });
 
     await wrapper
@@ -314,7 +333,7 @@ describe('custom rootLabel render', () => {
 
     const wrapper = mount(Breadcrumb, {
       propsData: defaultProps,
-      scopedSlots: {
+      slots: {
         rootLabel: rootLabelSlot,
       },
     });
@@ -331,7 +350,7 @@ describe('custom rootLabel render', () => {
 
     const wrapper = mount(Breadcrumb, {
       propsData: defaultProps,
-      scopedSlots: {
+      slots: {
         rootLabel: rootLabelSlot,
       },
     });
@@ -350,7 +369,7 @@ describe('custom separator render', () => {
 
     const wrapper = mount(Breadcrumb, {
       propsData: defaultProps,
-      scopedSlots: {
+      slots: {
         separator: separatorSlot,
       },
     });

--- a/src/components/__tests__/ClearRefinements.js
+++ b/src/components/__tests__/ClearRefinements.js
@@ -83,15 +83,14 @@ describe('default render', () => {
 });
 
 describe('custom default render', () => {
-  const defaultScopedSlot = `
-    <div
-      slot-scope="{ canRefine, refine, createURL }"
-      :class="[!canRefine && 'no-refinement']"
-    >
-      <a :href="createURL()" @click.prevent="refine">
-        Clear refinements
-      </a>
-    </div>
+  const defaultSlot = `
+    <template v-slot="{ canRefine, refine, createURL }">
+      <div :class="[!canRefine && 'no-refinement']">
+        <a :href="createURL()" @click.prevent="refine">
+          Clear refinements
+        </a>
+      </div>
+    </template>
   `;
 
   it('renders correctly', () => {
@@ -99,10 +98,13 @@ describe('custom default render', () => {
       ...defaultState,
     });
 
-    const wrapper = mount(ClearRefinements, {
-      scopedSlots: {
-        default: defaultScopedSlot,
-      },
+    const wrapper = mount({
+      components: { ClearRefinements },
+      template: `
+        <ClearRefinements>
+          ${defaultSlot}
+        </ClearRefinements>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -114,10 +116,13 @@ describe('custom default render', () => {
       hasRefinements: false,
     });
 
-    const wrapper = mount(ClearRefinements, {
-      scopedSlots: {
-        default: defaultScopedSlot,
-      },
+    const wrapper = mount({
+      components: { ClearRefinements },
+      template: `
+        <ClearRefinements>
+          ${defaultSlot}
+        </ClearRefinements>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -129,10 +134,13 @@ describe('custom default render', () => {
       createURL: () => `/clear/refinements`,
     });
 
-    const wrapper = mount(ClearRefinements, {
-      scopedSlots: {
-        default: defaultScopedSlot,
-      },
+    const wrapper = mount({
+      components: { ClearRefinements },
+      template: `
+        <ClearRefinements>
+          ${defaultSlot}
+        </ClearRefinements>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -146,10 +154,13 @@ describe('custom default render', () => {
       refine,
     });
 
-    const wrapper = mount(ClearRefinements, {
-      scopedSlots: {
-        default: defaultScopedSlot,
-      },
+    const wrapper = mount({
+      components: { ClearRefinements },
+      template: `
+        <ClearRefinements>
+          ${defaultSlot}
+        </ClearRefinements>
+      `,
     });
 
     await wrapper.find('a').trigger('click');

--- a/src/components/__tests__/Configure.js
+++ b/src/components/__tests__/Configure.js
@@ -16,10 +16,12 @@ const defaultProps = {
   hitsPerPage: 5,
 };
 
-const defaultScopedSlots = `
-  <span slot-scope="{ searchParameters }">
-    hitsPerPage: {{ searchParameters.hitsPerPage }}
-  </span>
+const defaultSlot = `
+  <template v-slot="{ searchParameters }">
+    <span>
+      hitsPerPage: {{ searchParameters.hitsPerPage }}
+    </span>
+  </template>
 `;
 
 it('accepts SearchParameters from attributes', () => {
@@ -49,11 +51,16 @@ it('renders null without scoped slots', () => {
 it('renders null without state', () => {
   __setState(null);
 
-  const wrapper = mount(Configure, {
-    propsData: defaultProps,
-    scopedSlots: {
-      default: defaultScopedSlots,
+  const wrapper = mount({
+    components: { Configure },
+    data() {
+      return { props: defaultProps };
     },
+    template: `
+      <Configure v-bind="props">
+        ${defaultSlot}
+      </Configure>
+    `,
   });
 
   expect(wrapper.html()).toMatchSnapshot();
@@ -62,11 +69,16 @@ it('renders null without state', () => {
 it('renders with scoped slots', () => {
   __setState({ ...defaultState });
 
-  const wrapper = mount(Configure, {
-    propsData: defaultProps,
-    scopedSlots: {
-      default: defaultScopedSlots,
+  const wrapper = mount({
+    components: { Configure },
+    data() {
+      return { props: defaultProps };
     },
+    template: `
+      <Configure v-bind="props">
+        ${defaultSlot}
+      </Configure>
+    `,
   });
 
   expect(wrapper.html()).toMatchSnapshot();

--- a/src/components/__tests__/CurrentRefinements.js
+++ b/src/components/__tests__/CurrentRefinements.js
@@ -159,8 +159,8 @@ describe.each([
 
     if (name === 'query') {
       expect(
-        wrapper.find('.ais-CurrentRefinements-categoryLabel').contains('q')
-      ).toBe(true);
+        wrapper.find('.ais-CurrentRefinements-categoryLabel q').text()
+      ).toEqual('search1');
     }
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -236,47 +236,53 @@ it('calls `refine` with a refinement', async () => {
 });
 
 describe('custom render', () => {
-  const defaultScopedSlot = `
-    <div slot-scope="{ refine, items, createURL }">
-      <ul>
-        <li
-          v-for="item in items"
-          :key="item.attribute"
-          >
-          {{item.label}}:
-          <button
-            v-for="refinement in item.refinements"
-            @click="item.refine(refinement)"
-            :key="refinement.value"
-          >
-            {{refinement.label}} ╳
-          </button>
-        </li>
-      </ul>
-    </div>
+  const defaultSlot = `
+    <template v-slot="{ refine, items, createURL }">
+      <div>
+        <ul>
+          <li
+            v-for="item in items"
+            :key="item.attribute"
+            >
+            {{item.label}}:
+            <button
+              v-for="refinement in item.refinements"
+              @click="item.refine(refinement)"
+              :key="refinement.value"
+            >
+              {{refinement.label}} ╳
+            </button>
+          </li>
+        </ul>
+      </div>
+    </template>
   `;
 
-  const itemScopedSlot = `
-    <div slot-scope="{ item, refine }">
-      {{item.label}}:
-      <button
-        v-for="refinement in item.refinements"
-        @click="item.refine(refinement)"
-        :key="refinement.value"
-      >
-        {{refinement.label}}
-      </button>
-    </div>
+  const itemSlot = `
+    <template v-slot:item="{ item, refine }">
+      <div>
+        {{item.label}}:
+        <button
+          v-for="refinement in item.refinements"
+          @click="item.refine(refinement)"
+          :key="refinement.value"
+        >
+          {{refinement.label}}
+        </button>
+      </div>
+    </template>
   `;
 
-  const refinementScopedSlot = `
-    <div slot-scope="{ refinement, refine, createURL }">
-      <button
-        @click="refine(refinement)"
-      >
-        <pre>{{refinement}}</pre>
-      </button>
-    </div>
+  const refinementSlot = `
+    <template v-slot:refinement="{ refinement, refine, createURL }">
+      <div>
+        <button
+          @click="refine(refinement)"
+        >
+          <pre>{{refinement}}</pre>
+        </button>
+      </div>
+    </template>
   `;
 
   const items = [
@@ -315,10 +321,13 @@ describe('custom render', () => {
       ),
     });
 
-    const wrapper = mount(CurrentRefinements, {
-      scopedSlots: {
-        default: defaultScopedSlot,
-      },
+    const wrapper = mount({
+      components: { CurrentRefinements },
+      template: `
+        <CurrentRefinements>
+          ${defaultSlot}
+        </CurrentRefinements>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -333,10 +342,13 @@ describe('custom render', () => {
       ),
     });
 
-    const wrapper = mount(CurrentRefinements, {
-      scopedSlots: {
-        default: defaultScopedSlot,
-      },
+    const wrapper = mount({
+      components: { CurrentRefinements },
+      template: `
+        <CurrentRefinements>
+          ${defaultSlot}
+        </CurrentRefinements>
+      `,
     });
 
     expect(wrapper.findAll('button')).toHaveLength(items.length);
@@ -351,10 +363,13 @@ describe('custom render', () => {
       ),
     });
 
-    const wrapper = mount(CurrentRefinements, {
-      scopedSlots: {
-        item: itemScopedSlot,
-      },
+    const wrapper = mount({
+      components: { CurrentRefinements },
+      template: `
+        <CurrentRefinements>
+          ${itemSlot}
+        </CurrentRefinements>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -369,10 +384,13 @@ describe('custom render', () => {
       ),
     });
 
-    const wrapper = mount(CurrentRefinements, {
-      scopedSlots: {
-        item: itemScopedSlot,
-      },
+    const wrapper = mount({
+      components: { CurrentRefinements },
+      template: `
+        <CurrentRefinements>
+          ${itemSlot}
+        </CurrentRefinements>
+      `,
     });
 
     expect(wrapper.findAll('button')).toHaveLength(items.length);
@@ -387,10 +405,13 @@ describe('custom render', () => {
       ),
     });
 
-    const wrapper = mount(CurrentRefinements, {
-      scopedSlots: {
-        refinement: refinementScopedSlot,
-      },
+    const wrapper = mount({
+      components: { CurrentRefinements },
+      template: `
+        <CurrentRefinements>
+          ${refinementSlot}
+        </CurrentRefinements>
+      `,
     });
 
     expect(wrapper.findAll('button')).toHaveLength(items.length);

--- a/src/components/__tests__/HierarchicalMenu.js
+++ b/src/components/__tests__/HierarchicalMenu.js
@@ -496,15 +496,20 @@ it('exposes send-event method for insights middleware', async () => {
     sendEvent,
   });
 
-  const wrapper = mount(HierarchicalMenu, {
-    propsData: defaultProps,
-    scopedSlots: {
-      default: `
-      <div slot-scope="{ sendEvent }">
-        <button @click="sendEvent()">Send Event</button>
-      </div>
-      `,
+  const wrapper = mount({
+    components: { HierarchicalMenu },
+    data() {
+      return { props: defaultProps };
     },
+    template: `
+      <HierarchicalMenu v-bind="props">
+        <template v-slot="{ sendEvent }">
+          <div>
+            <button @click="sendEvent()">Send Event</button>
+          </div>
+        </template>
+      </HierarchicalMenu>
+    `,
   });
 
   await wrapper.find('button').trigger('click');
@@ -512,54 +517,58 @@ it('exposes send-event method for insights middleware', async () => {
 });
 
 describe('custom default render', () => {
-  const defaultScopedSlot = `
-    <div
-      slot-scope="state"
-      :class="[!state.canRefine && 'no-refinement']"
-    >
-      <ol>
-        <li
-          v-for="item in state.items"
-          :key="item.value"
-        >
-          <a
-            :href="state.createURL(item.value)"
-            @click.prevent="state.refine(item.value)"
+  const defaultSlot = `
+    <template v-slot="state">
+      <div :class="[!state.canRefine && 'no-refinement']">
+        <ol>
+          <li
+            v-for="item in state.items"
+            :key="item.value"
           >
-            {{item.label}} - {{item.count}}
-          </a>
-          <ol v-if="item.data">
-            <li
-              v-for="child in item.data"
-              :key="child.value"
+            <a
+              :href="state.createURL(item.value)"
+              @click.prevent="state.refine(item.value)"
             >
-              <a
-                :href="state.createURL(child.value)"
-                @click.prevent="state.refine(child.value)"
+              {{item.label}} - {{item.count}}
+            </a>
+            <ol v-if="item.data">
+              <li
+                v-for="child in item.data"
+                :key="child.value"
               >
-                {{child.label}} - {{child.count}}
-              </a>
-            </li>
-          </ol>
-        </li>
-      </ol>
-      <button
-        :disabled="!state.canToggleShowMore"
-        @click.prevent="state.toggleShowMore"
-      >
-        {{ state.isShowingMore ? 'View less' : 'View more' }}
-      </button>
-    </div>
+                <a
+                  :href="state.createURL(child.value)"
+                  @click.prevent="state.refine(child.value)"
+                >
+                  {{child.label}} - {{child.count}}
+                </a>
+              </li>
+            </ol>
+          </li>
+        </ol>
+        <button
+          :disabled="!state.canToggleShowMore"
+          @click.prevent="state.toggleShowMore"
+        >
+          {{ state.isShowingMore ? 'View less' : 'View more' }}
+        </button>
+      </div>
+    </template>
   `;
 
   it('renders correctly', () => {
     __setState({ ...defaultState });
 
-    const wrapper = mount(HierarchicalMenu, {
-      propsData: defaultProps,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { HierarchicalMenu },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <HierarchicalMenu v-bind="props">
+          ${defaultSlot}
+        </HierarchicalMenu>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -571,11 +580,16 @@ describe('custom default render', () => {
       items: [],
     });
 
-    const wrapper = mount(HierarchicalMenu, {
-      propsData: defaultProps,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { HierarchicalMenu },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <HierarchicalMenu v-bind="props">
+          ${defaultSlot}
+        </HierarchicalMenu>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -587,11 +601,16 @@ describe('custom default render', () => {
       createURL: value => `/categories/${value.replace(/ > /g, '/')}`,
     });
 
-    const wrapper = mount(HierarchicalMenu, {
-      propsData: defaultProps,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { HierarchicalMenu },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <HierarchicalMenu v-bind="props">
+          ${defaultSlot}
+        </HierarchicalMenu>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -602,14 +621,20 @@ describe('custom default render', () => {
       ...defaultState,
     });
 
-    const wrapper = mount(HierarchicalMenu, {
-      propsData: {
-        ...defaultProps,
-        limit: 1,
+    const props = {
+      ...defaultProps,
+      limit: 1,
+    };
+    const wrapper = mount({
+      components: { HierarchicalMenu },
+      data() {
+        return { props };
       },
-      scopedSlots: {
-        default: defaultScopedSlot,
-      },
+      template: `
+        <HierarchicalMenu v-bind="props">
+          ${defaultSlot}
+        </HierarchicalMenu>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -619,22 +644,29 @@ describe('custom default render', () => {
     __setState({
       ...defaultState,
       toggleShowMore: () => {
-        wrapper.setData({
-          state: {
-            isShowingMore: true,
-          },
+        const component = wrapper.vm.$children[0];
+        component.$set(component, 'state', {
+          ...component.state,
+          isShowingMore: true,
         });
       },
     });
 
-    const wrapper = mount(HierarchicalMenu, {
-      propsData: {
-        ...defaultProps,
-        limit: 1,
+    const props = {
+      ...defaultProps,
+      limit: 1,
+    };
+
+    const wrapper = mount({
+      components: { HierarchicalMenu },
+      data() {
+        return { props };
       },
-      scopedSlots: {
-        default: defaultScopedSlot,
-      },
+      template: `
+        <HierarchicalMenu v-bind="props">
+          ${defaultSlot}
+        </HierarchicalMenu>
+      `,
     });
 
     expect(wrapper.find('button').text()).toBe('View more');
@@ -652,11 +684,16 @@ describe('custom default render', () => {
       canToggleShowMore: false,
     });
 
-    const wrapper = mount(HierarchicalMenu, {
-      propsData: defaultProps,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { HierarchicalMenu },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <HierarchicalMenu v-bind="props">
+          ${defaultSlot}
+        </HierarchicalMenu>
+      `,
     });
 
     expect(wrapper.find('button').attributes().disabled).toBe('disabled');
@@ -671,11 +708,16 @@ describe('custom default render', () => {
       refine,
     });
 
-    const wrapper = mount(HierarchicalMenu, {
-      propsData: defaultProps,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { HierarchicalMenu },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <HierarchicalMenu v-bind="props">
+          ${defaultSlot}
+        </HierarchicalMenu>
+      `,
     });
 
     await wrapper
@@ -693,48 +735,67 @@ describe('custom default render', () => {
     __setState({
       ...defaultState,
       toggleShowMore: () => {
-        wrapper.setData({ state: { isShowingMore: true } });
+        const component = wrapper.vm.$children[0];
+        component.$set(component, 'state', {
+          ...component.state,
+          isShowingMore: true,
+        });
       },
     });
 
-    const wrapper = mount(HierarchicalMenu, {
-      propsData: {
-        ...defaultProps,
-        showMore: true,
-        limit: 1,
+    const props = {
+      ...defaultProps,
+      showMore: true,
+      limit: 1,
+    };
+
+    const wrapper = mount({
+      components: { HierarchicalMenu },
+      data() {
+        return { props };
       },
-      scopedSlots: {
-        default: defaultScopedSlot,
-      },
+      template: `
+        <HierarchicalMenu v-bind="props">
+          ${defaultSlot}
+        </HierarchicalMenu>
+      `,
     });
 
-    expect(wrapper.vm.state.isShowingMore).toBe(false);
+    expect(wrapper.find('button').text()).toEqual('View more');
 
     await wrapper.find('button').trigger('click');
 
-    expect(wrapper.vm.state.isShowingMore).toBe(true);
+    expect(wrapper.find('button').text()).toEqual('View less');
   });
 });
 
 describe('custom showMoreLabel render', () => {
-  const showMoreLabelScopedSlot = `
-    <span slot-scope="{ isShowingMore }">
-      {{ isShowingMore ? 'Voir moins' : 'Voir plus' }}
-    </span>
+  const showMoreLabelSlot = `
+    <template v-slot:showMoreLabel="{ isShowingMore }">
+      <span>
+        {{ isShowingMore ? 'Voir moins' : 'Voir plus' }}
+      </span>
+    </template>
   `;
 
   it('renders correctly with a custom show more label', () => {
     __setState({ ...defaultState });
 
-    const wrapper = mount(HierarchicalMenu, {
-      propsData: {
-        ...defaultProps,
-        showMore: true,
-        limit: 1,
+    const props = {
+      ...defaultProps,
+      showMore: true,
+      limit: 1,
+    };
+    const wrapper = mount({
+      components: { HierarchicalMenu },
+      data() {
+        return { props };
       },
-      scopedSlots: {
-        showMoreLabel: showMoreLabelScopedSlot,
-      },
+      template: `
+        <HierarchicalMenu v-bind="props">
+          ${showMoreLabelSlot}
+        </HierarchicalMenu>
+      `,
     });
 
     expect(wrapper.find('.ais-HierarchicalMenu-showMore').text()).toBe(
@@ -748,19 +809,29 @@ describe('custom showMoreLabel render', () => {
     __setState({
       ...defaultState,
       toggleShowMore: () => {
-        wrapper.setData({ state: { isShowingMore: true } });
+        const component = wrapper.vm.$children[0];
+        component.$set(component, 'state', {
+          ...component.state,
+          isShowingMore: true,
+        });
       },
     });
 
-    const wrapper = mount(HierarchicalMenu, {
-      propsData: {
-        ...defaultProps,
-        showMore: true,
-        limit: 1,
+    const props = {
+      ...defaultProps,
+      showMore: true,
+      limit: 1,
+    };
+    const wrapper = mount({
+      components: { HierarchicalMenu },
+      data() {
+        return { props };
       },
-      scopedSlots: {
-        showMoreLabel: showMoreLabelScopedSlot,
-      },
+      template: `
+        <HierarchicalMenu v-bind="props">
+          ${showMoreLabelSlot}
+        </HierarchicalMenu>
+      `,
     });
 
     await wrapper.find('button').trigger('click');

--- a/src/components/__tests__/Hits.js
+++ b/src/components/__tests__/Hits.js
@@ -55,19 +55,22 @@ it('exposes insights prop to the default slot', async () => {
     insights,
   });
 
-  const wrapper = mount(Hits, {
-    scopedSlots: {
-      default: `
-        <ul slot-scope="{ items, insights }">
-          <li v-for="(item, itemIndex) in items" >
+  const wrapper = mount({
+    components: { Hits },
+    template: `
+      <Hits>
+        <template v-slot="{ items, insights }">
+          <ul>
+            <li v-for="(item, itemIndex) in items" >
 
-            <button :id="'add-to-cart-' + item.objectID" @click="insights('clickedObjectIDsAfterSearch', {eventName: 'Add to cart', objectIDs: [item.objectID]})">
-              Add to cart
-            </button>
-          </li>
-        </ul>
-      `,
-    },
+              <button :id="'add-to-cart-' + item.objectID" @click="insights('clickedObjectIDsAfterSearch', {eventName: 'Add to cart', objectIDs: [item.objectID]})">
+                Add to cart
+              </button>
+            </li>
+          </ul>
+        </template>
+      </Hits>
+    `,
   });
   await wrapper.find('#add-to-cart-two').trigger('click');
   expect(insights).toHaveBeenCalledWith('clickedObjectIDsAfterSearch', {
@@ -83,16 +86,19 @@ it('exposes insights prop to the item slot', async () => {
     insights,
   });
 
-  const wrapper = mount(Hits, {
-    scopedSlots: {
-      item: `
-        <div slot-scope="{ item, insights }">
-          <button :id="'add-to-cart-' + item.objectID" @click="insights('clickedObjectIDsAfterSearch', {eventName: 'Add to cart', objectIDs: [item.objectID]})">
-            Add to cart
-          </button>
-        </div>
-      `,
-    },
+  const wrapper = mount({
+    components: { Hits },
+    template: `
+      <Hits>
+        <template v-slot:item="{ item, insights }">
+          <div>
+            <button :id="'add-to-cart-' + item.objectID" @click="insights('clickedObjectIDsAfterSearch', {eventName: 'Add to cart', objectIDs: [item.objectID]})">
+              Add to cart
+            </button>
+          </div>
+        </template>
+      </Hits>
+    `,
   });
   await wrapper.find('#add-to-cart-two').trigger('click');
   expect(insights).toHaveBeenCalledWith('clickedObjectIDsAfterSearch', {
@@ -108,14 +114,17 @@ it('exposes send-event method for insights middleware', async () => {
     sendEvent,
   });
 
-  const wrapper = mount(Hits, {
-    scopedSlots: {
-      default: `
-      <div slot-scope="{ sendEvent }">
-        <button @click="sendEvent()">Send Event</button>
-      </div>
-      `,
-    },
+  const wrapper = mount({
+    components: { Hits },
+    template: `
+      <Hits>
+        <template v-slot="{ sendEvent }">
+          <div>
+            <button @click="sendEvent()">Send Event</button>
+          </div>
+        </template>
+      </Hits>
+    `,
   });
 
   await wrapper.find('button').trigger('click');

--- a/src/components/__tests__/InfiniteHits.js
+++ b/src/components/__tests__/InfiniteHits.js
@@ -114,16 +114,19 @@ it('renders correctly with a custom rendering', () => {
     ...defaultState,
   });
 
-  const wrapper = mount(InfiniteHits, {
-    scopedSlots: {
-      default: `
-        <div slot-scope="{ items }">
-          <div v-for="item in items">
-            {{item.objectID}}
+  const wrapper = mount({
+    components: { InfiniteHits },
+    template: `
+      <InfiniteHits>
+        <template v-slot="{ items }">
+          <div>
+            <div v-for="item in items">
+              {{item.objectID}}
+            </div>
           </div>
-        </div>
-      `,
-    },
+        </template>
+      </InfiniteHits>
+    `,
   });
 
   expect(wrapper.html()).toMatchSnapshot();
@@ -134,14 +137,17 @@ it('renders correctly with a custom item rendering', () => {
     ...defaultState,
   });
 
-  const wrapper = mount(InfiniteHits, {
-    scopedSlots: {
-      item: `
-        <div slot-scope="{ item }">
-          {{item.objectID}}
-        </div>
-      `,
-    },
+  const wrapper = mount({
+    components: { InfiniteHits },
+    template: `
+      <InfiniteHits>
+        <template v-slot:item="{ item }">
+          <div>
+            {{item.objectID}}
+          </div>
+        </template>
+      </InfiniteHits>
+    `,
   });
 
   expect(wrapper.html()).toMatchSnapshot();
@@ -249,19 +255,23 @@ it('exposes insights prop to the default slot', async () => {
     insights,
   });
 
-  const wrapper = mount(InfiniteHits, {
-    scopedSlots: {
-      default: `
-        <ul slot-scope="{ items, insights }">
-          <li v-for="(item, itemIndex) in items" >
-            <button :id="'add-to-cart-' + item.objectID" @click="insights('clickedObjectIDsAfterSearch', {eventName: 'Add to cart', objectIDs: [item.objectID]})">
-              Add to cart
-            </button>
-          </li>
-        </ul>
-      `,
-    },
+  const wrapper = mount({
+    components: { InfiniteHits },
+    template: `
+      <InfiniteHits>
+        <template v-slot="{ items, insights }">
+        <ul>
+        <li v-for="(item, itemIndex) in items" >
+          <button :id="'add-to-cart-' + item.objectID" @click="insights('clickedObjectIDsAfterSearch', {eventName: 'Add to cart', objectIDs: [item.objectID]})">
+            Add to cart
+          </button>
+        </li>
+      </ul>
+        </template>
+      </InfiniteHits>
+    `,
   });
+
   await wrapper.find('#add-to-cart-00002').trigger('click');
   expect(insights).toHaveBeenCalledWith('clickedObjectIDsAfterSearch', {
     eventName: 'Add to cart',
@@ -277,17 +287,21 @@ it('exposes insights prop to the item slot', async () => {
     insights,
   });
 
-  const wrapper = mount(InfiniteHits, {
-    scopedSlots: {
-      item: `
-          <div slot-scope="{ item, insights }">
+  const wrapper = mount({
+    components: { InfiniteHits },
+    template: `
+      <InfiniteHits>
+        <template v-slot:item="{ item, insights }">
+          <div>
             <button :id="'add-to-cart-' + item.objectID" @click="insights('clickedObjectIDsAfterSearch', {eventName: 'Add to cart', objectIDs: [item.objectID]})">
               Add to cart
             </button>
           </div>
-      `,
-    },
+        </template>
+      </InfiniteHits>
+    `,
   });
+
   await wrapper.find('#add-to-cart-00002').trigger('click');
   expect(insights).toHaveBeenCalledWith('clickedObjectIDsAfterSearch', {
     eventName: 'Add to cart',
@@ -302,14 +316,17 @@ it('exposes send-event method for insights middleware', async () => {
     sendEvent,
   });
 
-  const wrapper = mount(InfiniteHits, {
-    scopedSlots: {
-      default: `
-      <div slot-scope="{ sendEvent }">
-        <button @click="sendEvent()">Send Event</button>
-      </div>
-      `,
-    },
+  const wrapper = mount({
+    components: { InfiniteHits },
+    template: `
+      <InfiniteHits>
+        <template v-slot="{ sendEvent }">
+          <div>
+            <button @click="sendEvent()">Send Event</button>
+          </div>
+        </template>
+      </InfiniteHits>
+    `,
   });
 
   await wrapper.find('button').trigger('click');

--- a/src/components/__tests__/Menu.js
+++ b/src/components/__tests__/Menu.js
@@ -344,15 +344,20 @@ it('exposes send-event method for insights middleware', async () => {
     sendEvent,
   });
 
-  const wrapper = mount(Menu, {
-    propsData: defaultProps,
-    scopedSlots: {
-      default: `
-      <div slot-scope="{ sendEvent }">
-        <button @click="sendEvent()">Send Event</button>
-      </div>
-      `,
+  const wrapper = mount({
+    components: { Menu },
+    data() {
+      return { props: defaultProps };
     },
+    template: `
+      <Menu v-bind="props">
+        <template v-slot="{ sendEvent }">
+          <div>
+            <button @click="sendEvent()">Send Event</button>
+          </div>
+        </template>
+      </Menu>
+    `,
   });
 
   await wrapper.find('button').trigger('click');
@@ -360,41 +365,45 @@ it('exposes send-event method for insights middleware', async () => {
 });
 
 describe('custom default render', () => {
-  const defaultScopedSlot = `
-    <div
-      slot-scope="state"
-      :class="[!state.canRefine && 'no-refinement']"
-    >
-      <ol>
-        <li
-          v-for="item in state.items"
-          :key="item.value"
-        >
-          <a
-            :href="state.createURL(item.value)"
-            @click.prevent="state.refine(item.value)"
+  const defaultSlot = `
+    <template v-slot="state">
+      <div :class="[!state.canRefine && 'no-refinement']">
+        <ol>
+          <li
+            v-for="item in state.items"
+            :key="item.value"
           >
-            {{item.label}} - {{item.count}}
-          </a>
-        </li>
-      </ol>
-      <button
-        :disabled="!state.canToggleShowMore"
-        @click.prevent="state.toggleShowMore"
-      >
-        {{ state.isShowingMore ? 'Show less' : 'Show more' }}
-      </button>
-    </div>
+            <a
+              :href="state.createURL(item.value)"
+              @click.prevent="state.refine(item.value)"
+            >
+              {{item.label}} - {{item.count}}
+            </a>
+          </li>
+        </ol>
+        <button
+          :disabled="!state.canToggleShowMore"
+          @click.prevent="state.toggleShowMore"
+        >
+          {{ state.isShowingMore ? 'Show less' : 'Show more' }}
+        </button>
+      </div>
+    </template>
   `;
 
   it('renders correctly', () => {
     __setState({ ...defaultState });
 
-    const wrapper = mount(Menu, {
-      propsData: defaultProps,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { Menu },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <Menu v-bind="props">
+          ${defaultSlot}
+        </Menu>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -407,11 +416,16 @@ describe('custom default render', () => {
       canRefine: false,
     });
 
-    const wrapper = mount(Menu, {
-      propsData: defaultProps,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { Menu },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <Menu v-bind="props">
+          ${defaultSlot}
+        </Menu>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -423,11 +437,16 @@ describe('custom default render', () => {
       createURL: value => `/brand/${value}`,
     });
 
-    const wrapper = mount(Menu, {
-      propsData: defaultProps,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { Menu },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <Menu v-bind="props">
+          ${defaultSlot}
+        </Menu>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -439,11 +458,16 @@ describe('custom default render', () => {
       isShowingMore: true,
     });
 
-    const wrapper = mount(Menu, {
-      propsData: defaultProps,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { Menu },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <Menu v-bind="props">
+          ${defaultSlot}
+        </Menu>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -455,11 +479,16 @@ describe('custom default render', () => {
       canToggleShowMore: false,
     });
 
-    const wrapper = mount(Menu, {
-      propsData: defaultProps,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { Menu },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <Menu v-bind="props">
+          ${defaultSlot}
+        </Menu>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -473,11 +502,16 @@ describe('custom default render', () => {
       refine,
     });
 
-    const wrapper = mount(Menu, {
-      propsData: defaultProps,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { Menu },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <Menu v-bind="props">
+          ${defaultSlot}
+        </Menu>
+      `,
     });
 
     await wrapper.find('a').trigger('click');
@@ -495,13 +529,16 @@ describe('custom default render', () => {
       toggleShowMore,
     });
 
-    const wrapper = mount(Menu, {
-      propsData: {
-        ...defaultProps,
+    const wrapper = mount({
+      components: { Menu },
+      data() {
+        return { props: defaultProps };
       },
-      scopedSlots: {
-        default: defaultScopedSlot,
-      },
+      template: `
+        <Menu v-bind="props">
+          ${defaultSlot}
+        </Menu>
+      `,
     });
 
     await wrapper.find('button').trigger('click');
@@ -511,23 +548,31 @@ describe('custom default render', () => {
 });
 
 describe('custom showMoreLabel render', () => {
-  const showMoreLabelScopedSlot = `
-    <span slot-scope="{ isShowingMore }">
-      {{ isShowingMore ? 'Voir moins' : 'Voir plus' }}
-    </span>
+  const showMoreLabelSlot = `
+    <template v-slot:showMoreLabel="{ isShowingMore }">
+      <span>
+        {{ isShowingMore ? 'Voir moins' : 'Voir plus' }}
+      </span>
+    </template>
   `;
 
   it('renders correctly with a custom show more label', () => {
     __setState({ ...defaultState });
 
-    const wrapper = mount(Menu, {
-      propsData: {
-        ...defaultProps,
-        showMore: true,
+    const props = {
+      ...defaultProps,
+      showMore: true,
+    };
+    const wrapper = mount({
+      components: { Menu },
+      data() {
+        return { props };
       },
-      scopedSlots: {
-        showMoreLabel: showMoreLabelScopedSlot,
-      },
+      template: `
+        <Menu v-bind="props">
+          ${showMoreLabelSlot}
+        </Menu>
+      `,
     });
 
     expect(wrapper.find('.ais-Menu-showMore').text()).toBe('Voir plus');
@@ -540,14 +585,20 @@ describe('custom showMoreLabel render', () => {
       isShowingMore: true,
     });
 
-    const wrapper = mount(Menu, {
-      propsData: {
-        ...defaultProps,
-        showMore: true,
+    const props = {
+      ...defaultProps,
+      showMore: true,
+    };
+    const wrapper = mount({
+      components: { Menu },
+      data() {
+        return { props };
       },
-      scopedSlots: {
-        showMoreLabel: showMoreLabelScopedSlot,
-      },
+      template: `
+        <Menu v-bind="props">
+          ${showMoreLabelSlot}
+        </Menu>
+      `,
     });
 
     expect(wrapper.find('.ais-Menu-showMore').text()).toBe('Voir moins');

--- a/src/components/__tests__/MenuSelect.js
+++ b/src/components/__tests__/MenuSelect.js
@@ -231,15 +231,20 @@ it('exposes send-event method for insights middleware', async () => {
     sendEvent,
   });
 
-  const wrapper = mount(MenuSelect, {
-    propsData: defaultProps,
-    scopedSlots: {
-      default: `
-      <div slot-scope="{ sendEvent }">
-        <button @click="sendEvent()">Send Event</button>
-      </div>
-      `,
+  const wrapper = mount({
+    components: { MenuSelect },
+    data() {
+      return { props: defaultProps };
     },
+    template: `
+      <MenuSelect v-bind="props">
+        <template v-slot="{ sendEvent }">
+          <div>
+            <button @click="sendEvent()">Send Event</button>
+          </div>
+        </template>
+      </MenuSelect>
+    `,
   });
 
   await wrapper.find('button').trigger('click');
@@ -247,29 +252,27 @@ it('exposes send-event method for insights middleware', async () => {
 });
 
 describe('custom item slot', () => {
-  // can not be <template>
-  // https://github.com/vuejs/vue-test-utils/pull/507
-  const customItemSlot = `
-    <span slot="item" slot-scope="{ item }">
-      {{ item.label }}
-    </span>
-  `;
-
   it('renders correctly', () => {
     __setState({
       ...defaultState,
     });
 
-    const props = {
-      ...defaultProps,
-    };
-
-    const wrapper = mount(MenuSelect, {
-      propsData: props,
-      scopedSlots: {
-        item: customItemSlot,
+    const wrapper = mount({
+      components: { MenuSelect },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <MenuSelect v-bind="props">
+          <template v-slot:item="{ item }">
+            <span>
+              {{ item.label }}
+            </span>
+          </template>
+        </MenuSelect>
+      `,
     });
+
     expect(wrapper.html()).toMatchSnapshot();
 
     expect(
@@ -282,22 +285,23 @@ describe('custom item slot', () => {
 });
 
 describe('custom default render', () => {
-  const defaultScopedSlots = `
-    <select
-      slot-scope="{ items, canRefine, refine }"
-      @change="refine($event.currentTarget.value)"
-      :disabled="!canRefine"
-    >
-      <option value="">All</option>
-      <option
-        v-for="item in items"
-        :key="item.value"
-        :value="item.value"
-        :selected="item.isRefined"
+  const defaultSlot = `
+    <template v-slot="{ items, canRefine, refine }">
+      <select
+        @change="refine($event.currentTarget.value)"
+        :disabled="!canRefine"
       >
-        {{item.label}}
-      </option>
-    </select>
+        <option value="">All</option>
+        <option
+          v-for="item in items"
+          :key="item.value"
+          :value="item.value"
+          :selected="item.isRefined"
+        >
+          {{item.label}}
+        </option>
+      </select>
+    </template>
   `;
 
   it('renders correctly', () => {
@@ -305,15 +309,16 @@ describe('custom default render', () => {
       ...defaultState,
     });
 
-    const props = {
-      ...defaultProps,
-    };
-
-    const wrapper = mount(MenuSelect, {
-      propsData: props,
-      scopedSlots: {
-        default: defaultScopedSlots,
+    const wrapper = mount({
+      components: { MenuSelect },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <MenuSelect v-bind="props">
+          ${defaultSlot}
+        </MenuSelect>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -329,15 +334,16 @@ describe('custom default render', () => {
       ],
     });
 
-    const props = {
-      ...defaultProps,
-    };
-
-    const wrapper = mount(MenuSelect, {
-      propsData: props,
-      scopedSlots: {
-        default: defaultScopedSlots,
+    const wrapper = mount({
+      components: { MenuSelect },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <MenuSelect v-bind="props">
+          ${defaultSlot}
+        </MenuSelect>
+      `,
     });
 
     const selected = wrapper.find('[value="Samsung"]');
@@ -357,15 +363,16 @@ describe('custom default render', () => {
       items: [],
     });
 
-    const props = {
-      ...defaultProps,
-    };
-
-    const wrapper = mount(MenuSelect, {
-      propsData: props,
-      scopedSlots: {
-        default: defaultScopedSlots,
+    const wrapper = mount({
+      components: { MenuSelect },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <MenuSelect v-bind="props">
+          ${defaultSlot}
+        </MenuSelect>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -379,15 +386,16 @@ describe('custom default render', () => {
       refine,
     });
 
-    const props = {
-      ...defaultProps,
-    };
-
-    const wrapper = mount(MenuSelect, {
-      propsData: props,
-      scopedSlots: {
-        default: defaultScopedSlots,
+    const wrapper = mount({
+      components: { MenuSelect },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <MenuSelect v-bind="props">
+          ${defaultSlot}
+        </MenuSelect>
+      `,
     });
 
     expect(refine).not.toHaveBeenCalled();

--- a/src/components/__tests__/NumericMenu.js
+++ b/src/components/__tests__/NumericMenu.js
@@ -217,15 +217,20 @@ it('exposes send-event method for insights middleware', async () => {
     sendEvent,
   });
 
-  const wrapper = mount(NumericMenu, {
-    propsData: defaultProps,
-    scopedSlots: {
-      default: `
-      <div slot-scope="{ sendEvent }">
-        <button @click="sendEvent()">Send Event</button>
-      </div>
-      `,
+  const wrapper = mount({
+    components: { NumericMenu },
+    data() {
+      return { props: defaultProps };
     },
+    template: `
+      <NumericMenu v-bind="props">
+        <template v-slot="{ sendEvent }">
+          <div>
+            <button @click="sendEvent()">Send Event</button>
+          </div>
+        </template>
+      </NumericMenu>
+    `,
   });
 
   await wrapper.find('button').trigger('click');
@@ -233,38 +238,38 @@ it('exposes send-event method for insights middleware', async () => {
 });
 
 describe('custom default render', () => {
-  const defaultScopedSlot = `
-    <ul
-      slot-scope="{ items, canRefine, refine, createURL }"
-      :class="[!canRefine && 'no-refinement']"
-    >
-      <li
-        v-for="item in items"
-        :key="item.label"
-        :class="[item.isRefined && 'selected']"
-      >
-        <a
-          :href="createURL(item.value)"
-          @click.prevent="refine(item.value)"
+  const defaultSlot = `
+    <template v-slot="{ items, canRefine, refine, createURL }">
+      <ul :class="[!canRefine && 'no-refinement']">
+        <li
+          v-for="item in items"
+          :key="item.label"
+          :class="[item.isRefined && 'selected']"
         >
-          {{ item.label }}
-        </a>
-      </li>
-    </ul>
+          <a
+            :href="createURL(item.value)"
+            @click.prevent="refine(item.value)"
+          >
+            {{ item.label }}
+          </a>
+        </li>
+      </ul>
+    </template>
   `;
 
   it('renders correctly', () => {
     __setState(defaultState);
 
-    const props = {
-      ...defaultProps,
-    };
-
-    const wrapper = mount(NumericMenu, {
-      propsData: props,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { NumericMenu },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <NumericMenu v-bind="props">
+          ${defaultSlot}
+        </NumericMenu>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -276,15 +281,16 @@ describe('custom default render', () => {
       hasNoResults: true,
     });
 
-    const props = {
-      ...defaultProps,
-    };
-
-    const wrapper = mount(NumericMenu, {
-      propsData: props,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { NumericMenu },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <NumericMenu v-bind="props">
+          ${defaultSlot}
+        </NumericMenu>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -302,15 +308,16 @@ describe('custom default render', () => {
       ],
     });
 
-    const props = {
-      ...defaultProps,
-    };
-
-    const wrapper = mount(NumericMenu, {
-      propsData: props,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { NumericMenu },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <NumericMenu v-bind="props">
+          ${defaultSlot}
+        </NumericMenu>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -322,15 +329,16 @@ describe('custom default render', () => {
       createURL: (value = 'all') => `/price/${value}`,
     });
 
-    const props = {
-      ...defaultProps,
-    };
-
-    const wrapper = mount(NumericMenu, {
-      propsData: props,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { NumericMenu },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <NumericMenu v-bind="props">
+          ${defaultSlot}
+        </NumericMenu>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -344,15 +352,16 @@ describe('custom default render', () => {
       refine,
     });
 
-    const props = {
-      ...defaultProps,
-    };
-
-    const wrapper = mount(NumericMenu, {
-      propsData: props,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { NumericMenu },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <NumericMenu v-bind="props">
+          ${defaultSlot}
+        </NumericMenu>
+      `,
     });
 
     const link = wrapper.findAll('a').at(3);

--- a/src/components/__tests__/RangeInput.js
+++ b/src/components/__tests__/RangeInput.js
@@ -288,15 +288,20 @@ it('exposes send-event method for insights middleware', async () => {
     sendEvent,
   });
 
-  const wrapper = mount(RangeInput, {
-    propsData: defaultProps,
-    scopedSlots: {
-      default: `
-      <div slot-scope="{ sendEvent }">
-        <button @click="sendEvent()">Send Event</button>
-      </div>
-      `,
+  const wrapper = mount({
+    components: { RangeInput },
+    data() {
+      return { props: defaultProps };
     },
+    template: `
+      <RangeInput v-bind="props">
+        <template v-slot="{ sendEvent }">
+          <div>
+            <button @click="sendEvent()">Send Event</button>
+          </div>
+        </template>
+      </RangeInput>
+    `,
   });
 
   await wrapper.find('button').trigger('click');

--- a/src/components/__tests__/RatingMenu.js
+++ b/src/components/__tests__/RatingMenu.js
@@ -157,15 +157,20 @@ it('exposes send-event method for insights middleware', async () => {
     sendEvent,
   });
 
-  const wrapper = mount(RatingMenu, {
-    propsData: defaultProps,
-    scopedSlots: {
-      default: `
-      <div slot-scope="{ sendEvent }">
-        <button @click="sendEvent()">Send Event</button>
-      </div>
-      `,
+  const wrapper = mount({
+    components: { RatingMenu },
+    data() {
+      return { props: defaultProps };
     },
+    template: `
+      <RatingMenu v-bind="props">
+        <template v-slot="{ sendEvent }">
+          <div>
+            <button @click="sendEvent()">Send Event</button>
+          </div>
+        </template>
+      </RatingMenu>
+    `,
   });
 
   await wrapper.find('button').trigger('click');

--- a/src/components/__tests__/RefinementList.js
+++ b/src/components/__tests__/RefinementList.js
@@ -196,15 +196,20 @@ it('exposes send-event method for insights middleware', async () => {
     sendEvent,
   });
 
-  const wrapper = mount(RefinementList, {
-    propsData: { attribute: 'something' },
-    scopedSlots: {
-      default: `
-      <div slot-scope="{ sendEvent }">
-        <button @click="sendEvent()">Send Event</button>
-      </div>
-      `,
+  const wrapper = mount({
+    components: { RefinementList },
+    data() {
+      return { props: { attribute: 'something' } };
     },
+    template: `
+      <RefinementList v-bind="props">
+        <template v-slot="{ sendEvent }">
+          <div>
+            <button @click="sendEvent()">Send Event</button>
+          </div>
+        </template>
+      </RefinementList>
+    `,
   });
 
   await wrapper.find('button').trigger('click');

--- a/src/components/__tests__/SortBy.js
+++ b/src/components/__tests__/SortBy.js
@@ -51,32 +51,34 @@ it('renders correctly', () => {
 
 it('renders with scoped slots', () => {
   const defaultSlot = `
-  <select
-    slot-scope="{ items, refine, currentRefinement }"
-    @change="refine($event.currentTarget.value)"
-  >
-    <option
-      v-for="item in items"
-      :key="item.value"
-      :value="item.value"
-      :selected="item.value === currentRefinement"
-    >
-      {{item.label}}
-    </option>
-  </select>
+  <template v-slot="{ items, refine, currentRefinement }">
+    <select @change="refine($event.currentTarget.value)">
+      <option
+        v-for="item in items"
+        :key="item.value"
+        :value="item.value"
+        :selected="item.value === currentRefinement"
+      >
+        {{item.label}}
+      </option>
+    </select>
+  </template>
 `;
 
   __setState({
     ...defaultState,
   });
 
-  const wrapper = mount(SortBy, {
-    propsData: {
-      ...defaultProps,
+  const wrapper = mount({
+    components: { SortBy },
+    data() {
+      return { props: defaultProps };
     },
-    scopedSlots: {
-      default: defaultSlot,
-    },
+    template: `
+      <SortBy v-bind="props">
+        ${defaultSlot}
+      </SortBy>
+    `,
   });
 
   expect(wrapper.html()).toMatchSnapshot();

--- a/src/components/__tests__/StateResults.js
+++ b/src/components/__tests__/StateResults.js
@@ -66,18 +66,20 @@ it('allows default slot to render whatever they want', () => {
     results,
   });
 
-  const wrapper = mount(StateResults, {
-    scopedSlots: {
-      default: `
-      <template slot-scope="{ state: { query }, results: { page } }">
-        <p v-if="query">
-          Query is here, page is {{ page }}
-        </p>
-        <p v-else>
-          There's no query
-        </p>
-      </template>`,
-    },
+  const wrapper = mount({
+    components: { StateResults },
+    template: `
+      <StateResults>
+        <template v-slot="{ state: { query }, results: { page } }">
+          <p v-if="query">
+            Query is here, page is {{ page }}
+          </p>
+          <p v-else>
+            There's no query
+          </p>
+        </template>
+      </StateResults>
+    `,
   });
 
   expect(wrapper.html()).toMatchInlineSnapshot(`
@@ -105,18 +107,20 @@ it('allows default slot to render whatever they want (truthy query)', () => {
     results,
   });
 
-  const wrapper = mount(StateResults, {
-    scopedSlots: {
-      default: `
-      <template slot-scope="{ results: { query } }">
-        <p v-if="query">
-          Query is here
-        </p>
-        <p v-else>
-          There's no query
-        </p>
-      </template>`,
-    },
+  const wrapper = mount({
+    components: { StateResults },
+    template: `
+      <StateResults>
+        <template v-slot="{ results: { query } }">
+          <p v-if="query">
+            Query is here
+          </p>
+          <p v-else>
+            There's no query
+          </p>
+        </template>
+      </StateResults>
+    `,
   });
 
   expect(wrapper.html()).toMatchInlineSnapshot(`
@@ -144,18 +148,20 @@ it('allows default slot to render whatever they want (falsy query)', () => {
     results,
   });
 
-  const wrapper = mount(StateResults, {
-    scopedSlots: {
-      default: `
-      <template slot-scope="{ results: { query } }">
-        <p v-if="query">
-          Query is here
-        </p>
-        <p v-else>
-          There's no query
-        </p>
-      </template>`,
-    },
+  const wrapper = mount({
+    components: { StateResults },
+    template: `
+      <StateResults>
+        <template v-slot="{ results: { query } }">
+          <p v-if="query">
+            Query is here
+          </p>
+          <p v-else>
+            There's no query
+          </p>
+        </template>
+      </StateResults>
+    `,
   });
 
   expect(wrapper.html()).toMatchInlineSnapshot(`
@@ -180,18 +186,20 @@ describe('legacy spread props', () => {
       state: {},
     });
 
-    const wrapper = mount(StateResults, {
-      scopedSlots: {
-        default: `
-        <template slot-scope="{ query }">
-          <p v-if="query">
-            Query is here
-          </p>
-          <p v-else>
-            There's no query
-          </p>
-        </template>`,
-      },
+    const wrapper = mount({
+      components: { StateResults },
+      template: `
+        <StateResults>
+          <template v-slot="{ query }">
+            <p v-if="query">
+              Query is here
+            </p>
+            <p v-else>
+              There's no query
+            </p>
+          </template>
+        </StateResults>
+      `,
     });
 
     expect(wrapper.html()).toMatchInlineSnapshot(`
@@ -215,18 +223,20 @@ describe('legacy spread props', () => {
       state: {},
     });
 
-    const wrapper = mount(StateResults, {
-      scopedSlots: {
-        default: `
-        <template slot-scope="{ query }">
-          <p v-if="query">
-            Query is here
-          </p>
-          <p v-else>
-            There's no query
-          </p>
-        </template>`,
-      },
+    const wrapper = mount({
+      components: { StateResults },
+      template: `
+        <StateResults>
+          <template v-slot="{ query }">
+            <p v-if="query">
+              Query is here
+            </p>
+            <p v-else>
+              There's no query
+            </p>
+          </template>
+        </StateResults>
+      `,
     });
 
     expect(wrapper.html()).toMatchInlineSnapshot(`

--- a/src/components/__tests__/ToggleRefinement.js
+++ b/src/components/__tests__/ToggleRefinement.js
@@ -202,15 +202,18 @@ it('exposes send-event method for insights middleware', async () => {
     sendEvent,
   });
 
-  const wrapper = mount(Toggle, {
-    propsData: defaultProps,
-    scopedSlots: {
-      default: `
-      <div slot-scope="{ sendEvent }">
-        <button @click="sendEvent()">Send Event</button>
-      </div>
-      `,
+  const wrapper = mount({
+    components: { Toggle },
+    data() {
+      return { props: defaultProps };
     },
+    template: `
+      <Toggle v-bind="props">
+        <template v-slot="{ sendEvent }">
+          <button @click="sendEvent()">Send Event</button>
+        </template>
+      </Toggle>
+    `,
   });
 
   await wrapper.find('button').trigger('click');
@@ -218,26 +221,32 @@ it('exposes send-event method for insights middleware', async () => {
 });
 
 describe('custom default render', () => {
-  const defaultScopedSlot = `
-    <a
-      slot-scope="{ value, canRefine, refine, createURL }"
-      :href="createURL()"
-      :class="[!canRefine && 'noRefinement']"
-      @click.prevent="refine(value)"
-    >
-      <span>{{ value.name }}</span>
-      <span>{{ value.isRefined ? '(is enabled)' : '(is disabled)' }}</span>
-    </a>
+  const defaultSlot = `
+    <template v-slot="{ value, canRefine, refine, createURL }">
+      <a
+        :href="createURL()"
+        :class="[!canRefine && 'noRefinement']"
+        @click.prevent="refine(value)"
+      >
+        <span>{{ value.name }}</span>
+        <span>{{ value.isRefined ? '(is enabled)' : '(is disabled)' }}</span>
+      </a>
+    </template>
   `;
 
   it('renders correctly', () => {
     __setState({ ...defaultState });
 
-    const wrapper = mount(Toggle, {
-      propsData: defaultProps,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { Toggle },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <Toggle v-bind="props">
+          ${defaultSlot}
+        </Toggle>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -252,11 +261,16 @@ describe('custom default render', () => {
       },
     });
 
-    const wrapper = mount(Toggle, {
-      propsData: defaultProps,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { Toggle },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <Toggle v-bind="props">
+          ${defaultSlot}
+        </Toggle>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -268,11 +282,16 @@ describe('custom default render', () => {
       createURL: () => `/free-shipping`,
     });
 
-    const wrapper = mount(Toggle, {
-      propsData: defaultProps,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { Toggle },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <Toggle v-bind="props">
+          ${defaultSlot}
+        </Toggle>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -287,11 +306,16 @@ describe('custom default render', () => {
       },
     });
 
-    const wrapper = mount(Toggle, {
-      propsData: defaultProps,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { Toggle },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <Toggle v-bind="props">
+          ${defaultSlot}
+        </Toggle>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -305,11 +329,16 @@ describe('custom default render', () => {
       refine,
     });
 
-    const wrapper = mount(Toggle, {
-      propsData: defaultProps,
-      scopedSlots: {
-        default: defaultScopedSlot,
+    const wrapper = mount({
+      components: { Toggle },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <Toggle v-bind="props">
+          ${defaultSlot}
+        </Toggle>
+      `,
     });
 
     await wrapper.find('a').trigger('click');

--- a/src/components/__tests__/VoiceSearch.js
+++ b/src/components/__tests__/VoiceSearch.js
@@ -15,10 +15,12 @@ const defaultState = {
   toggleListening: jest.fn(),
 };
 
-const buttonTextScopedSlot = `
-  <span slot-scope="{ isListening }">
-    {{isListening ? "Stop": "Start"}}
-  </span>
+const buttonTextSlot = `
+  <template v-slot:buttonText="{ isListening }">
+    <span>
+      {{isListening ? "Stop": "Start"}}
+    </span>
+  </template>
 `;
 
 describe('button', () => {
@@ -51,10 +53,13 @@ describe('Rendering', () => {
       ...defaultState,
       isListening: true,
     });
-    const wrapper = mount(VoiceSearch, {
-      scopedSlots: {
-        buttonText: buttonTextScopedSlot,
-      },
+    const wrapper = mount({
+      components: { VoiceSearch },
+      template: `
+        <VoiceSearch>
+          ${buttonTextSlot}
+        </VoiceSearch>
+      `,
     });
     expect(wrapper.find('button').text()).toBe('Stop');
   });
@@ -64,10 +69,13 @@ describe('Rendering', () => {
       ...defaultState,
       isListening: false,
     });
-    const wrapper = mount(VoiceSearch, {
-      scopedSlots: {
-        buttonText: buttonTextScopedSlot,
-      },
+    const wrapper = mount({
+      components: { VoiceSearch },
+      template: `
+        <VoiceSearch>
+          ${buttonTextSlot}
+        </VoiceSearch>
+      `,
     });
     expect(wrapper.find('button').text()).toBe('Start');
   });
@@ -84,19 +92,22 @@ describe('Rendering', () => {
       isListening: true,
       toggleListening: jest.fn(),
     });
-    const wrapper = mount(VoiceSearch, {
-      scopedSlots: {
-        status: `
-          <div slot-scope="{ status, errorCode, isListening, transcript, isSpeechFinal, isBrowserSupported }">
-            <p>status: {{status}}</p>
-            <p>errorCode: {{errorCode}}</p>
-            <p>isListening: {{isListening}}</p>
-            <p>transcript: {{transcript}}</p>
-            <p>isSpeechFinal: {{isSpeechFinal}}</p>
-            <p>isBrowserSupported: {{isBrowserSupported}}</p>
-          </div>
-        `,
-      },
+    const wrapper = mount({
+      components: { VoiceSearch },
+      template: `
+        <VoiceSearch>
+          <template v-slot:status="{ status, errorCode, isListening, transcript, isSpeechFinal, isBrowserSupported }">
+            <div>
+              <p>status: {{status}}</p>
+              <p>errorCode: {{errorCode}}</p>
+              <p>isListening: {{isListening}}</p>
+              <p>transcript: {{transcript}}</p>
+              <p>isSpeechFinal: {{isSpeechFinal}}</p>
+              <p>isBrowserSupported: {{isBrowserSupported}}</p>
+            </div>
+          </template>
+        </VoiceSearch>
+      `,
     });
     expect(wrapper.find('.ais-VoiceSearch-status').html()).toMatchSnapshot();
   });

--- a/src/components/__tests__/__snapshots__/StateResults.js.snap
+++ b/src/components/__tests__/__snapshots__/StateResults.js.snap
@@ -7,11 +7,7 @@ exports[`renders explanation if no slot is used 1`] = `
     Use this component to have a different layout based on a certain state.
   </p>
   <p>
-    Fill in the slot, and get access to the following things on the
-    <code>
-      v-slot
-    </code>
-    :
+    Fill in the slot, and get access to the following things:
   </p>
   <pre>
     results: [

--- a/src/components/__tests__/__snapshots__/StateResults.js.snap
+++ b/src/components/__tests__/__snapshots__/StateResults.js.snap
@@ -9,7 +9,7 @@ exports[`renders explanation if no slot is used 1`] = `
   <p>
     Fill in the slot, and get access to the following things on the
     <code>
-      slot-scope
+      v-slot
     </code>
     :
   </p>

--- a/stories/Autocomplete.stories.js
+++ b/stories/Autocomplete.stories.js
@@ -13,7 +13,7 @@ storiesOf('ais-autocomplete', module)
     template: `
       <div>
         <ais-autocomplete>
-          <template slot-scope="{currentRefinement, indices, refine}">
+          <template v-slot="{currentRefinement, indices, refine}">
             <vue-autosuggest
               :suggestions="indicesToSuggestions(indices)"
               @selected="onSelect"
@@ -22,7 +22,7 @@ storiesOf('ais-autocomplete', module)
                 onInputChange: refine,
               }"
             >
-              <template slot-scope="{ suggestion }">
+              <template v-slot="{ suggestion }">
                 <img :src="suggestion.item.image" style="width: 50px;"/>
                 <span>
                   <ais-highlight
@@ -62,7 +62,7 @@ storiesOf('ais-autocomplete', module)
         <ais-index index-name="airbnb" />
         <ais-index index-name="instantsearch_query_suggestions" />
         <ais-autocomplete>
-          <template slot-scope="{currentRefinement, indices, refine}">
+          <template v-slot="{currentRefinement, indices, refine}">
             <vue-autosuggest
               :suggestions="indicesToSuggestions(indices)"
               @selected="onSelect"
@@ -71,7 +71,7 @@ storiesOf('ais-autocomplete', module)
                 onInputChange: refine,
               }"
             >
-            <template slot="default" slot-scope="{ suggestion }">
+            <template v-slot="{ suggestion }">
               <img
                 :src="suggestion.item.image"
                 style="height: 50px;"

--- a/stories/Breadcrumb.stories.js
+++ b/stories/Breadcrumb.stories.js
@@ -42,7 +42,7 @@ storiesOf('ais-breadcrumb', module)
   .add('with a custom separator', () => ({
     template: `
       <ais-breadcrumb :attributes="attributes">
-        <template slot="separator" slot-scope="_">~</template>
+        <template v-slot:separator>~</template>
       </ais-breadcrumb>
     `,
     data: () => ({
@@ -74,33 +74,35 @@ storiesOf('ais-breadcrumb', module)
   .add('with a custom render', () => ({
     template: `
       <ais-breadcrumb :attributes="attributes">
-        <ul slot-scope="{ items, refine, createURL }">
-          <li>
-            <a
-              v-if="Boolean(items.length)"
-              :href="createURL()"
-              @click.prevent="refine()"
+        <template v-slot="{ items, refine, createURL }">
+          <ul>
+            <li>
+              <a
+                v-if="Boolean(items.length)"
+                :href="createURL()"
+                @click.prevent="refine()"
+              >
+                Home
+              </a>
+              <span v-else>
+                Home
+              </span>
+            </li>
+            <li
+              v-for="(item, index) in items"
+              :key="item.label"
             >
-              Home
-            </a>
-            <span v-else>
-              Home
-            </span>
-          </li>
-          <li
-            v-for="(item, index) in items"
-            :key="item.label"
-          >
-            <a
-              :href="createURL(item.value)"
-              @click.prevent="refine(item.value)"
-            >
-              <component :is="index === items.length -1 ? 'strong' : 'span'">
-                {{ item.label }}
-              </component>
-            </a>
-          </li>
-        </ul>
+              <a
+                :href="createURL(item.value)"
+                @click.prevent="refine(item.value)"
+              >
+                <component :is="index === items.length -1 ? 'strong' : 'span'">
+                  {{ item.label }}
+                </component>
+              </a>
+            </li>
+          </ul>
+        </template>
       </ais-breadcrumb>
     `,
     data: () => ({

--- a/stories/ClearRefinements.stories.js
+++ b/stories/ClearRefinements.stories.js
@@ -48,13 +48,14 @@ storiesOf('ais-clear-refinements', module)
   .add('with a custom render', () => ({
     template: `
       <ais-clear-refinements>
-        <button
-          slot-scope="{ canRefine, refine }"
-          :disabled="!canRefine"
-          @click="refine()"
-        >
-          Clear the search query
-        </button>
+        <template v-slot="{ canRefine, refine }">
+          <button
+            :disabled="!canRefine"
+            @click="refine()"
+          >
+            Clear the search query
+          </button>
+        </template>
       </ais-clear-refinements>
     `,
   }))

--- a/stories/Configure.stories.js
+++ b/stories/Configure.stories.js
@@ -43,7 +43,7 @@ storiesOf('ais-configure', module)
   .add('inline toggler', () => ({
     template: `
       <ais-configure :hitsPerPage="1" :analytics="false">
-        <template slot-scope="{ searchParameters, refine }">
+        <template v-slot="{ searchParameters, refine }">
           <pre>{{JSON.stringify(searchParameters, null, 2)}}</pre>
           <button @click="refine({hitsPerPage: searchParameters.hitsPerPage === 1 ? 5 : 1})">
             hitsPerPage: {{searchParameters.hitsPerPage}}, change
@@ -55,14 +55,16 @@ storiesOf('ais-configure', module)
   .add('with display of the parameters', () => ({
     template: `
       <ais-configure :hitsPerPage="1">
-        <pre slot-scope="{ searchParameters }">{{ searchParameters }}</pre>
+        <template v-slot="{ searchParameters }">
+          <pre>{{ searchParameters }}</pre>
+        </template>
       </ais-configure>
     `,
   }))
   .add('merging parameters', () => ({
     template: `
     <ais-configure :enableRules="false" :hitsPerPage="5">
-      <template slot-scope="{ searchParameters, refine }">
+      <template v-slot="{ searchParameters, refine }">
         <button
           @click="refine(
             Object.assign(
@@ -72,7 +74,7 @@ storiesOf('ais-configure', module)
             )
           )"
         >
-          toggle only query rules 
+          toggle only query rules
         </button>
         currently applied filters: <pre>{{searchParameters}}</pre>
       </template>
@@ -82,7 +84,9 @@ storiesOf('ais-configure', module)
   .add('playground', () => ({
     template: `
       <ais-configure v-bind="knobs">
-        <pre slot-scope="{ searchParameters }">{{ searchParameters }}</pre>
+        <template v-slot="{ searchParameters }">
+          <pre>{{ searchParameters }}</pre>
+        </template>
       </ais-configure>
     `,
     data() {

--- a/stories/ConfigureRelatedItems.stories.js
+++ b/stories/ConfigureRelatedItems.stories.js
@@ -10,7 +10,7 @@ storiesOf('ais-configure-related-items', module).add('default', () => ({
         <ais-search-box />
 
         <ais-hits>
-          <template slot="item" slot-scope="{ item }">
+          <template v-slot:item="{ item }">
             <div :ref="setReferenceHit(item)">
               <div
                 class="playground-hits-image"
@@ -36,19 +36,21 @@ storiesOf('ais-configure-related-items', module).add('default', () => ({
 
         <div class="related-items">
           <ais-pagination>
-            <div slot-scope="{ currentRefinement, isFirstPage, refine }">
-              <button
-                class="ais-RelatedHits-button"
-                :disabled="isFirstPage"
-                @click="refine(currentRefinement - 1)"
-              >
-                ←
-              </button>
-            </div>
+            <template v-slot="{ currentRefinement, isFirstPage, refine }">
+              <div>
+                <button
+                  class="ais-RelatedHits-button"
+                  :disabled="isFirstPage"
+                  @click="refine(currentRefinement - 1)"
+                >
+                  ←
+                </button>
+              </div>
+            </template>
           </ais-pagination>
 
           <ais-hits>
-            <template slot="item" slot-scope="{ item }">
+            <template v-slot:item="{ item }">
               <div class="ais-RelatedHits-item-image">
                 <img :src="item.image" alt="item.name" />
               </div>
@@ -61,15 +63,17 @@ storiesOf('ais-configure-related-items', module).add('default', () => ({
           </ais-hits>
 
           <ais-pagination>
-            <div slot-scope="{ currentRefinement, isLastPage, refine }">
-              <button
-                class="ais-RelatedHits-button"
-                :disabled="isLastPage"
-                @click="refine(currentRefinement + 1)"
-              >
-                →
-              </button>
-            </div>
+            <template v-slot="{ currentRefinement, isLastPage, refine }">
+              <div>
+                <button
+                  class="ais-RelatedHits-button"
+                  :disabled="isLastPage"
+                  @click="refine(currentRefinement + 1)"
+                >
+                  →
+                </button>
+              </div>
+            </template>
           </ais-pagination>
         </div>
       </ais-index>

--- a/stories/CurrentRefinements.stories.js
+++ b/stories/CurrentRefinements.stories.js
@@ -74,7 +74,7 @@ storiesOf('ais-current-refinements', module)
   .add('with custom item rendering', () => ({
     template: `
       <ais-current-refinements :excluded-attributes="[]">
-        <template slot="item" slot-scope="{ item, refine }">
+        <template v-slot:item="{ item, refine }">
           <span style="color: white">
             {{item.label}}
             <ul>
@@ -92,7 +92,7 @@ storiesOf('ais-current-refinements', module)
   .add('with custom refinement rendering', () => ({
     template: `
       <ais-current-refinements :excluded-attributes="[]">
-        <template slot="refinement" slot-scope="{ refinement, refine }">
+        <template v-slot:refinement="{ refinement, refine }">
           <button
             @click="refine(refinement)"
             style="color: white"
@@ -106,13 +106,13 @@ storiesOf('ais-current-refinements', module)
   .add('with full custom rendering', () => ({
     template: `
       <ais-current-refinements :excluded-attributes="[]">
-        <template slot-scope="{ refine, items, createURL }">
+        <template v-slot="{ refine, items, createURL }">
           <ul>
             <li
               v-for="item in items"
               :key="item.attribute"
               >
-              {{item.attribute}}: 
+              {{item.attribute}}:
               <button
                 v-for="refinement in item.refinements"
                 @click="item.refine(refinement)"

--- a/stories/HierarchicalMenu.stories.js
+++ b/stories/HierarchicalMenu.stories.js
@@ -62,7 +62,7 @@ storiesOf('ais-hierarchical-menu', module)
         :show-more-limit="5"
         :showMore="true"
       >
-        <template slot="showMoreLabel" slot-scope="{ isShowingMore }">
+        <template v-slot:showMoreLabel="{ isShowingMore }">
           {{ isShowingMore ? 'View less' : 'View more' }}
         </template>
       </ais-hierarchical-menu>
@@ -89,48 +89,50 @@ storiesOf('ais-hierarchical-menu', module)
           'hierarchicalCategories.lvl2',
         ]"
       >
-        <ol slot-scope="{ items, refine, createURL }">
-          <li
-            v-for="item in items"
-            :key="item.value"
-            :style="{ fontWeight: item.isRefined ? 600 : 400 }"
-          >
-            <a
-              :href="createURL(item.value)"
-              @click.prevent="refine(item.value)"
+        <template v-slot="{ items, refine, createURL }">
+          <ol>
+            <li
+              v-for="item in items"
+              :key="item.value"
+              :style="{ fontWeight: item.isRefined ? 600 : 400 }"
             >
-              {{item.label}} - {{item.count}}
-            </a>
-            <ol v-if="item.data">
-              <li
-                v-for="child in item.data"
-                :key="child.value"
-                :style="{ fontWeight: child.isRefined ? 600 : 400 }"
+              <a
+                :href="createURL(item.value)"
+                @click.prevent="refine(item.value)"
               >
-                <a
-                  :href="createURL(child.value)"
-                  @click.prevent="refine(child.value)"
+                {{item.label}} - {{item.count}}
+              </a>
+              <ol v-if="item.data">
+                <li
+                  v-for="child in item.data"
+                  :key="child.value"
+                  :style="{ fontWeight: child.isRefined ? 600 : 400 }"
                 >
-                  {{child.label}} - {{child.count}}
-                </a>
-                <ol v-if="child.data">
-                  <li
-                    v-for="subchild in child.data"
-                    :key="subchild.value"
-                    :style="{ fontWeight: subchild.isRefined ? 600 : 400 }"
+                  <a
+                    :href="createURL(child.value)"
+                    @click.prevent="refine(child.value)"
                   >
-                    <a
-                      :href="createURL(subchild.value)"
-                      @click.prevent="refine(subchild.value)"
+                    {{child.label}} - {{child.count}}
+                  </a>
+                  <ol v-if="child.data">
+                    <li
+                      v-for="subchild in child.data"
+                      :key="subchild.value"
+                      :style="{ fontWeight: subchild.isRefined ? 600 : 400 }"
                     >
-                      {{subchild.label}} - {{subchild.count}}
-                    </a>
-                  </li>
-                </ol>
-              </li>
-            </ol>
-          </li>
-        </ol>
+                      <a
+                        :href="createURL(subchild.value)"
+                        @click.prevent="refine(subchild.value)"
+                      >
+                        {{subchild.label}} - {{subchild.count}}
+                      </a>
+                    </li>
+                  </ol>
+                </li>
+              </ol>
+            </li>
+          </ol>
+        </template>
       </ais-hierarchical-menu>
     `,
   }))

--- a/stories/Highlight.stories.js
+++ b/stories/Highlight.stories.js
@@ -7,10 +7,12 @@ storiesOf('ais-highlight', module)
     template: `
     <div>
       <ais-hits>
-        <div slot="item" slot-scope="{ item }">
-          <h2><ais-highlight attribute="name" :hit="item"></ais-highlight></h2>
-          <small><ais-highlight attribute="description" :hit="item"></ais-highlight></small>
-        </div>
+        <template v-slot:item="{ item }">
+          <div>
+            <h2><ais-highlight attribute="name" :hit="item"></ais-highlight></h2>
+            <small><ais-highlight attribute="description" :hit="item"></ais-highlight></small>
+          </div>
+        </template>
       </ais-hits>
     </div>
   `,
@@ -19,11 +21,13 @@ storiesOf('ais-highlight', module)
     template: `
     <div>
       <ais-hits>
-        <div slot="item" slot-scope="{ item }">
-          <p v-for="(category, index) in item.categories" :key="index">
-            <ais-highlight :attribute="'categories.' + index" :hit="item"></ais-highlight></p>
-          </p>
-        </div>
+        <template v-slot:item="{ item }">
+          <div>
+            <p v-for="(category, index) in item.categories" :key="index">
+              <ais-highlight :attribute="'categories.' + index" :hit="item"></ais-highlight></p>
+            </p>
+          </div>
+        </template>
       </ais-hits>
     </div>
   `,
@@ -32,14 +36,16 @@ storiesOf('ais-highlight', module)
     template: `
     <div>
       <ais-hits>
-        <div slot="item" slot-scope="{ item }">
-          <h2>
-            <ais-highlight attribute="name" :hit="item" highlighted-tag-name="span"></ais-highlight>
-          </h2>
-          <small>
-            <ais-highlight attribute="description" :hit="item" highlighted-tag-name="span"></ais-highlight>
-          </small>
-        </div>
+        <template v-slot:item="{ item }">
+          <div>
+            <h2>
+              <ais-highlight attribute="name" :hit="item" highlighted-tag-name="span"></ais-highlight>
+            </h2>
+            <small>
+              <ais-highlight attribute="description" :hit="item" highlighted-tag-name="span"></ais-highlight>
+            </small>
+          </div>
+        </template>
       </ais-hits>
     </div>
     `,

--- a/stories/Hits.stories.js
+++ b/stories/Hits.stories.js
@@ -10,9 +10,11 @@ storiesOf('ais-hits', module)
   .add('with transform items', () => ({
     template: `
       <ais-hits :transform-items="transformItems">
-        <div slot="item" slot-scope="{ item }">
-          <h2>{{item.name}}</h2>
-        </div>
+        <template v-slot:item="{ item }">
+          <div>
+            <h2>{{item.name}}</h2>
+          </div>
+        </template>
       </ais-hits>
     `,
     methods: {
@@ -28,26 +30,30 @@ storiesOf('ais-hits', module)
   .add('custom rendering', () => ({
     template: `
     <ais-hits>
-      <div slot="item" slot-scope="{ item }">
-        <marquee>before one</marquee>
-        <h2>{{item.name}}</h2>
-        <small>{{item.description}}</small>
-      </div>
+      <template v-slot:item="{ item }">
+        <div>
+          <marquee>before one</marquee>
+          <h2>{{item.name}}</h2>
+          <small>{{item.description}}</small>
+        </div>
+      </template>
     </ais-hits>
   `,
   }))
   .add('custom rendering (all)', () => ({
     template: `
     <ais-hits>
-      <div slot-scope="{ items }">
-        <marquee>before everything</marquee>
-        <div
-          v-for="item in items"
-          :key="item.objectID"
-        >
-          custom objectID: {{item.objectID}}
+      <template v-slot="{ items }">
+        <div>
+          <marquee>before everything</marquee>
+          <div
+            v-for="item in items"
+            :key="item.objectID"
+          >
+            custom objectID: {{item.objectID}}
+          </div>
         </div>
-      </div>
+      </template>
     </ais-hits>`,
   }))
   .add('with a Panel', () => ({
@@ -72,15 +78,17 @@ storiesOf('ais-hits', module)
       <div>
         <ais-configure :clickAnalytics="true" />
         <ais-hits>
-          <div slot-scope="{ items, insights }">
-            <div
-              v-for="item in items"
-              :key="item.objectID"
-            >
-              custom objectID: {{item.objectID}}
-              <button @click="insights('clickedObjectIDsAfterSearch', { eventName: 'Add to cart', objectIDs: [item.objectID] })">Add to cart</button>
+          <template v-slot="{ items, insights }">
+            <div>
+              <div
+                v-for="item in items"
+                :key="item.objectID"
+              >
+                custom objectID: {{item.objectID}}
+                <button @click="insights('clickedObjectIDsAfterSearch', { eventName: 'Add to cart', objectIDs: [item.objectID] })">Add to cart</button>
+              </div>
             </div>
-          </div>
+          </template>
         </ais-hits>
       </div>
     `,
@@ -90,10 +98,12 @@ storiesOf('ais-hits', module)
       <div>
         <ais-configure :clickAnalytics="true" />
         <ais-hits>
-          <div slot="item" slot-scope="{ item, insights }">
-            custom objectID: {{item.objectID}}
-            <button @click="insights('clickedObjectIDsAfterSearch', { eventName: 'Add to cart', objectIDs: [item.objectID] })">Add to cart</button>
-          </div>
+          <template v-slot:item="{ item, insights }">
+            <div>
+              custom objectID: {{item.objectID}}
+              <button @click="insights('clickedObjectIDsAfterSearch', { eventName: 'Add to cart', objectIDs: [item.objectID] })">Add to cart</button>
+            </div>
+          </template>
         </ais-hits>
       </div>
     `,

--- a/stories/HitsPerPage.stories.js
+++ b/stories/HitsPerPage.stories.js
@@ -51,18 +51,20 @@ storiesOf('ais-hits-per-page', module)
           { label: '6 results', value: 6 }
         ]"
       >
-        <div slot-scope="{ items, refine }">
-          <label
-            v-for="(item, itemIndex) in items"
-            @change="refine(item.value)"
-          >
-            <input
-              type="radio"
-              :checked="item.isRefined"
+        <template v-slot="{ items, refine }">
+          <div>
+            <label
+              v-for="(item, itemIndex) in items"
+              @change="refine(item.value)"
             >
-            {{item.label}}
-          </label>
-        </div>
+              <input
+                type="radio"
+                :checked="item.isRefined"
+              >
+              {{item.label}}
+            </label>
+          </div>
+        </template>
       </ais-hits-per-page>`,
   }))
   .add('with a Panel', () => ({

--- a/stories/Index.stories.js
+++ b/stories/Index.stories.js
@@ -10,7 +10,7 @@ storiesOf('ais-index', module)
       <ais-search-box />
       <div>
         <ais-hits>
-          <template slot="item" slot-scope="{ item }">
+          <template v-slot:item="{ item }">
             <h3><ais-highlight :hit="item" attribute="name"/></h3>
           </template>
         </ais-hits>
@@ -18,7 +18,7 @@ storiesOf('ais-index', module)
       <hr />
       <ais-index index-name="instant_search">
         <ais-hits>
-          <template slot="item" slot-scope="{ item }">
+          <template v-slot:item="{ item }">
             <h3><ais-highlight :hit="item" attribute="name"/></h3>
           </template>
         </ais-hits>
@@ -48,7 +48,7 @@ storiesOf('ais-index', module)
         hitsPerPage="4"
       />
       <ais-hits>
-        <template slot="item" slot-scope="{ item }">
+        <template v-slot:item="{ item }">
           <h3><ais-highlight :hit="item" attribute="name"/></h3>
         </template>
       </ais-hits>
@@ -56,7 +56,7 @@ storiesOf('ais-index', module)
       <ais-index index-name="instant_search_rating_asc">
         <ais-refinement-list attribute="brand" />
         <ais-hits>
-          <template slot="item" slot-scope="{ item }">
+          <template v-slot:item="{ item }">
             <h3><ais-highlight :hit="item" attribute="name"/></h3>
           </template>
         </ais-hits>

--- a/stories/InfiniteHits.stories.js
+++ b/stories/InfiniteHits.stories.js
@@ -13,9 +13,11 @@ storiesOf('ais-infinite-hits', module)
   .add('with transform items', () => ({
     template: `
       <ais-infinite-hits :transform-items="transformItems">
-        <div slot="item" slot-scope="{ item, index }">
-          {{item.name}} - {{index}}
-        </div>
+        <template v-slot:item="{ item, index }">
+          <div>
+            {{item.name}} - {{index}}
+          </div>
+        </template>
       </ais-infinite-hits>
     `,
     methods: {
@@ -31,44 +33,50 @@ storiesOf('ais-infinite-hits', module)
   .add('with a custom render', () => ({
     template: `
       <ais-infinite-hits>
-        <div slot-scope="{ items, isLastPage, refine }">
-          <div
-            v-for="(item, index) in items"
-            :key="item.objectID"
-          >
-            {{item.name}}
-          </div>
+        <template v-slot="{ items, isLastPage, refine }">
+          <div>
+            <div
+              v-for="(item, index) in items"
+              :key="item.objectID"
+            >
+              {{item.name}}
+            </div>
 
-          <button
-            :disabled="isLastPage"
-            @click="refine"
-          >
-            Load more
-          </button>
-        </div>
+            <button
+              :disabled="isLastPage"
+              @click="refine"
+            >
+              Load more
+            </button>
+          </div>
+        </template>
       </ais-infinite-hits>
     `,
   }))
   .add('with a custom item render', () => ({
     template: `
       <ais-infinite-hits>
-        <div slot="item" slot-scope="{ item, index }">
-          {{item.name}} - {{index}}
-        </div>
+        <template v-slot:item="{ item, index }">
+          <div>
+            {{item.name}} - {{index}}
+          </div>
+        </template>
       </ais-infinite-hits>
     `,
   }))
   .add('with a custom show more render', () => ({
     template: `
       <ais-infinite-hits>
-        <div slot="loadMore" slot-scope="{ refine, page, isLastPage }">
-          <button
-            :disabled="isLastPage"
-            @click="refine"
-          >
-            Gimme {{ isLastPage ? "nothing anymore" : "page " + (page + 2) }}!
-          </button>
-        </div>
+        <template v-slot:loadMore="{ refine, page, isLastPage }">
+          <div>
+            <button
+              :disabled="isLastPage"
+              @click="refine"
+            >
+              Gimme {{ isLastPage ? "nothing anymore" : "page " + (page + 2) }}!
+            </button>
+          </div>
+        </template>
       </ais-infinite-hits>
     `,
   }))
@@ -116,14 +124,16 @@ storiesOf('ais-infinite-hits', module)
   .add('with a custom show previous render', () => ({
     template: `
       <ais-infinite-hits :show-previous="true">
-        <div slot="loadPrevious" slot-scope="{ refinePrevious, isFirstPage }">
-          <button
-            :disabled="isFirstPage"
-            @click="refinePrevious"
-          >
-            Gimme {{ isFirstPage ? "nothing anymore" : "previous page" }}!
-          </button>
-        </div>
+        <template v-slot:loadPrevious="{ refinePrevious, isFirstPage }">
+          <div>
+            <button
+              :disabled="isFirstPage"
+              @click="refinePrevious"
+            >
+              Gimme {{ isFirstPage ? "nothing anymore" : "previous page" }}!
+            </button>
+          </div>
+        </template>
       </ais-infinite-hits>`,
   }));
 
@@ -139,21 +149,23 @@ storiesOf('ais-infinite-hits', module)
       <div>
         <ais-configure :clickAnalytics="true" />
         <ais-infinite-hits>
-          <div slot-scope="{ items, refine, isLastPage, insights }">
-            <div
-              v-for="item in items"
-              :key="item.objectID"
-            >
-              custom objectID: {{item.objectID}}
-              <button @click="insights('clickedObjectIDsAfterSearch', { eventName: 'Add to cart', objectIDs: [item.objectID] })">Add to cart</button>
+          <template v-slot="{ items, refine, isLastPage, insights }">
+            <div>
+              <div
+                v-for="item in items"
+                :key="item.objectID"
+              >
+                custom objectID: {{item.objectID}}
+                <button @click="insights('clickedObjectIDsAfterSearch', { eventName: 'Add to cart', objectIDs: [item.objectID] })">Add to cart</button>
+              </div>
+              <button
+                :disabled="isLastPage"
+                @click="refine"
+              >
+                Load more
+              </button>
             </div>
-            <button
-              :disabled="isLastPage"
-              @click="refine"
-            >
-              Load more
-            </button>
-          </div>
+          </template>
         </ais-infinite-hits>
       </div>
     `,
@@ -163,10 +175,12 @@ storiesOf('ais-infinite-hits', module)
       <div>
         <ais-configure :clickAnalytics="true" />
         <ais-infinite-hits>
-          <div slot="item" slot-scope="{ item, insights }">
-            custom objectID: {{item.objectID}}
-            <button @click="insights('clickedObjectIDsAfterSearch', { eventName: 'Add to cart', objectIDs: [item.objectID] })">Add to cart</button>
-          </div>
+          <template v-slot:item="{ item, insights }">
+            <div>
+              custom objectID: {{item.objectID}}
+              <button @click="insights('clickedObjectIDsAfterSearch', { eventName: 'Add to cart', objectIDs: [item.objectID] })">Add to cart</button>
+            </div>
+          </template>
         </ais-infinite-hits>
       </div>
     `,
@@ -174,10 +188,12 @@ storiesOf('ais-infinite-hits', module)
   .add('with sessionStorage cache enabled', () => ({
     template: `
       <ais-infinite-hits :cache="cache">
-        <div slot="item" slot-scope="{ item, insights }">
-          custom objectID: {{item.objectID}}
-          <a href="https://google.com">Go to the detail</a>
-        </div>
+        <template v-slot:item="{ item, insights }">
+          <div>
+            custom objectID: {{item.objectID}}
+            <a href="https://google.com">Go to the detail</a>
+          </div>
+        </template>
       </ais-infinite-hits>
     `,
     data: () => ({

--- a/stories/InstantSearch.stories.js
+++ b/stories/InstantSearch.stories.js
@@ -80,7 +80,7 @@ storiesOf('ais-instant-search', module)
           <p>This is inside a <code>ais-instant-search</code>: <code>{{indexName}}</code></p>
           <ais-search-box show-loading-indicator/>
           <ais-hits>
-            <template slot="item" slot-scope="{item}">
+            <template v-slot:item="{item}">
               <p><ais-highlight :hit="item" attribute="name"/></p>
             </template>
           </ais-hits>

--- a/stories/Menu.stories.js
+++ b/stories/Menu.stories.js
@@ -29,7 +29,7 @@ storiesOf('ais-menu', module)
   .add('with custom label', () => ({
     template: `
       <ais-menu attribute="categories" :limit="2" :showMoreLimit="5" :show-more="true">
-        <template slot="showMoreLabel" slot-scope="{ isShowingMore }">
+        <template v-slot:showMoreLabel="{ isShowingMore }">
           {{isShowingMore ? 'View less' : 'View more'}}
         </template>
       </ais-menu>
@@ -57,21 +57,23 @@ storiesOf('ais-menu', module)
   .add('with a custom render', () => ({
     template: `
     <ais-menu attribute="categories">
-      <ol slot-scope="{ items, createURL, refine }">
-        <li
-          v-for="item in items"
-          :key="item.value"
-        >
-          <component :is="item.isRefined ? 'strong' : 'span'">
-            <a
-              :href="createURL(item.value)"
-              @click.prevent="refine(item.value)"
-            >
-              {{item.label}} - {{item.count}}
-            </a>
-          </component>
-        </li>
-      </ol>
+      <template v-slot="{ items, createURL, refine }">
+        <ol>
+          <li
+            v-for="item in items"
+            :key="item.value"
+          >
+            <component :is="item.isRefined ? 'strong' : 'span'">
+              <a
+                :href="createURL(item.value)"
+                @click.prevent="refine(item.value)"
+              >
+                {{item.label}} - {{item.count}}
+              </a>
+            </component>
+          </li>
+        </ol>
+      </template>
     </ais-menu>
     `,
   }))

--- a/stories/MenuSelect.stories.js
+++ b/stories/MenuSelect.stories.js
@@ -35,7 +35,7 @@ storiesOf('ais-menu-select', module)
   .add('with a custom item slot', () => ({
     template: `
       <ais-menu-select attribute="categories">
-        <template slot="item" slot-scope="{ item }">
+        <template v-slot:item="{ item }">
           {{ item.label }}
         </template>
       </ais-menu-select>
@@ -62,23 +62,24 @@ storiesOf('ais-menu-select', module)
   .add('with a custom rendering', () => ({
     template: `
       <ais-menu-select attribute="categories">
-        <select
-          slot-scope="{ items, canRefine, refine }"
-          @change="refine($event.currentTarget.value)"
-          :disabled="!canRefine"
-        >
-          <option value="">
-            All
-          </option>
-          <option
-            v-for="item in items"
-            :key="item.value"
-            :value="item.value"
-            :selected="item.isRefined"
+        <template v-slot="{ items, canRefine, refine }">
+          <select
+            @change="refine($event.currentTarget.value)"
+            :disabled="!canRefine"
           >
-            {{item.label}}
-          </option>
-        </select>
+            <option value="">
+              All
+            </option>
+            <option
+              v-for="item in items"
+              :key="item.value"
+              :value="item.value"
+              :selected="item.isRefined"
+            >
+              {{item.label}}
+            </option>
+          </select>
+        </template>
       </ais-menu-select>
     `,
   }))

--- a/stories/NumericMenu.stories.js
+++ b/stories/NumericMenu.stories.js
@@ -51,20 +51,22 @@ storiesOf('ais-numeric-menu', module)
           { label: '>= 500$', start: 500 },
         ]"
       >
-        <ul slot-scope="{ items, canRefine, refine, createURL }">
-          <li
-            v-for="item in items"
-            :key="item.label"
-            :style="{ fontWeight: item.isRefined ? 600 : 400 }"
-          >
-            <a
-              :href="createURL(item.value)"
-              @click.prevent="refine(item.value)"
+        <template v-slot="{ items, canRefine, refine, createURL }">
+          <ul>
+            <li
+              v-for="item in items"
+              :key="item.label"
+              :style="{ fontWeight: item.isRefined ? 600 : 400 }"
             >
-              {{ item.label }}
-            </a>
-          </li>
-        </ul>
+              <a
+                :href="createURL(item.value)"
+                @click.prevent="refine(item.value)"
+              >
+                {{ item.label }}
+              </a>
+            </li>
+          </ul>
+        </template>
       </ais-numeric-menu>
     `,
   }))

--- a/stories/Pagination.stories.js
+++ b/stories/Pagination.stories.js
@@ -25,7 +25,7 @@ storiesOf('ais-pagination', module)
         style="font-family: Fira Code, sans-serif"
       >
         <template
-          slot-scope="{
+          v-slot="{
             pages,
             refine,
             currentRefinement
@@ -46,7 +46,7 @@ storiesOf('ais-pagination', module)
   .add('with named slots', () => ({
     template: `
       <ais-pagination :padding="5">
-        <template slot="first" slot-scope="{ refine, isFirstPage }">
+        <template v-slot:first="{ refine, isFirstPage }">
           <button
             @click="refine"
             :disabled="isFirstPage"
@@ -54,7 +54,7 @@ storiesOf('ais-pagination', module)
             first
           </button>
         </template>
-        <template slot="previous" slot-scope="{ refine, isFirstPage }">
+        <template v-slot:previous="{ refine, isFirstPage }">
           <button
             @click="refine"
             :disabled="isFirstPage"
@@ -63,7 +63,7 @@ storiesOf('ais-pagination', module)
           </button>
         </template>
         </template>
-        <template slot="item" slot-scope="{ page, refine, createURL }">
+        <template v-slot:item="{ page, refine, createURL }">
           <a
             class="ais-Pagination-link"
             :href="createURL()"
@@ -72,7 +72,7 @@ storiesOf('ais-pagination', module)
             {{page}}
           </a>
         </template>
-        <template slot="next" slot-scope="{ refine, isFirstPage }">
+        <template v-slot:next="{ refine, isLastPage }">
           <button
             @click="refine"
             :disabled="isLastPage"
@@ -80,7 +80,7 @@ storiesOf('ais-pagination', module)
             next
           </button>
         </template>
-        <template slot="last" slot-scope="{ refine, isFirstPage }">
+        <template v-slot:last="{ refine, isLastPage }">
           <button
             @click="refine"
             :disabled="isLastPage"

--- a/stories/QueryRuleContext.stories.js
+++ b/stories/QueryRuleContext.stories.js
@@ -7,23 +7,25 @@ storiesOf('ais-query-rule-context', module)
       indexName: 'instant_search_movies',
       filters: '<ais-refinement-list attribute="genre" />',
       hits: `
-      <ol slot-scope="{ items }" class="playground-hits">
-        <li
-          v-for="item in items"
-          :key="item.objectID"
-          class="playground-hits-item"
-        >
-          <div
-            class="playground-hits-image"
-            :style="{ backgroundImage: 'url(' + item.image + ')' }"
-          />
-          <article>
-            <header>
-              <strong><ais-highlight attribute="title" :hit="item"/></strong>
-            </header>
-          </article>
-        </li>
-      </ol>
+      <template v-slot="{ items }">
+        <ol class="playground-hits">
+          <li
+            v-for="item in items"
+            :key="item.objectID"
+            class="playground-hits-item"
+          >
+            <div
+              class="playground-hits-image"
+              :style="{ backgroundImage: 'url(' + item.image + ')' }"
+            />
+            <article>
+              <header>
+                <strong><ais-highlight attribute="title" :hit="item"/></strong>
+              </header>
+            </article>
+          </li>
+        </ol>
+      </template>
       `,
     })
   )
@@ -37,7 +39,7 @@ storiesOf('ais-query-rule-context', module)
       </ul>
       <ais-query-rule-context :tracked-filters="trackedFilters" />
       <ais-query-rule-custom-data>
-        <template slot="item" slot-scope="{ item }">
+        <template v-slot:item="{ item }">
           <h2>{{ item.title }}</h2>
           <a :href="item.link">
             <img
@@ -72,7 +74,7 @@ storiesOf('ais-query-rule-context', module)
       />
       <ais-query-rule-context :tracked-filters="trackedFilters" />
       <ais-query-rule-custom-data>
-        <template slot="item" slot-scope="{ item }">
+        <template v-slot:item="{ item }">
           <h2>{{ item.title }}</h2>
           <a :href="item.link">
             <img
@@ -106,7 +108,7 @@ storiesOf('ais-query-rule-context', module)
         :transform-rule-contexts="transformRuleContexts"
       />
       <ais-query-rule-custom-data>
-        <template slot="item" slot-scope="{ item }">
+        <template v-slot:item="{ item }">
           <h2>{{ item.title }}</h2>
           <a :href="item.link">
             <img

--- a/stories/QueryRuleCustomData.stories.js
+++ b/stories/QueryRuleCustomData.stories.js
@@ -7,23 +7,25 @@ storiesOf('ais-query-rule-custom-data', module)
       indexName: 'instant_search_movies',
       filters: '<ais-refinement-list attribute="genre" />',
       hits: `
-      <ol slot-scope="{ items }" class="playground-hits">
-        <li
-          v-for="item in items"
-          :key="item.objectID"
-          class="playground-hits-item"
-        >
-          <div
-            class="playground-hits-image"
-            :style="{ backgroundImage: 'url(' + item.image + ')' }"
-          />
-          <article>
-            <header>
-              <strong><ais-highlight attribute="title" :hit="item"/></strong>
-            </header>
-          </article>
-        </li>
-      </ol>
+      <template v-slot="{ items }">
+        <ol class="playground-hits">
+          <li
+            v-for="item in items"
+            :key="item.objectID"
+            class="playground-hits-item"
+          >
+            <div
+              class="playground-hits-image"
+              :style="{ backgroundImage: 'url(' + item.image + ')' }"
+            />
+            <article>
+              <header>
+                <strong><ais-highlight attribute="title" :hit="item"/></strong>
+              </header>
+            </article>
+          </li>
+        </ol>
+      </template>
       `,
     })
   )
@@ -34,7 +36,7 @@ storiesOf('ais-query-rule-custom-data', module)
         <li>On query <q>music</q>: "This is it" appears.</li>
       </ul>
       <ais-query-rule-custom-data>
-        <template slot="item" slot-scope="{ item }">
+        <template v-slot:item="{ item }">
           <h2>{{ item.title }}</h2>
           <a :href="item.link">
             <img
@@ -56,7 +58,7 @@ storiesOf('ais-query-rule-custom-data', module)
         <li>On any other query: "Kill Bill" appears.</li>
       </ul>
       <ais-query-rule-custom-data :transform-items="transformItems">
-        <template slot="item" slot-scope="{ item }">
+        <template v-slot:item="{ item }">
           <h2>{{ item.title }}</h2>
           <a :href="item.link">
             <img

--- a/stories/RangeInput.stories.js
+++ b/stories/RangeInput.stories.js
@@ -39,7 +39,7 @@ storiesOf('ais-range-input', module)
   .add('with a custom render', () => ({
     template: `
       <ais-range-input attribute="price">
-        <template slot-scope="{ refine, currentRefinement }">
+        <template v-slot="{ refine, currentRefinement }">
           <form  @submit.prevent="refine({ min, max })" >
             <label>
               <input
@@ -76,7 +76,7 @@ storiesOf('ais-range-input', module)
     template: `
       <ais-range-input attribute="price">
         <template
-          slot-scope="{
+          v-slot="{
             refine,
             currentRefinement: { min: minValue, max: maxValue },
             range: { min: minRange, max: maxRange }
@@ -103,7 +103,7 @@ storiesOf('ais-range-input', module)
       <v-container mt-4>
         <ais-range-input attribute="price">
           <template
-            slot-scope="{
+            v-slot="{
               refine,
               currentRefinement: { min: minValue, max: maxValue },
               range: { min: minRange, max: maxRange }

--- a/stories/RatingMenu.stories.js
+++ b/stories/RatingMenu.stories.js
@@ -16,7 +16,7 @@ storiesOf('ais-rating-menu', module)
     template: `
       <div>
         <ais-rating-menu attribute="rating">
-          <template slot-scope="{ items, refine }">
+          <template v-slot="{ items, refine }">
             rating
             <ul>
               <li v-for="(item, key) in items" :key="key">

--- a/stories/RefinementList.stories.js
+++ b/stories/RefinementList.stories.js
@@ -44,7 +44,7 @@ storiesOf('ais-refinement-list', module)
   .add('item custom rendering', () => ({
     template: `
     <ais-refinement-list attribute="brand">
-      <template slot="item" slot-scope="{item, refine}">
+      <template v-slot:item="{item, refine}">
         <button
           @click="refine(item.value)"
         >
@@ -56,7 +56,7 @@ storiesOf('ais-refinement-list', module)
   .add('full custom rendering', () => ({
     template: `
     <ais-refinement-list attribute="brand" searchable show-more>
-      <template slot-scope="{
+      <template v-slot="{
         items,
         refine,
         searchForItems,

--- a/stories/RelevantSort.stories.js
+++ b/stories/RelevantSort.stories.js
@@ -18,7 +18,7 @@ storiesOf('ais-relevant-sort', module)
   .add('with custom text', () => ({
     template: `
       <ais-relevant-sort>
-        <template slot="text" slot-scope="{ isRelevantSorted }">
+        <template v-slot:text="{ isRelevantSorted }">
           <template v-if="isRelevantSorted">
             We removed some search results to show you the most relevant ones
           </template>
@@ -26,7 +26,7 @@ storiesOf('ais-relevant-sort', module)
             Currently showing all results
           </template>
         </template>
-        <template slot="button" slot-scope="{ isRelevantSorted }">
+        <template v-slot:button="{ isRelevantSorted }">
           <template v-if="isRelevantSorted">
             See all results
           </template>

--- a/stories/SearchBox.stories.js
+++ b/stories/SearchBox.stories.js
@@ -15,12 +15,13 @@ storiesOf('ais-search-box', module)
   .add('with custom rendering', () => ({
     template: `
       <ais-search-box autofocus>
-        <input
-          slot-scope="{ currentRefinement, refine }"
-          :value="currentRefinement"
-          @input="refine($event.currentTarget.value)"
-          placeholder="Custom SearchBox"
-        />
+        <template v-slot="{ currentRefinement, refine }">
+          <input
+            :value="currentRefinement"
+            @input="refine($event.currentTarget.value)"
+            placeholder="Custom SearchBox"
+          />
+        </template>
       </ais-search-box>
     `,
   }))

--- a/stories/Snippet.stories.js
+++ b/stories/Snippet.stories.js
@@ -12,12 +12,14 @@ storiesOf('ais-snippet', module)
       />
 
       <ais-hits>
-        <div slot="item" slot-scope="{ item }">
-          <h2><ais-snippet attribute="name" :hit="item"></ais-snippet></h2>
-          <small>
-            <ais-snippet attribute="description" :hit="item"></ais-snippet>
-          </small>
-        </div>
+        <template v-slot:item="{ item }">
+          <div>
+            <h2><ais-snippet attribute="name" :hit="item"></ais-snippet></h2>
+            <small>
+              <ais-snippet attribute="description" :hit="item"></ais-snippet>
+            </small>
+          </div>
+        </template>
       </ais-hits>
     </div>
   `,
@@ -31,12 +33,14 @@ storiesOf('ais-snippet', module)
       />
 
       <ais-hits>
-        <div slot="item" slot-scope="{ item }">
-          <h2><ais-snippet attribute="name" :hit="item"></ais-snippet></h2>
-          <small>
-            <ais-snippet attribute="description" :hit="item" highlighted-tag-name="span"></ais-snippet>
-          </small>
-        </div>
+        <template v-slot:item="{ item }">
+          <div>
+            <h2><ais-snippet attribute="name" :hit="item"></ais-snippet></h2>
+            <small>
+              <ais-snippet attribute="description" :hit="item" highlighted-tag-name="span"></ais-snippet>
+            </small>
+          </div>
+        </template>
       </ais-hits>
     </div>
   `,

--- a/stories/SortBy.stories.js
+++ b/stories/SortBy.stories.js
@@ -44,13 +44,15 @@ storiesOf('ais-sort-by', module)
           { value: 'instant_search_price_desc', label: 'Price desc.' },
         ]"
       >
-        <ul slot-scope="{ items, refine, currentRefinement}">
-          <li v-for="item in items" :key="item.value">
-            <button @click="refine(item.value)">
-              {{item.label}} {{currentRefinement === item.value ? '✔️' : ''}}
-            </button>
-          </li>
-        </ul>
+        <template v-slot="{ items, refine, currentRefinement}">
+          <ul>
+            <li v-for="item in items" :key="item.value">
+              <button @click="refine(item.value)">
+                {{item.label}} {{currentRefinement === item.value ? '✔️' : ''}}
+              </button>
+            </li>
+          </ul>
+        </template>
       </ais-sort-by>
     `,
   }))

--- a/stories/StateResults.stories.js
+++ b/stories/StateResults.stories.js
@@ -7,26 +7,25 @@ storiesOf('ais-state-results', module)
       indexName: 'demo-query-rules',
       filters: '<ais-refinement-list attribute="genre" />',
       hits: `
-      <ol
-        slot-scope="{ items }"
-        class="playground-hits"
-      >
-        <li
-          v-for="item in items"
-          :key="item.objectID"
-          class="playground-hits-item"
-        >
-          <div
-            class="playground-hits-image"
-            :style="{ backgroundImage: 'url(' + item.image + ')' }"
-          />
-          <div class="playground-hits-desc">
-            <p>
-              <ais-highlight attribute="title" :hit="item" />
-            </p>
-          </div>
-        </li>
-      </ol>
+      <template v-slot="{ items }">
+        <ol class="playground-hits">
+          <li
+            v-for="item in items"
+            :key="item.objectID"
+            class="playground-hits-item"
+          >
+            <div
+              class="playground-hits-image"
+              :style="{ backgroundImage: 'url(' + item.image + ')' }"
+            />
+            <div class="playground-hits-desc">
+              <p>
+                <ais-highlight attribute="title" :hit="item" />
+              </p>
+            </div>
+          </li>
+        </ol>
+      </template>
       `,
     })
   )
@@ -38,17 +37,17 @@ storiesOf('ais-state-results', module)
     <div>
       <ais-search-box />
       <ais-state-results>
-        <template slot-scope="{ state: { query } }">
+        <template v-slot="{ state: { query } }">
           <ais-hits v-if="query">
-            <h3
-              slot="item"
-              slot-scope="{ item }"
-              :tabindex="0"
-              @click="alert(item)"
-              @keyup.enter="alert(item)"
-            >
-              <ais-highlight :hit="item" attribute="title"/>
-            </h3>
+            <template v-slot:item="{ item }">
+              <h3
+                :tabindex="0"
+                @click="alert(item)"
+                @keyup.enter="alert(item)"
+              >
+                <ais-highlight :hit="item" attribute="title"/>
+              </h3>
+            </template>
           </ais-hits>
         </template>
       </ais-state-results>
@@ -67,7 +66,7 @@ storiesOf('ais-state-results', module)
       <ais-search-box />
       <p>type "documentary"</p>
       <ais-state-results>
-        <template slot-scope="{ results: { userData } }">
+        <template v-slot="{ results: { userData } }">
           <div>
             <img
               v-for="{ banner_img_slug: src } in userData"
@@ -85,7 +84,7 @@ storiesOf('ais-state-results', module)
       <div>
         <ais-search-box />
         <ais-state-results>
-          <template slot-scope="{ state: { query }, results: { hits } }">
+          <template v-slot="{ state: { query }, results: { hits } }">
             <p v-if="hits.length === 0">
               No results found for the query: <q>{{ query }}</q>
             </p>
@@ -98,10 +97,12 @@ storiesOf('ais-state-results', module)
   .add('ssr debugger', () => ({
     template: `
       <ais-state-results>
-        <div slot-scope="{ state }">
-          <p>copy this to <code>findResultsState</code></p>
-          <pre>{{ cleanup(state) }}</pre>
-        </div>
+        <template v-slot="{ state }">
+          <div>
+            <p>copy this to <code>findResultsState</code></p>
+            <pre>{{ cleanup(state) }}</pre>
+          </div>
+        </template>
       </ais-state-results>
     `,
     methods: {

--- a/stories/Stats.stories.js
+++ b/stories/Stats.stories.js
@@ -11,7 +11,7 @@ storiesOf('ais-stats', module)
   .add('custom rendering', () => ({
     template: `
       <ais-stats>
-        <template slot-scope="{nbHits, processingTimeMS}">
+        <template v-slot="{nbHits, processingTimeMS}">
           {{nbHits}} hits computed, in {{processingTimeMS}}ms 😲 Woh!
         </template>
       </ais-stats>

--- a/stories/ToggleRefinement.stories.js
+++ b/stories/ToggleRefinement.stories.js
@@ -44,14 +44,12 @@ storiesOf('ais-toggle-refinement', module)
         attribute="free_shipping"
         label="Free Shipping"
       >
-        <a
-          slot-scope="{ value, refine, createURL }"
-          :href="createURL()"
-          @click.prevent="refine(value)"
-        >
-          <span>{{ value.name }}</span>
-          <span>{{ value.isRefined ? '(is enabled)' : '(is disabled)' }}</span>
-        </a>
+        <template v-slot="{ value, refine, createURL }">
+          <a :href="createURL()" @click.prevent="refine(value)">
+            <span>{{ value.name }}</span>
+            <span>{{ value.isRefined ? '(is enabled)' : '(is disabled)' }}</span>
+          </a>
+        </template>
       </ais-toggle-refinement>
     `,
   }))

--- a/stories/VoiceSearch.stories.js
+++ b/stories/VoiceSearch.stories.js
@@ -39,7 +39,7 @@ storiesOf('ais-voice-search', module)
       template: `
       <div class="custom-button-wrapper">
         <ais-voice-search>
-          <template slot="buttonText" slot-scope="{ status, errorCode, isListening, transcript, isSpeechFinal, isBrowserSupported }">
+          <template v-slot:buttonText="{ status, errorCode, isListening, transcript, isSpeechFinal, isBrowserSupported }">
             {{ isListening ? '⏹' : '🎙' }}
           </template>
         </ais-voice-search>
@@ -50,7 +50,7 @@ storiesOf('ais-voice-search', module)
   .add('with full status', () => ({
     template: `
       <ais-voice-search>
-        <template slot="status" slot-scope="{ status, errorCode, isListening, transcript, isSpeechFinal, isBrowserSupported }">
+        <template v-slot:status="{ status, errorCode, isListening, transcript, isSpeechFinal, isBrowserSupported }">
           <p>status: {{status}}</p>
           <p>errorCode: {{errorCode}}</p>
           <p>isListening: {{isListening}}</p>
@@ -64,7 +64,7 @@ storiesOf('ais-voice-search', module)
   .add('search as you speak', () => ({
     template: `
       <ais-voice-search :search-as-you-speak="true">
-        <template slot="status" slot-scope="{ status, errorCode, isListening, transcript, isSpeechFinal, isBrowserSupported }">
+        <template v-slot:status="{ status, errorCode, isListening, transcript, isSpeechFinal, isBrowserSupported }">
           <p>status: {{status}}</p>
           <p>errorCode: {{errorCode}}</p>
           <p>isListening: {{isListening}}</p>
@@ -110,7 +110,7 @@ storiesOf('ais-voice-search', module)
       template: `
         <div class="custom-ui">
           <ais-voice-search>
-            <template slot="status" slot-scope="{ isListening, transcript }">
+            <template v-slot:status="{ isListening, transcript }">
               <div :class="'layer listening-' + isListening">
                 <span>{{ transcript }}</span>
               </div>
@@ -127,7 +127,7 @@ storiesOf('ais-voice-search', module)
   .add('with custom template for default slot', () => ({
     template: `
       <ais-voice-search>
-        <template slot-scope="{ isBrowserSupported, isListening, toggleListening, voiceListeningState }">
+        <template v-slot="{ isBrowserSupported, isListening, toggleListening, voiceListeningState }">
           <button @click="toggleListening()">click</button>
           <p>isListening: {{isListening ? 'true' : 'false'}}</p>
           <p>isBrowserSupported: {{isBrowserSupported ? 'true' : 'false'}}</p>

--- a/stories/utils.js
+++ b/stories/utils.js
@@ -5,28 +5,27 @@ export const previewWrapper = ({
   insightsClient,
   indexName = 'instant_search',
   hits = `
-    <ol
-      slot-scope="{ items }"
-      class="playground-hits"
-    >
-      <li
-        v-for="item in items"
-        :key="item.objectID"
-        class="playground-hits-item"
-      >
-        <div
-          class="playground-hits-image"
-          :style="{ backgroundImage: 'url(' + item.image + ')' }"
-        />
-        <div class="playground-hits-desc">
-          <p>
-            <ais-highlight attribute="name" :hit="item" />
-          </p>
-          <p>Rating: {{ item.rating }}✭</p>
-          <p>Price: {{ item.price }}$</p>
-        </div>
-      </li>
-    </ol>
+    <template v-slot="{ items }">
+      <ol class="playground-hits">
+        <li
+          v-for="item in items"
+          :key="item.objectID"
+          class="playground-hits-item"
+        >
+          <div
+            class="playground-hits-image"
+            :style="{ backgroundImage: 'url(' + item.image + ')' }"
+          />
+          <div class="playground-hits-desc">
+            <p>
+              <ais-highlight attribute="name" :hit="item" />
+            </p>
+            <p>Rating: {{ item.rating }}✭</p>
+            <p>Price: {{ item.price }}$</p>
+          </div>
+        </li>
+      </ol>
+    </template>
   `,
   filters = `
     <ais-refinement-list attribute="brand" />


### PR DESCRIPTION
## Summary

This PR replaces `slot-scope` with `v-slot` so that all the test cases can pass for both Vue 2 and Vue 3.

`slot-scope` is removed since Vue 3 and `v-slot` is supported since Vue 2.6.0.

---

Sorry for this massive PR.

![image](https://user-images.githubusercontent.com/499898/124279421-c76e7d00-db47-11eb-954b-2ab4deb4f749.png)

Hiding whitespace changes make it easier to review this PR.

### Two major types of changes in this PR:

1.
```
slot-scope="..."
```

to

```
v-slot="..."
```

2. Mounting the test subject as a dependent component and use template to render them (and plus, using `data` to pass the props to the inner component.)

```js
    const wrapper = mount(Breadcrumb, {
      propsData: defaultProps,
      scopedSlots: {
        default: defaultScopedSlot,
      }
    });
```

to

```js
    const wrapper = mount({
      components: { Breadcrumb },
      data() {
        return { props: defaultProps };
      },
      template: `
        <Breadcrumb v-bind="props">
          ${defaultSlot}
        </Breadcrumb>
      `,
    });
```