### PR TITLE
fix(vue 3): update the implementation of createServerRootMixin

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,12 @@
   "peerDependencies": {
     "algoliasearch": ">= 3.32.0 < 5",
     "vue": "^2.6.0 || >=3.0.0-rc.0",
-    "vue-server-renderer": "^2.6.11"
+    "vue-server-renderer": "^2.6.11",
+    "@vue/server-renderer": "^3.1.2"
+  },
+  "peerDependenciesMeta": {
+    "vue-server-renderer": { "optional": true },
+    "@vue/server-renderer": { "optional": true }
   },
   "devDependencies": {
     "@storybook/addon-actions": "3.4.11",

--- a/src/util/__tests__/createServerRootMixin.test.js
+++ b/src/util/__tests__/createServerRootMixin.test.js
@@ -1,15 +1,18 @@
-import Vue from 'vue';
-import { mount } from '../../../test/utils';
-import _renderToString from 'vue-server-renderer/basic';
+import { mount, createSSRApp, renderCompat } from '../../../test/utils';
 import Router from 'vue-router';
 import Vuex from 'vuex';
-import { createServerRootMixin } from '../createServerRootMixin';
+import { createStore } from 'vuex4';
+import {
+  createServerRootMixin,
+  renderToString,
+} from '../createServerRootMixin';
 import InstantSearchSsr from '../../components/InstantSearchSsr';
 import Configure from '../../components/Configure';
 import SearchBox from '../../components/SearchBox.vue';
 import { createWidgetMixin } from '../../mixins/widget';
 import { createFakeClient } from '../testutils/client';
 import { createSerializedState } from '../testutils/helper';
+import { isVue3, isVue2, Vue2 } from '../vue-compat';
 import {
   SearchResults,
   SearchParameters,
@@ -17,15 +20,6 @@ import {
 } from 'algoliasearch-helper';
 
 jest.unmock('instantsearch.js/es');
-
-function renderToString(app) {
-  return new Promise((resolve, reject) =>
-    _renderToString(app, {}, (err, res) => {
-      if (err) reject(err);
-      resolve(res);
-    })
-  );
-}
 
 const forceIsServerMixin = {
   beforeCreate() {
@@ -44,55 +38,55 @@ process.env.VUE_ENV = 'server';
 describe('createServerRootMixin', () => {
   describe('creation', () => {
     it('requires searchClient', () => {
-      expect(
-        () =>
-          new Vue({
-            mixins: [
-              createServerRootMixin({
-                searchClient: undefined,
-                indexName: 'lol',
-              }),
-            ],
-          })
+      expect(() =>
+        createSSRApp({
+          mixins: [
+            createServerRootMixin({
+              searchClient: undefined,
+              indexName: 'lol',
+            }),
+          ],
+        })
       ).toThrowErrorMatchingInlineSnapshot(
         `"createServerRootMixin requires \`searchClient\` and \`indexName\` in the first argument"`
       );
     });
 
     it('requires indexName', () => {
-      expect(
-        () =>
-          new Vue({
-            mixins: [
-              createServerRootMixin({
-                searchClient: createFakeClient(),
-                indexName: undefined,
-              }),
-            ],
-          })
+      expect(() =>
+        createSSRApp({
+          mixins: [
+            createServerRootMixin({
+              searchClient: createFakeClient(),
+              indexName: undefined,
+            }),
+          ],
+        })
       ).toThrowErrorMatchingInlineSnapshot(
         `"createServerRootMixin requires \`searchClient\` and \`indexName\` in the first argument"`
       );
     });
 
     it('creates an instantsearch instance on "data"', () => {
-      const app = new Vue({
+      const App = {
         mixins: [
           createServerRootMixin({
             searchClient: createFakeClient(),
             indexName: 'lol',
           }),
         ],
-      });
+        render: () => null,
+      };
 
-      expect(app.$data).toEqual({
+      const wrapper = mount(App);
+      expect(wrapper.vm.$data).toEqual({
         instantsearch: expect.objectContaining({
           start: expect.any(Function),
         }),
       });
     });
 
-    it('provides the instantsearch instance ', () => {
+    it('provides the instantsearch instance', done => {
       const App = {
         mixins: [
           createServerRootMixin({
@@ -100,59 +94,64 @@ describe('createServerRootMixin', () => {
             indexName: 'myIndexName',
           }),
         ],
-        render(h) {
-          return h('div', {}, this.$slots.default);
-        },
+        template: `<div><slot /></div>`,
       };
 
       const Child = {
         mixins: [createWidgetMixin({ connector: true })],
-        render(h) {
-          return h('p', {}, this.instantSearchInstance.indexName);
+        mounted() {
+          expect(this.instantSearchInstance).toEqual(
+            expect.objectContaining({
+              start: expect.any(Function),
+              dispose: expect.any(Function),
+              mainIndex: expect.any(Object),
+              addWidgets: expect.any(Function),
+              removeWidgets: expect.any(Function),
+            })
+          );
+          done();
+        },
+        render() {
+          return null;
         },
       };
 
-      const wrapper = mount(App, {
-        slots: {
-          default: {
-            render(h) {
-              return h(InstantSearchSsr, [h(Child)]);
-            },
-          },
-        },
+      mount({
+        components: { App, InstantSearchSsr, Child },
+        template: `
+          <App>
+            <InstantSearchSsr>
+              <Child />
+            </InstantSearchSsr>
+          </App>
+        `,
       });
-
-      expect(wrapper.html()).toMatchInlineSnapshot(`
-<div>
-  <div class="ais-InstantSearch ais-InstantSearch--ssr">
-    <p>
-      myIndexName
-    </p>
-  </div>
-</div>
-`);
     });
   });
 
   describe('findResultsState', () => {
-    it('provides findResultsState', () => {
-      const app = new Vue({
+    it('provides findResultsState', async done => {
+      const app = createSSRApp({
         mixins: [
+          forceIsServerMixin,
           createServerRootMixin({
             searchClient: createFakeClient(),
             indexName: 'hello',
           }),
         ],
-        render(h) {
-          return h(InstantSearchSsr);
+        render: renderCompat(h => h(InstantSearchSsr, {})),
+        created() {
+          expect(typeof this.instantsearch.findResultsState).toBe('function');
+          done();
         },
       });
 
-      expect(typeof app.$data.instantsearch.findResultsState).toBe('function');
+      await renderToString(app);
     });
 
     it('detects child widgets', async () => {
       const searchClient = createFakeClient();
+      let mainIndex;
 
       const app = {
         mixins: [
@@ -162,33 +161,48 @@ describe('createServerRootMixin', () => {
             indexName: 'hello',
           }),
         ],
-        render(h) {
-          return h(InstantSearchSsr, {}, [
-            h(Configure, {
-              attrs: {
-                hitsPerPage: 100,
-              },
-            }),
+        render: renderCompat(h =>
+          /**
+           * This code triggers this warning in Vue 3:
+           * > Non-function value encountered for default slot. Prefer function slots for better performance.
+           *
+           * To fix it, replace the third argument
+           * > [h(...), h(...)]
+           * with
+           * > { default: () => [h(...), h(...)] }
+           *
+           * but it's not important (and not compatible in vue2), we're leaving it as-is.
+           */
+          h(InstantSearchSsr, {}, [
+            h(
+              Configure,
+              isVue3
+                ? { hitsPerPage: 100 }
+                : {
+                    attrs: {
+                      hitsPerPage: 100,
+                    },
+                  }
+            ),
             h(SearchBox),
-          ]);
-        },
+          ])
+        ),
         serverPrefetch() {
           return this.instantsearch.findResultsState(this);
         },
+        created() {
+          mainIndex = this.instantsearch.mainIndex;
+        },
       };
 
-      const wrapper = new Vue({
+      const wrapper = createSSRApp({
         mixins: [forceIsServerMixin],
-        render(h) {
-          return h(app);
-        },
+        render: renderCompat(h => h(app)),
       });
 
       await renderToString(wrapper);
 
-      const { instantsearch } = wrapper.$children[0].$data;
-
-      expect(instantsearch.mainIndex.getWidgetState()).toMatchInlineSnapshot(`
+      expect(mainIndex.getWidgetState()).toMatchInlineSnapshot(`
 Object {
   "hello": Object {
     "configure": Object {
@@ -216,13 +230,25 @@ Array [
 
     it('forwards router', async () => {
       const searchClient = createFakeClient();
-
-      const router = new Router({});
+      let router;
+      if (isVue3) {
+        const Router4 = require('vue-router4');
+        router = Router4.createRouter({
+          history: Router4.createMemoryHistory(),
+          routes: [{ path: '', component: {} }],
+        });
+      } else {
+        router = new Router({});
+      }
 
       // there are two renders of App, each with an assertion
       expect.assertions(2);
 
-      const App = Vue.component('App', {
+      if (isVue2) {
+        Vue2.use(Router);
+      }
+
+      const App = {
         mixins: [
           forceIsServerMixin,
           createServerRootMixin({
@@ -234,30 +260,34 @@ Array [
           expect(this.$router).toBe(router);
           return {};
         },
-        render(h) {
-          return h(InstantSearchSsr, {}, [
-            h(Configure, {
-              attrs: {
-                hitsPerPage: 100,
-              },
-            }),
+        render: renderCompat(h =>
+          h(InstantSearchSsr, {}, [
+            h(
+              Configure,
+              isVue3
+                ? { hitsPerPage: 100 }
+                : {
+                    attrs: {
+                      hitsPerPage: 100,
+                    },
+                  }
+            ),
             h(SearchBox),
-          ]);
-        },
+          ])
+        ),
         serverPrefetch() {
           return this.instantsearch.findResultsState(this);
         },
-      });
+      };
 
-      Vue.use(Router);
-
-      const wrapper = new Vue({
+      const wrapper = createSSRApp({
         mixins: [forceIsServerMixin],
-        router,
-        render(h) {
-          return h(App);
-        },
+        render: renderCompat(h => h(App)),
+        ...(isVue2 ? { router } : {}),
       });
+      if (isVue3) {
+        wrapper.use(router);
+      }
 
       await renderToString(wrapper);
     });
@@ -265,14 +295,15 @@ Array [
     it('forwards vuex', async () => {
       const searchClient = createFakeClient();
 
-      Vue.use(Vuex);
-
-      const store = new Vuex.Store();
+      if (isVue2) {
+        Vue2.use(Vuex);
+      }
+      const store = isVue3 ? createStore() : new Vuex.Store();
 
       // there are two renders of App, each with an assertion
       expect.assertions(2);
 
-      const App = Vue.component('App', {
+      const App = {
         mixins: [
           forceIsServerMixin,
           createServerRootMixin({
@@ -284,28 +315,35 @@ Array [
           expect(this.$store).toBe(store);
           return {};
         },
-        render(h) {
-          return h(InstantSearchSsr, {}, [
-            h(Configure, {
-              attrs: {
-                hitsPerPage: 100,
-              },
-            }),
+        render: renderCompat(h =>
+          h(InstantSearchSsr, {}, [
+            h(
+              Configure,
+              isVue3
+                ? { hitsPerPage: 100 }
+                : {
+                    attrs: {
+                      hitsPerPage: 100,
+                    },
+                  }
+            ),
             h(SearchBox),
-          ]);
-        },
+          ])
+        ),
         serverPrefetch() {
           return this.instantsearch.findResultsState(this);
         },
+      };
+
+      const wrapper = createSSRApp({
+        mixins: [forceIsServerMixin],
+        ...(isVue2 ? { store } : {}),
+        render: renderCompat(h => h(App)),
       });
 
-      const wrapper = new Vue({
-        mixins: [forceIsServerMixin],
-        store,
-        render(h) {
-          return h(App);
-        },
-      });
+      if (isVue3) {
+        wrapper.use(store);
+      }
 
       await renderToString(wrapper);
     });
@@ -318,7 +356,7 @@ Array [
 
       const someProp = { data: Math.random() };
 
-      const App = Vue.component('App', {
+      const App = {
         mixins: [
           forceIsServerMixin,
           createServerRootMixin({
@@ -336,187 +374,191 @@ Array [
             },
           },
         },
-        render(h) {
-          return h(InstantSearchSsr, {}, [
-            h(Configure, {
-              attrs: {
-                hitsPerPage: 100,
-              },
-            }),
-            h(SearchBox),
-          ]);
-        },
-        serverPrefetch() {
-          return this.instantsearch.findResultsState(this);
-        },
-      });
-
-      const wrapper = new Vue({
-        mixins: [forceIsServerMixin],
-        render(h) {
-          return h(App, { props: { someProp } });
-        },
-      });
-
-      await renderToString(wrapper);
-    });
-
-    it('forwards slots', async done => {
-      const searchClient = createFakeClient();
-
-      expect.assertions(2);
-
-      const App = Vue.component('App', {
-        mixins: [
-          forceIsServerMixin,
-          createServerRootMixin({
-            searchClient,
-            indexName: 'hello',
-          }),
-        ],
-        render(h) {
-          return h(InstantSearchSsr, {}, this.$slots.default);
-        },
-        serverPrefetch() {
-          return (
-            this.instantsearch
-              .findResultsState(this)
-              .then(res => {
-                expect(
-                  this.instantsearch.mainIndex.getWidgets().map(w => w.$$type)
-                ).toEqual(['ais.configure']);
-
-                expect(res.hello._state.hitsPerPage).toBe(100);
-              })
-              // jest throws an error we need to catch, since stuck in the flow
-              .catch(e => {
-                done.fail(e);
-              })
-          );
-        },
-      });
-
-      const wrapper = new Vue({
-        mixins: [forceIsServerMixin],
-        render(h) {
-          return h(App, [
-            h('template', { slot: 'default' }, [
-              h(Configure, {
-                attrs: {
-                  hitsPerPage: 100,
-                },
-              }),
-            ]),
-          ]);
-        },
-      });
-
-      await renderToString(wrapper);
-      done();
-    });
-
-    // TODO: forwarding of scoped slots doesn't yet work.
-    it.skip('forwards scoped slots', async done => {
-      const searchClient = createFakeClient();
-
-      expect.assertions(2);
-
-      const App = Vue.component('App', {
-        mixins: [
-          forceIsServerMixin,
-          createServerRootMixin({
-            searchClient,
-            indexName: 'hello',
-          }),
-        ],
-        render(h) {
-          return h(InstantSearchSsr, {}, [
-            this.$scopedSlots.default({ test: true }),
-          ]);
-        },
-        serverPrefetch() {
-          return (
-            this.instantsearch
-              .findResultsState(this)
-              .then(res => {
-                expect(
-                  this.instantsearch.mainIndex.getWidgets().map(w => w.$$type)
-                ).toEqual(['ais.configure']);
-
-                expect(res.hello._state.hitsPerPage).toBe(100);
-              })
-              // jest throws an error we need to catch, since stuck in the flow
-              .catch(e => {
-                done.fail(e);
-              })
-          );
-        },
-      });
-
-      const wrapper = new Vue({
-        mixins: [forceIsServerMixin],
-        render(h) {
-          return h(App, {
-            scopedSlots: {
-              default({ test }) {
-                if (test) {
-                  return h(Configure, {
+        render: renderCompat(h =>
+          h(InstantSearchSsr, {}, [
+            h(
+              Configure,
+              isVue3
+                ? { hitsPerPage: 100 }
+                : {
                     attrs: {
                       hitsPerPage: 100,
                     },
-                  });
-                }
-                return null;
-              },
-            },
-          });
-        },
-      });
-
-      await renderToString(wrapper);
-      done();
-    });
-
-    it('forwards root', async () => {
-      const searchClient = createFakeClient();
-
-      // there are two renders of App, each with an assertion
-      expect.assertions(2);
-
-      const App = Vue.component('App', {
-        mixins: [
-          forceIsServerMixin,
-          createServerRootMixin({
-            searchClient,
-            indexName: 'hello',
-          }),
-        ],
-        render(h) {
-          expect(this.$root).toBe(wrapper);
-
-          return h(InstantSearchSsr, {}, [
-            h(Configure, {
-              attrs: {
-                hitsPerPage: 100,
-              },
-            }),
+                  }
+            ),
             h(SearchBox),
-          ]);
-        },
+          ])
+        ),
         serverPrefetch() {
           return this.instantsearch.findResultsState(this);
         },
-      });
+      };
 
-      const wrapper = new Vue({
+      const wrapper = createSSRApp({
         mixins: [forceIsServerMixin],
-        render(h) {
-          return h(App);
-        },
+        render: renderCompat(h =>
+          h(App, isVue3 ? { someProp } : { props: { someProp } })
+        ),
       });
 
       await renderToString(wrapper);
     });
+
+    // FIXME: make these work with Vue 3
+    if (isVue2) {
+      it('forwards slots', async done => {
+        const searchClient = createFakeClient();
+
+        expect.assertions(2);
+
+        const App = {
+          mixins: [
+            forceIsServerMixin,
+            createServerRootMixin({
+              searchClient,
+              indexName: 'hello',
+            }),
+          ],
+          components: { InstantSearchSsr },
+          template: `
+            <InstantSearchSsr>
+              <slot />
+            </InstantSearchSsr>
+          `,
+          serverPrefetch() {
+            return (
+              this.instantsearch
+                .findResultsState(this)
+                .then(res => {
+                  expect(
+                    this.instantsearch.mainIndex.getWidgets().map(w => w.$$type)
+                  ).toEqual(['ais.configure']);
+
+                  expect(res.hello._state.hitsPerPage).toBe(100);
+                })
+                // jest throws an error we need to catch, since stuck in the flow
+                .catch(e => {
+                  done.fail(e);
+                })
+            );
+          },
+        };
+
+        const wrapper = createSSRApp({
+          mixins: [forceIsServerMixin],
+          components: { App, Configure },
+          template: `
+          <App>
+            <Configure :hits-per-page.camel="100" />
+          </App>
+        `,
+        });
+
+        await renderToString(wrapper);
+        done();
+      });
+
+      // TODO: forwarding of scoped slots doesn't yet work.
+      it.skip('forwards scoped slots', async done => {
+        const searchClient = createFakeClient();
+
+        expect.assertions(2);
+
+        const App = {
+          mixins: [
+            forceIsServerMixin,
+            createServerRootMixin({
+              searchClient,
+              indexName: 'hello',
+            }),
+          ],
+          render: renderCompat(h =>
+            h(InstantSearchSsr, {}, [this.$scopedSlots.default({ test: true })])
+          ),
+          serverPrefetch() {
+            return (
+              this.instantsearch
+                .findResultsState(this)
+                .then(res => {
+                  expect(
+                    this.instantsearch.mainIndex.getWidgets().map(w => w.$$type)
+                  ).toEqual(['ais.configure']);
+
+                  expect(res.hello._state.hitsPerPage).toBe(100);
+                })
+                // jest throws an error we need to catch, since stuck in the flow
+                .catch(e => {
+                  done.fail(e);
+                })
+            );
+          },
+        };
+
+        const wrapper = createSSRApp({
+          mixins: [forceIsServerMixin],
+          render: renderCompat(h =>
+            h(App, {
+              scopedSlots: {
+                default({ test }) {
+                  if (test) {
+                    return h(Configure, {
+                      hitsPerPage: 100,
+                    });
+                  }
+                  return null;
+                },
+              },
+            })
+          ),
+        });
+
+        await renderToString(wrapper);
+        done();
+      });
+
+      it('forwards root', async () => {
+        const searchClient = createFakeClient();
+
+        // there are two renders of App, each with an assertion
+        expect.assertions(2);
+
+        const App = {
+          mixins: [
+            forceIsServerMixin,
+            createServerRootMixin({
+              searchClient,
+              indexName: 'hello',
+            }),
+          ],
+          render: renderCompat(function(h) {
+            expect(this.$root).toBe(wrapper);
+            return h(InstantSearchSsr, {}, [
+              h(
+                Configure,
+                isVue3
+                  ? { hitsPerPage: 100 }
+                  : {
+                      attrs: {
+                        hitsPerPage: 100,
+                      },
+                    }
+              ),
+              h(SearchBox),
+            ]);
+          }),
+          serverPrefetch() {
+            return this.instantsearch.findResultsState(this);
+          },
+        };
+
+        const wrapper = createSSRApp({
+          mixins: [forceIsServerMixin],
+          render: renderCompat(h => h(App)),
+        });
+
+        await renderToString(wrapper);
+      });
+    }
   });
 
   describe('hydrate', () => {
@@ -530,16 +572,21 @@ Array [
             indexName: 'hello',
           }),
         ],
-        render(h) {
-          return h(InstantSearchSsr, {}, [
-            h(Configure, {
-              attrs: {
-                hitsPerPage: 100,
-              },
-            }),
+        render: renderCompat(h =>
+          h(InstantSearchSsr, {}, [
+            h(
+              Configure,
+              isVue3
+                ? { hitsPerPage: 100 }
+                : {
+                    attrs: {
+                      hitsPerPage: 100,
+                    },
+                  }
+            ),
             h(SearchBox),
-          ]);
-        },
+          ])
+        ),
         // in test, beforeCreated doesn't have $data yet, but IRL it does
         created() {
           this.instantsearch.hydrate({
@@ -576,33 +623,37 @@ Array [
             indexName: 'movies',
           }),
         ],
-        render(h) {
-          return h(InstantSearchSsr, {}, [
-            h(Configure, {
-              attrs: {
-                hitsPerPage: 100,
-              },
-            }),
+        render: renderCompat(h =>
+          h(InstantSearchSsr, {}, [
+            h(
+              Configure,
+              isVue3
+                ? { hitsPerPage: 100 }
+                : {
+                    attrs: {
+                      hitsPerPage: 100,
+                    },
+                  }
+            ),
             h(SearchBox),
-          ]);
-        },
-        // in test, beforeCreated doesn't have $data yet, but IRL it does
+          ])
+        ),
         created() {
           this.instantsearch.hydrate({
             movies: nonSerialized,
           });
+
+          expect(this.instantsearch.__initialSearchResults).toEqual(
+            expect.objectContaining({ movies: expect.any(SearchResults) })
+          );
+
+          expect(this.instantsearch.__initialSearchResults.movies).toEqual(
+            nonSerialized
+          );
         },
       };
 
-      const {
-        vm: { instantsearch },
-      } = mount(app);
-
-      expect(instantsearch.__initialSearchResults).toEqual(
-        expect.objectContaining({ movies: expect.any(SearchResults) })
-      );
-
-      expect(instantsearch.__initialSearchResults.movies).toBe(nonSerialized);
+      mount(app);
     });
 
     it('inits the main index', () => {
@@ -615,16 +666,21 @@ Array [
             indexName: 'hello',
           }),
         ],
-        render(h) {
-          return h(InstantSearchSsr, {}, [
-            h(Configure, {
-              attrs: {
-                hitsPerPage: 100,
-              },
-            }),
+        render: renderCompat(h =>
+          h(InstantSearchSsr, {}, [
+            h(
+              Configure,
+              isVue3
+                ? { hitsPerPage: 100 }
+                : {
+                    attrs: {
+                      hitsPerPage: 100,
+                    },
+                  }
+            ),
             h(SearchBox),
-          ]);
-        },
+          ])
+        ),
       };
 
       const {
@@ -653,16 +709,21 @@ Array [
             indexName: 'hello',
           }),
         ],
-        render(h) {
-          return h(InstantSearchSsr, {}, [
-            h(Configure, {
-              attrs: {
-                hitsPerPage: 100,
-              },
-            }),
+        render: renderCompat(h =>
+          h(InstantSearchSsr, {}, [
+            h(
+              Configure,
+              isVue3
+                ? { hitsPerPage: 100 }
+                : {
+                    attrs: {
+                      hitsPerPage: 100,
+                    },
+                  }
+            ),
             h(SearchBox),
-          ]);
-        },
+          ])
+        ),
       };
 
       const {
@@ -684,21 +745,23 @@ Array [
 
   describe('__forceRender', () => {
     it('calls render on widget', () => {
-      const app = new Vue({
+      let instantSearchInstance;
+      mount({
         mixins: [
           createServerRootMixin({
             searchClient: createFakeClient(),
             indexName: 'lol',
           }),
         ],
+        created() {
+          instantSearchInstance = this.instantsearch;
+        },
       });
 
       const widget = {
         init: jest.fn(),
         render: jest.fn(),
       };
-
-      const instantSearchInstance = app.$data.instantsearch;
 
       instantSearchInstance.hydrate({
         lol: createSerializedState(),
@@ -753,21 +816,23 @@ Object {
 
     describe('createURL', () => {
       it('returns # if instantsearch has no routing', () => {
-        const app = new Vue({
+        let instantSearchInstance;
+        mount({
           mixins: [
             createServerRootMixin({
               searchClient: createFakeClient(),
               indexName: 'lol',
             }),
           ],
+          created() {
+            instantSearchInstance = this.instantsearch;
+          },
         });
 
         const widget = {
           init: jest.fn(),
           render: jest.fn(),
         };
-
-        const instantSearchInstance = app.$data.instantsearch;
 
         instantSearchInstance.hydrate({
           lol: createSerializedState(),
@@ -784,13 +849,17 @@ Object {
       });
 
       it('allows for widgets without getWidgetState', () => {
-        const app = new Vue({
+        let instantSearchInstance;
+        mount({
           mixins: [
             createServerRootMixin({
               searchClient: createFakeClient(),
               indexName: 'lol',
             }),
           ],
+          created() {
+            instantSearchInstance = this.instantsearch;
+          },
         });
 
         const widget = {
@@ -805,8 +874,6 @@ Object {
           init: jest.fn(),
           render: jest.fn(),
         };
-
-        const instantSearchInstance = app.$data.instantsearch;
 
         instantSearchInstance.hydrate({
           lol: createSerializedState(),

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -107,8 +107,6 @@ function defaultCloneComponent(componentInstance, { mixins = [] } = {}) {
   app.$root = componentInstance.$root;
   if (isVue2) {
     app.$options.serverPrefetch = [];
-  } else {
-    // FIXME: ???
   }
 
   return app;

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -1,6 +1,7 @@
 import instantsearch from 'instantsearch.js/es';
 import algoliaHelper from 'algoliasearch-helper';
-import { isVue3, Vue2, defineComponent } from '../util/vue';
+import { isVue3, isVue2, Vue2, createSSRApp } from '../util/vue-compat';
+import { _objectSpread } from '../util/polyfills';
 const { SearchResults, SearchParameters } = algoliaHelper;
 import { warn } from './warn';
 
@@ -14,13 +15,33 @@ function walkIndex(indexWidget, visit) {
   });
 }
 
-function renderToString(app, _renderToString) {
-  return new Promise((resolve, reject) =>
-    _renderToString(app, (err, res) => {
-      if (err) reject(err);
-      resolve(res);
-    })
-  );
+export function renderToString(app) {
+  let _renderToString;
+  try {
+    _renderToString = isVue3
+      ? require('@vue/server-renderer').renderToString
+      : require('vue-server-renderer/basic');
+  } catch (e) {
+    // error is handled by regular if, in case it's `undefined`
+  }
+  if (!_renderToString) {
+    if (isVue3) {
+      throw new Error('you need to install @vue/server-renderer');
+    } else {
+      throw new Error('you need to install vue-server-renderer');
+    }
+  }
+
+  if (isVue3) {
+    return _renderToString(app);
+  } else {
+    return new Promise((resolve, reject) =>
+      _renderToString(app, (err, res) => {
+        if (err) reject(err);
+        resolve(res);
+      })
+    );
+  }
 }
 
 function searchOnlyWithDerivedHelpers(helper) {
@@ -40,31 +61,56 @@ function searchOnlyWithDerivedHelpers(helper) {
   });
 }
 
-function defaultCloneComponent(componentInstance) {
+function defaultCloneComponent(componentInstance, { mixins = [] } = {}) {
   const options = {
     serverPrefetch: undefined,
     fetch: undefined,
     _base: undefined,
     name: 'ais-ssr-root-component',
-    // copy over global Vue APIs
-    router: componentInstance.$router,
-    store: componentInstance.$store,
   };
+  if (isVue2) {
+    // copy over global Vue APIs
+    options.router = componentInstance.$router;
+    options.store = componentInstance.$store;
+  }
 
-  const Extended = componentInstance.$vnode
-    ? componentInstance.$vnode.componentOptions.Ctor.extend(options)
-    : (isVue3 ? defineComponent : Vue2.component)(
-        Object.assign({}, componentInstance.$options, options)
-      );
+  let app;
 
-  const app = new Extended({
-    propsData: componentInstance.$options.propsData,
-  });
+  if (isVue3) {
+    const appOptions = Object.assign({}, componentInstance.$options, options);
+    appOptions.mixins = [...appOptions.mixins, ...mixins];
+    // Unlike Vue 2, there is no componentInstance.$options.propsData in Vue 3.
+    // The only way to pass the propsData is to spread componentInstance
+    // in the second argument, hoping the rest wouldn't make any side effect.
+    // At this point, we don't even have the definition of the props.
+    // So we cannot pass exactly the propsData only.
+    // FIXME: Maybe we need to get the list of props in `createServerRootMixin`.
+    app = createSSRApp(appOptions, _objectSpread({}, componentInstance));
+    if (componentInstance.$router) {
+      app.use(componentInstance.$router);
+    }
+    if (componentInstance.$store) {
+      app.use(componentInstance.$store);
+    }
+  } else {
+    const Extended = componentInstance.$vnode
+      ? componentInstance.$vnode.componentOptions.Ctor.extend(options)
+      : Vue2.component(Object.assign({}, componentInstance.$options, options));
+
+    app = new Extended({
+      propsData: componentInstance.$options.propsData,
+      mixins: [...mixins],
+    });
+  }
 
   // https://stackoverflow.com/a/48195006/3185307
   app.$slots = componentInstance.$slots;
   app.$root = componentInstance.$root;
-  app.$options.serverPrefetch = [];
+  if (isVue2) {
+    app.$options.serverPrefetch = [];
+  } else {
+    // FIXME: ???
+  }
 
   return app;
 }
@@ -88,36 +134,35 @@ function augmentInstantSearch(
    * @returns {Promise} result of the search, to save for .hydrate
    */
   search.findResultsState = function(componentInstance) {
-    let _renderToString;
-    try {
-      _renderToString = require('vue-server-renderer/basic');
-    } catch (e) {
-      // error is handled by regular if, in case it's `undefined`
-    }
-    if (!_renderToString) {
-      throw new Error('you need to install vue-server-renderer');
-    }
-
     let app;
+    let renderedApp;
 
     return Promise.resolve()
       .then(() => {
-        app = cloneComponent(componentInstance);
+        app = cloneComponent(componentInstance, {
+          mixins: [
+            {
+              created() {
+                // eslint-disable-next-line consistent-this
+                renderedApp = this;
+                this.instantsearch.helper = helper;
+                this.instantsearch.mainHelper = helper;
 
-        app.instantsearch.helper = helper;
-        app.instantsearch.mainHelper = helper;
-
-        app.instantsearch.mainIndex.init({
-          instantSearchInstance: app.instantsearch,
-          parent: null,
-          uiState: app.instantsearch._initialUiState,
+                this.instantsearch.mainIndex.init({
+                  instantSearchInstance: this.instantsearch,
+                  parent: null,
+                  uiState: this.instantsearch._initialUiState,
+                });
+              },
+            },
+          ],
         });
       })
-      .then(() => renderToString(app, _renderToString))
+      .then(() => renderToString(app))
       .then(() => searchOnlyWithDerivedHelpers(helper))
       .then(() => {
         const results = {};
-        walkIndex(app.instantsearch.mainIndex, widget => {
+        walkIndex(renderedApp.instantsearch.mainIndex, widget => {
           results[widget.getIndexId()] = widget.getResults();
         });
 

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -132,7 +132,6 @@ function augmentInstantSearch(
    */
   search.findResultsState = function(componentInstance) {
     let app;
-    let renderedApp;
 
     return Promise.resolve()
       .then(() => {
@@ -140,8 +139,6 @@ function augmentInstantSearch(
           mixins: [
             {
               created() {
-                // eslint-disable-next-line consistent-this
-                renderedApp = this;
                 this.instantsearch.helper = helper;
                 this.instantsearch.mainHelper = helper;
 
@@ -159,7 +156,7 @@ function augmentInstantSearch(
       .then(() => searchOnlyWithDerivedHelpers(helper))
       .then(() => {
         const results = {};
-        walkIndex(renderedApp.instantsearch.mainIndex, widget => {
+        walkIndex(app.instantsearch.mainIndex, widget => {
           results[widget.getIndexId()] = widget.getResults();
         });
 

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -68,11 +68,6 @@ function defaultCloneComponent(componentInstance, { mixins = [] } = {}) {
     _base: undefined,
     name: 'ais-ssr-root-component',
   };
-  if (isVue2) {
-    // copy over global Vue APIs
-    options.router = componentInstance.$router;
-    options.store = componentInstance.$store;
-  }
 
   let app;
 
@@ -93,6 +88,10 @@ function defaultCloneComponent(componentInstance, { mixins = [] } = {}) {
       app.use(componentInstance.$store);
     }
   } else {
+    // copy over global Vue APIs
+    options.router = componentInstance.$router;
+    options.store = componentInstance.$store;
+
     const Extended = componentInstance.$vnode
       ? componentInstance.$vnode.componentOptions.Ctor.extend(options)
       : Vue2.component(Object.assign({}, componentInstance.$options, options));


### PR DESCRIPTION
## Summary

This PR updates the implementation of `createServerRootMixin`.
It excludes the test cases for vue 3 about forwarding $root and $slots. I haven't figured it out, and if it's really necessary, etc.

I will try it out separately and if so, I'll probably do it in a separate PR as a fix (because I don't think I'll do it immediately).

---

It's normal that the CI doesn't pass here. It's fixed in https://github.com/algolia/vue-instantsearch/pull/1021 because

```
feat/vue3-compat
  ㄴ test: update tests compatible for both vue 2 and vue 3 [1/2] #1014
    ㄴ this PR
       ㄴ  test: update tests compatible for both vue 2 and vue 3 [2/2] #1021
```

However once it's approved, I will rebase this and merge it as an individual commit to `feat/vue3-compat` (not mixing with the "update tests" PRs).