### PR TITLE
 test: update tests compatible for both vue 2 and vue 3 [2/2]

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,5 @@ coverage/
 dist/
 examples/*/node_modules/*
 scripts/es-index-template.js
+website/examples/*
+website/stories/*

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -13,10 +13,27 @@ expect.addSnapshotSerializer(
   })
 );
 
+const toHaveBooleanAttribute = attribute => wrapper => {
+  // vue2: https://codesandbox.io/s/optimistic-blackwell-enw30
+  // vue3: https://codesandbox.io/s/affectionate-vaughan-f6sf0
+  const value = wrapper.attributes(attribute);
+  if ((isVue2 && value === attribute) || (isVue3 && value === '')) {
+    return { pass: true };
+  } else {
+    return {
+      pass: false,
+      message: () => `expected ${wrapper} to have \`${attribute}\` attribute`,
+    };
+  }
+};
+
 expect.extend({
-  toHaveEmptyHTML: received => {
-    const html = received.html();
-    if ((isVue2 && html === '') || (isVue3 && html === '<!---->')) {
+  toHaveEmptyHTML: wrapper => {
+    const html = wrapper.html();
+    if (
+      (isVue2 && html === '') ||
+      (isVue3 && ['<!---->', '<!--v-if-->'].includes(html))
+    ) {
       return {
         pass: true,
       };
@@ -27,4 +44,7 @@ expect.extend({
       };
     }
   },
+  toBeDisabled: toHaveBooleanAttribute('disabled'),
+  toBeHidden: toHaveBooleanAttribute('hidden'),
+  toBeAutofocused: toHaveBooleanAttribute('autofocus'),
 });

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -14,8 +14,11 @@ expect.addSnapshotSerializer(
 );
 
 const toHaveBooleanAttribute = attribute => wrapper => {
-  // vue2: https://codesandbox.io/s/optimistic-blackwell-enw30
-  // vue3: https://codesandbox.io/s/affectionate-vaughan-f6sf0
+  // :hidden="true" becomes
+  // hidden="hidden" in Vue 2 and
+  // hidden="" in Vue 3.
+
+  // So we need this to write correct tests to match them in both versions.
   const value = wrapper.attributes(attribute);
   if ((isVue2 && value === attribute) || (isVue3 && value === '')) {
     return { pass: true };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -13,6 +13,23 @@ expect.addSnapshotSerializer(
   })
 );
 
+const toHaveEmptyHTML = wrapper => {
+  const html = wrapper.html();
+  if (
+    (isVue2 && html === '') ||
+    (isVue3 && ['<!---->', '<!--v-if-->'].includes(html))
+  ) {
+    return {
+      pass: true,
+    };
+  } else {
+    return {
+      pass: false,
+      message: () => `expected ${html} to be an empty HTML string`,
+    };
+  }
+};
+
 const toHaveBooleanAttribute = attribute => wrapper => {
   // :hidden="true" becomes
   // hidden="hidden" in Vue 2 and
@@ -31,22 +48,7 @@ const toHaveBooleanAttribute = attribute => wrapper => {
 };
 
 expect.extend({
-  toHaveEmptyHTML: wrapper => {
-    const html = wrapper.html();
-    if (
-      (isVue2 && html === '') ||
-      (isVue3 && ['<!---->', '<!--v-if-->'].includes(html))
-    ) {
-      return {
-        pass: true,
-      };
-    } else {
-      return {
-        pass: false,
-        message: () => `expected ${html} to be an empty HTML string`,
-      };
-    }
-  },
+  toHaveEmptyHTML,
   toBeDisabled: toHaveBooleanAttribute('disabled'),
   toBeHidden: toHaveBooleanAttribute('hidden'),
   toBeAutofocused: toHaveBooleanAttribute('autofocus'),

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     },
     {
       "path": "./dist/vue3/umd/index.js",
-      "maxSize": "54.50 kB"
+      "maxSize": "55.50 kB"
     },
     {
       "path": "./dist/vue3/cjs/index.js",

--- a/src/components/CurrentRefinements.vue
+++ b/src/components/CurrentRefinements.vue
@@ -20,7 +20,7 @@
             :item="item"
             :createURL="state.createURL"
           >
-            <span :class="suit('label')">{{ item.label | capitalize }}: </span>
+            <span :class="suit('label')">{{ capitalize(item.label) }}: </span>
             <span
               v-for="refinement in item.refinements"
               :key="createItemKey(refinement)"
@@ -99,8 +99,6 @@ export default {
     createItemKey({ attribute, value, type, operator }) {
       return [attribute, type, value, operator].join(':');
     },
-  },
-  filters: {
     capitalize(value) {
       if (!value) return '';
       return (

--- a/src/components/DynamicWidgets.js
+++ b/src/components/DynamicWidgets.js
@@ -1,9 +1,12 @@
 import { createWidgetMixin } from '../mixins/widget';
 import { EXPERIMENTAL_connectDynamicWidgets } from 'instantsearch.js/es/connectors';
 import { createSuitMixin } from '../mixins/suit';
+import { isVue3, h as _h } from '../util/vue-compat';
 
 function getWidgetAttribute(vnode) {
-  const props = vnode.componentOptions && vnode.componentOptions.propsData;
+  const props = isVue3
+    ? vnode.props
+    : vnode.componentOptions && vnode.componentOptions.propsData;
   if (props) {
     if (props.attribute) {
       return props.attribute;
@@ -13,10 +16,16 @@ function getWidgetAttribute(vnode) {
     }
   }
 
-  const children =
-    vnode.componentOptions && vnode.componentOptions.children
-      ? vnode.componentOptions.children
-      : vnode.children;
+  let children;
+  if (isVue3) {
+    children =
+      vnode.children && vnode.children.default && vnode.children.default();
+  } else {
+    children =
+      vnode.componentOptions && vnode.componentOptions.children
+        ? vnode.componentOptions.children
+        : vnode.children;
+  }
 
   if (Array.isArray(children)) {
     // return first child with a truthy attribute
@@ -43,16 +52,17 @@ export default {
   },
   render(createElement) {
     const components = new Map();
-    (this.$slots.default || []).forEach(vnode => {
+    const h = isVue3 ? _h : createElement;
+    const defaultSlot = isVue3
+      ? this.$slots.default && this.$slots.default()
+      : this.$slots.default;
+
+    (defaultSlot || []).forEach(vnode => {
       const attribute = getWidgetAttribute(vnode);
       if (attribute) {
         components.set(
           attribute,
-          createElement(
-            'div',
-            { key: attribute, class: [this.suit('widget')] },
-            [vnode]
-          )
+          h('div', { key: attribute, class: [this.suit('widget')] }, [vnode])
         );
       }
     });
@@ -62,14 +72,17 @@ export default {
       const allComponents = [];
       components.forEach(component => allComponents.push(component));
 
-      return createElement(
+      return h(
         'div',
-        { attrs: { hidden: true }, class: [this.suit()] },
+        {
+          class: [this.suit()],
+          ...(isVue3 ? { hidden: true } : { attrs: { hidden: true } }),
+        },
         allComponents
       );
     }
 
-    return createElement(
+    return h(
       'div',
       { class: [this.suit()] },
       this.state.attributesToRender.map(attribute => components.get(attribute))

--- a/src/components/DynamicWidgets.js
+++ b/src/components/DynamicWidgets.js
@@ -1,6 +1,7 @@
 import { createWidgetMixin } from '../mixins/widget';
 import { EXPERIMENTAL_connectDynamicWidgets } from 'instantsearch.js/es/connectors';
 import { createSuitMixin } from '../mixins/suit';
+import { _objectSpread } from '../util/polyfills';
 import { isVue3, h as _h } from '../util/vue-compat';
 
 function getWidgetAttribute(vnode) {
@@ -74,10 +75,12 @@ export default {
 
       return h(
         'div',
-        {
-          class: [this.suit()],
-          ...(isVue3 ? { hidden: true } : { attrs: { hidden: true } }),
-        },
+        _objectSpread(
+          {
+            class: [this.suit()],
+          },
+          isVue3 ? { hidden: true } : { attrs: { hidden: true } }
+        ),
         allComponents
       );
     }

--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -21,15 +21,44 @@
         :class-names="classNames"
         v-model="currentRefinement"
       >
+        <template
+          v-slot:loading-indicator
+          v-if="isVue3"
+        >
+          <slot
+            name="loading-indicator"
+          />
+        </template>
         <slot
+          v-if="isVue2"
           name="loading-indicator"
           slot="loading-indicator"
         />
+
+        <template
+          v-slot:submit-icon
+          v-if="isVue3"
+        >
+          <slot
+            name="submit-icon"
+          />
+        </template>
         <slot
+          v-if="isVue2"
           name="submit-icon"
           slot="submit-icon"
         />
+
+        <template
+          v-slot:reset-icon
+          v-if="isVue3"
+        >
+          <slot
+            name="reset-icon"
+          />
+        </template>
         <slot
+          v-if="isVue2"
           name="reset-icon"
           slot="reset-icon"
         />
@@ -42,6 +71,7 @@
 import { connectSearchBox } from 'instantsearch.js/es/connectors';
 import { createSuitMixin } from '../mixins/suit';
 import { createWidgetMixin } from '../mixins/widget';
+import { isVue3, isVue2 } from '../util/vue-compat';
 import SearchInput from './SearchInput.vue';
 
 export default {
@@ -86,6 +116,8 @@ export default {
   data() {
     return {
       localValue: '',
+      isVue2,
+      isVue3,
     };
   },
   computed: {

--- a/src/components/__tests__/Breadcrumb.js
+++ b/src/components/__tests__/Breadcrumb.js
@@ -157,10 +157,7 @@ describe('default render', () => {
       propsData: defaultProps,
     });
 
-    await wrapper
-      .findAll('a')
-      .at(0)
-      .trigger('click');
+    await wrapper.find('a').trigger('click');
 
     expect(refine).toHaveBeenCalledTimes(1);
     expect(refine).toHaveBeenCalledWith();
@@ -178,10 +175,7 @@ describe('default render', () => {
       propsData: defaultProps,
     });
 
-    await wrapper
-      .findAll('a')
-      .at(1)
-      .trigger('click');
+    await wrapper.find('a:nth-child(2)').trigger('click');
 
     expect(refine).toHaveBeenCalledTimes(1);
     expect(refine).toHaveBeenCalledWith('TV & Home Theater');
@@ -313,10 +307,7 @@ describe('custom default render', () => {
       `,
     });
 
-    await wrapper
-      .findAll('a')
-      .at(0)
-      .trigger('click');
+    await wrapper.find('a').trigger('click');
 
     expect(refine).toHaveBeenCalledTimes(1);
     expect(refine).toHaveBeenCalledWith('TV & Home Theater');
@@ -324,18 +315,19 @@ describe('custom default render', () => {
 });
 
 describe('custom rootLabel render', () => {
-  const rootLabelSlot = `
-    <template>Home page</template>
-  `;
-
   it('renders correctly', () => {
     __setState({ ...defaultState });
 
-    const wrapper = mount(Breadcrumb, {
-      propsData: defaultProps,
-      slots: {
-        rootLabel: rootLabelSlot,
+    const wrapper = mount({
+      components: { Breadcrumb },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <Breadcrumb v-bind="props">
+          <template v-slot:rootLabel>Home page</template>
+        </Breadcrumb>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -348,11 +340,16 @@ describe('custom rootLabel render', () => {
       canRefine: false,
     });
 
-    const wrapper = mount(Breadcrumb, {
-      propsData: defaultProps,
-      slots: {
-        rootLabel: rootLabelSlot,
+    const wrapper = mount({
+      components: { Breadcrumb },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <Breadcrumb v-bind="props">
+          <template v-slot:rootLabel>Home page</template>
+        </Breadcrumb>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();
@@ -360,18 +357,19 @@ describe('custom rootLabel render', () => {
 });
 
 describe('custom separator render', () => {
-  const separatorSlot = `
-    <template>~~</template>
-  `;
-
   it('renders correctly', () => {
     __setState({ ...defaultState });
 
-    const wrapper = mount(Breadcrumb, {
-      propsData: defaultProps,
-      slots: {
-        separator: separatorSlot,
+    const wrapper = mount({
+      components: { Breadcrumb },
+      data() {
+        return { props: defaultProps };
       },
+      template: `
+        <Breadcrumb v-bind="props">
+          <template v-slot:separator>~~</template>
+        </Breadcrumb>
+      `,
     });
 
     expect(wrapper.html()).toMatchSnapshot();

--- a/src/components/__tests__/ClearRefinements.js
+++ b/src/components/__tests__/ClearRefinements.js
@@ -61,9 +61,9 @@ describe('default render', () => {
 
     const button = wrapper.find('button');
 
-    expect(button.attributes().disabled).toBe('disabled');
+    expect(button).toBeDisabled();
     expect(button.classes()).toContain('ais-ClearRefinements-button--disabled');
-    expect(wrapper.html()).toMatchSnapshot();
+    expect(wrapper.htmlCompat()).toMatchSnapshot();
   });
 
   it('calls refine on button click', async () => {

--- a/src/components/__tests__/CurrentRefinements.js
+++ b/src/components/__tests__/CurrentRefinements.js
@@ -1,4 +1,4 @@
-import { mount } from '../../../test/utils';
+import { mount, nextTick } from '../../../test/utils';
 import CurrentRefinements from '../CurrentRefinements.vue';
 import { __setState } from '../../mixins/widget';
 
@@ -177,11 +177,8 @@ it('calls the Panel mixin with `canRefine`', async () => {
 
   expect(mapStateToCanRefine()).toBe(true);
 
-  await wrapper.setData({
-    state: {
-      items: [],
-    },
-  });
+  wrapper.vm.state.items = [];
+  await nextTick();
 
   expect(mapStateToCanRefine()).toBe(false);
 

--- a/src/components/__tests__/DynamicWidgets.js
+++ b/src/components/__tests__/DynamicWidgets.js
@@ -50,27 +50,29 @@ it('renders all children without state', () => {
     },
   });
 
-  expect(wrapper.classes()).toContain('ais-DynamicWidgets');
-  expect(wrapper).toBeHidden();
-  expect(wrapper.element.innerHTML).toMatchInlineSnapshot(`
-<div class="ais-DynamicWidgets-widget">
-  <div widget-name="ais-refinement-list">
-    test1
+  expect(wrapper.htmlCompat()).toMatchInlineSnapshot(`
+<div class="ais-DynamicWidgets"
+     hidden="hidden"
+>
+  <div class="ais-DynamicWidgets-widget">
+    <div widget-name="ais-refinement-list">
+      test1
+    </div>
   </div>
-</div>
-<div class="ais-DynamicWidgets-widget">
-  <div widget-name="ais-menu">
-    test2
+  <div class="ais-DynamicWidgets-widget">
+    <div widget-name="ais-menu">
+      test2
+    </div>
   </div>
-</div>
-<div class="ais-DynamicWidgets-widget">
-  <div class="ais-Panel">
-    <div class="ais-Panel-body">
-      <div widget-name="ais-hierarchical-menu">
-        [
-  "test3",
-  "test4"
-]
+  <div class="ais-DynamicWidgets-widget">
+    <div class="ais-Panel">
+      <div class="ais-Panel-body">
+        <div widget-name="ais-hierarchical-menu">
+          [
+          "test3",
+          "test4"
+          ]
+        </div>
       </div>
     </div>
   </div>

--- a/src/components/__tests__/DynamicWidgets.js
+++ b/src/components/__tests__/DynamicWidgets.js
@@ -7,21 +7,21 @@ jest.mock('../../mixins/widget');
 const MockRefinementList = {
   props: { attribute: { type: String } },
   template: `
-    <div widget-name="ais-refinement-list">{{ attribute }}</div>
+    <div widget-name="ais-refinement-list" :attribute="attribute" />
   `,
 };
 
 const MockMenu = {
   props: { attribute: { type: String } },
   template: `
-    <div widget-name="ais-menu">{{ attribute }}</div>
+    <div widget-name="ais-menu" :attribute="attribute" />
   `,
 };
 
 const MockHierarchicalMenu = {
   props: { attributes: { type: Array } },
   template: `
-    <div widget-name="ais-hierarchical-menu">{{ attributes }}</div>
+    <div widget-name="ais-hierarchical-menu" :attributes="attributes.join(',')" />
   `,
 };
 
@@ -55,23 +55,23 @@ it('renders all children without state', () => {
      hidden="hidden"
 >
   <div class="ais-DynamicWidgets-widget">
-    <div widget-name="ais-refinement-list">
-      test1
+    <div attribute="test1"
+         widget-name="ais-refinement-list"
+    >
     </div>
   </div>
   <div class="ais-DynamicWidgets-widget">
-    <div widget-name="ais-menu">
-      test2
+    <div attribute="test2"
+         widget-name="ais-menu"
+    >
     </div>
   </div>
   <div class="ais-DynamicWidgets-widget">
     <div class="ais-Panel">
       <div class="ais-Panel-body">
-        <div widget-name="ais-hierarchical-menu">
-          [
-          "test3",
-          "test4"
-          ]
+        <div attributes="test3,test4"
+             widget-name="ais-hierarchical-menu"
+        >
         </div>
       </div>
     </div>
@@ -141,8 +141,9 @@ it('renders attributesToRender (menu)', () => {
   expect(wrapper.html()).toMatchInlineSnapshot(`
 <div class="ais-DynamicWidgets">
   <div class="ais-DynamicWidgets-widget">
-    <div widget-name="ais-menu">
-      test1
+    <div attribute="test1"
+         widget-name="ais-menu"
+    >
     </div>
   </div>
 </div>
@@ -171,8 +172,9 @@ it('renders attributesToRender (refinement list)', () => {
   expect(wrapper.html()).toMatchInlineSnapshot(`
 <div class="ais-DynamicWidgets">
   <div class="ais-DynamicWidgets-widget">
-    <div widget-name="ais-refinement-list">
-      test2
+    <div attribute="test2"
+         widget-name="ais-refinement-list"
+    >
     </div>
   </div>
 </div>
@@ -206,8 +208,9 @@ it('renders attributesToRender (panel)', () => {
   <div class="ais-DynamicWidgets-widget">
     <div class="ais-Panel">
       <div class="ais-Panel-body">
-        <div widget-name="ais-refinement-list">
-          test2
+        <div attribute="test2"
+             widget-name="ais-refinement-list"
+        >
         </div>
       </div>
     </div>
@@ -243,11 +246,9 @@ it('renders attributesToRender (hierarchical menu)', () => {
   expect(wrapper.html()).toMatchInlineSnapshot(`
 <div class="ais-DynamicWidgets">
   <div class="ais-DynamicWidgets-widget">
-    <div widget-name="ais-hierarchical-menu">
-      [
-      "test1",
-      "test2"
-      ]
+    <div attributes="test1,test2"
+         widget-name="ais-hierarchical-menu"
+    >
     </div>
   </div>
 </div>
@@ -285,11 +286,9 @@ it('updates DOM when attributesToRender changes', async () => {
   expect(wrapper.html()).toMatchInlineSnapshot(`
 <div class="ais-DynamicWidgets">
   <div class="ais-DynamicWidgets-widget">
-    <div widget-name="ais-hierarchical-menu">
-      [
-      "test1",
-      "test2"
-      ]
+    <div attributes="test1,test2"
+         widget-name="ais-hierarchical-menu"
+    >
     </div>
   </div>
 </div>
@@ -302,8 +301,9 @@ it('updates DOM when attributesToRender changes', async () => {
   expect(wrapper.html()).toMatchInlineSnapshot(`
 <div class="ais-DynamicWidgets">
   <div class="ais-DynamicWidgets-widget">
-    <div widget-name="ais-menu">
-      test3
+    <div attribute="test3"
+         widget-name="ais-menu"
+    >
     </div>
   </div>
 </div>
@@ -316,18 +316,17 @@ it('updates DOM when attributesToRender changes', async () => {
   expect(wrapper.html()).toMatchInlineSnapshot(`
 <div class="ais-DynamicWidgets">
   <div class="ais-DynamicWidgets-widget">
-    <div widget-name="ais-hierarchical-menu">
-      [
-      "test1",
-      "test2"
-      ]
+    <div attributes="test1,test2"
+         widget-name="ais-hierarchical-menu"
+    >
     </div>
   </div>
   <div class="ais-DynamicWidgets-widget">
     <div class="ais-Panel">
       <div class="ais-Panel-body">
-        <div widget-name="ais-refinement-list">
-          test4
+        <div attribute="test4"
+             widget-name="ais-refinement-list"
+        >
         </div>
       </div>
     </div>

--- a/src/components/__tests__/DynamicWidgets.js
+++ b/src/components/__tests__/DynamicWidgets.js
@@ -1,4 +1,4 @@
-import { mount } from '../../../test/utils';
+import { mount, nextTick } from '../../../test/utils';
 import DynamicWidgets from '../DynamicWidgets';
 import { __setState } from '../../mixins/widget';
 import { AisPanel } from '../../widgets';
@@ -6,89 +6,76 @@ jest.mock('../../mixins/widget');
 
 const MockRefinementList = {
   props: { attribute: { type: String } },
-  render(h) {
-    return h('div', {
-      attrs: {
-        'widget-name': 'ais-refinement-list',
-        attribute: this.attribute,
-      },
-    });
-  },
+  template: `
+    <div widget-name="ais-refinement-list">{{ attribute }}</div>
+  `,
 };
 
 const MockMenu = {
   props: { attribute: { type: String } },
-  render(h) {
-    return h('div', {
-      attrs: { 'widget-name': 'ais-menu', attribute: this.attribute },
-    });
-  },
+  template: `
+    <div widget-name="ais-menu">{{ attribute }}</div>
+  `,
 };
 
 const MockHierarchicalMenu = {
   props: { attributes: { type: Array } },
-  render(h) {
-    return h('div', {
-      attrs: {
-        'widget-name': 'ais-hierarchical-menu',
-        attributes: this.attributes,
-      },
-    });
-  },
+  template: `
+    <div widget-name="ais-hierarchical-menu">{{ attributes }}</div>
+  `,
 };
 
 it('renders all children without state', () => {
   __setState(null);
 
-  const wrapper = mount(DynamicWidgets, {
-    propsData: {
-      transformItems: items => items,
+  const wrapper = mount({
+    data() {
+      return { props: { transformItems: items => items } };
     },
-    slots: {
-      default: `
-      <ais-refinement-list attribute="test1"/>
-      <ais-menu attribute="test2"/>
-      <ais-panel>
-        <ais-hierarchical-menu :attributes="['test3', 'test4']" />
-      </ais-panel>
+    template: `
+      <DynamicWidgets v-bind="props">
+        <MockRefinementList attribute="test1"/>
+        <MockMenu attribute="test2"/>
+        <AisPanel>
+          <MockHierarchicalMenu :attributes="['test3', 'test4']" />
+        </AisPanel>
+      </DynamicWidgets>
       `,
-    },
     components: {
-      'ais-refinement-list': MockRefinementList,
-      'ais-menu': MockMenu,
-      'ais-hierarchical-menu': MockHierarchicalMenu,
+      DynamicWidgets,
+      MockRefinementList,
+      MockMenu,
+      MockHierarchicalMenu,
       AisPanel,
     },
   });
 
-  expect(wrapper.html()).toMatchInlineSnapshot(`
-<div class="ais-DynamicWidgets"
-     hidden="hidden"
->
-  <div class="ais-DynamicWidgets-widget">
-    <div attribute="test1"
-         widget-name="ais-refinement-list"
-    >
+  expect(wrapper.classes()).toContain('ais-DynamicWidgets');
+  expect(wrapper).toBeHidden();
+  expect(wrapper.element.innerHTML).toMatchInlineSnapshot(`
+    <div class="ais-DynamicWidgets-widget">
+      <div widget-name="ais-refinement-list">
+        test1
+      </div>
     </div>
-  </div>
-  <div class="ais-DynamicWidgets-widget">
-    <div attribute="test2"
-         widget-name="ais-menu"
-    >
+    <div class="ais-DynamicWidgets-widget">
+      <div widget-name="ais-menu">
+        test2
+      </div>
     </div>
-  </div>
-  <div class="ais-DynamicWidgets-widget">
-    <div class="ais-Panel">
-      <div class="ais-Panel-body">
-        <div attributes="test3,test4"
-             widget-name="ais-hierarchical-menu"
-        >
+    <div class="ais-DynamicWidgets-widget">
+      <div class="ais-Panel">
+        <div class="ais-Panel-body">
+          <div widget-name="ais-hierarchical-menu">
+            [
+      "test3",
+      "test4"
+    ]
+          </div>
         </div>
       </div>
     </div>
-  </div>
-</div>
-`);
+  `);
 });
 
 it('renders nothing without children', () => {
@@ -102,9 +89,9 @@ it('renders nothing without children', () => {
     },
   });
   expect(wrapper.html()).toMatchInlineSnapshot(`
-<div class="ais-DynamicWidgets">
-</div>
-`);
+    <div class="ais-DynamicWidgets">
+    </div>
+  `);
 });
 
 it('renders nothing with empty attributesToRender', () => {
@@ -113,21 +100,21 @@ it('renders nothing with empty attributesToRender', () => {
   });
 
   const wrapper = mount(DynamicWidgets, {
-    propsData: {
-      transformItems: items => items,
-    },
-    slots: {
-      default: `<ais-refinement-list attribute="test1"/>`,
-    },
+    template: `
+      <DynamicWidgets :transformItems="items => items">
+        <MockRefinementList attribute="test1" />
+      </DynamicWidgets>
+    `,
     components: {
-      'ais-refinement-list': MockRefinementList,
+      DynamicWidgets,
+      MockRefinementList,
     },
   });
 
   expect(wrapper.html()).toMatchInlineSnapshot(`
-<div class="ais-DynamicWidgets">
-</div>
-`);
+    <div class="ais-DynamicWidgets">
+    </div>
+  `);
 });
 
 it('renders attributesToRender (menu)', () => {
@@ -135,32 +122,29 @@ it('renders attributesToRender (menu)', () => {
     attributesToRender: ['test1'],
   });
 
-  const wrapper = mount(DynamicWidgets, {
-    propsData: {
-      transformItems: items => items,
-    },
-    slots: {
-      default: `
-        <ais-menu attribute="test1" />
-        <ais-refinement-list attribute="test2" />
-      `,
-    },
+  const wrapper = mount({
+    template: `
+      <DynamicWidgets :transformItems="items => items">
+        <MockMenu attribute="test1" />
+        <MockRefinementList attribute="test2" />
+      </DynamicWidgets>
+    `,
     components: {
-      'ais-refinement-list': MockRefinementList,
-      'ais-menu': MockMenu,
+      DynamicWidgets,
+      MockRefinementList,
+      MockMenu,
     },
   });
 
   expect(wrapper.html()).toMatchInlineSnapshot(`
-<div class="ais-DynamicWidgets">
-  <div class="ais-DynamicWidgets-widget">
-    <div attribute="test1"
-         widget-name="ais-menu"
-    >
+    <div class="ais-DynamicWidgets">
+      <div class="ais-DynamicWidgets-widget">
+        <div widget-name="ais-menu">
+          test1
+        </div>
+      </div>
     </div>
-  </div>
-</div>
-`);
+  `);
 });
 
 it('renders attributesToRender (refinement list)', () => {
@@ -168,32 +152,29 @@ it('renders attributesToRender (refinement list)', () => {
     attributesToRender: ['test2'],
   });
 
-  const wrapper = mount(DynamicWidgets, {
-    propsData: {
-      transformItems: items => items,
-    },
-    slots: {
-      default: `
-        <ais-menu attribute="test1" />
-        <ais-refinement-list attribute="test2" />
-      `,
-    },
+  const wrapper = mount({
+    template: `
+      <DynamicWidgets :transformItems="items => items">
+        <MockMenu attribute="test1" />
+        <MockRefinementList attribute="test2" />
+      </DynamicWidgets>
+    `,
     components: {
-      'ais-refinement-list': MockRefinementList,
-      'ais-menu': MockMenu,
+      DynamicWidgets,
+      MockRefinementList,
+      MockMenu,
     },
   });
 
   expect(wrapper.html()).toMatchInlineSnapshot(`
-<div class="ais-DynamicWidgets">
-  <div class="ais-DynamicWidgets-widget">
-    <div attribute="test2"
-         widget-name="ais-refinement-list"
-    >
+    <div class="ais-DynamicWidgets">
+      <div class="ais-DynamicWidgets-widget">
+        <div widget-name="ais-refinement-list">
+          test2
+        </div>
+      </div>
     </div>
-  </div>
-</div>
-`);
+  `);
 });
 
 it('renders attributesToRender (panel)', () => {
@@ -201,39 +182,36 @@ it('renders attributesToRender (panel)', () => {
     attributesToRender: ['test2'],
   });
 
-  const wrapper = mount(DynamicWidgets, {
-    propsData: {
-      transformItems: items => items,
-    },
-    slots: {
-      default: `
-        <ais-menu attribute="test1" />
-        <ais-panel>
-          <ais-refinement-list attribute="test2" />
-        </ais-panel>
-      `,
-    },
+  const wrapper = mount({
+    template: `
+      <DynamicWidgets :transformItems="items => items">
+        <MockMenu attribute="test1" />
+        <AisPanel>
+          <MockRefinementList attribute="test2" />
+        </AisPanel>
+      </DynamicWidgets>
+    `,
     components: {
-      'ais-refinement-list': MockRefinementList,
-      'ais-menu': MockMenu,
+      DynamicWidgets,
+      MockRefinementList,
+      MockMenu,
       AisPanel,
     },
   });
 
   expect(wrapper.html()).toMatchInlineSnapshot(`
-<div class="ais-DynamicWidgets">
-  <div class="ais-DynamicWidgets-widget">
-    <div class="ais-Panel">
-      <div class="ais-Panel-body">
-        <div attribute="test2"
-             widget-name="ais-refinement-list"
-        >
+    <div class="ais-DynamicWidgets">
+      <div class="ais-DynamicWidgets-widget">
+        <div class="ais-Panel">
+          <div class="ais-Panel-body">
+            <div widget-name="ais-refinement-list">
+              test2
+            </div>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-</div>
-`);
+  `);
 });
 
 it('renders attributesToRender (hierarchical menu)', () => {
@@ -241,118 +219,126 @@ it('renders attributesToRender (hierarchical menu)', () => {
     attributesToRender: ['test1'],
   });
 
-  const wrapper = mount(DynamicWidgets, {
-    propsData: {
-      transformItems: items => items,
-    },
-    slots: {
-      default: `
-        <ais-hierarchical-menu :attributes="['test1','test2']" />
-        <ais-menu attribute="test3" />
-        <ais-panel>
-          <ais-refinement-list attribute="test4" />
-        </ais-panel>
-      `,
-    },
+  const wrapper = mount({
+    template: `
+      <DynamicWidgets :transformItems="items => items">
+        <MockHierarchicalMenu :attributes="['test1','test2']" />
+        <MockMenu attribute="test3" />
+        <AisPanel>
+          <MockRefinementList attribute="test4" />
+        </AisPanel>
+      </DynamicWidgets>
+    `,
     components: {
-      'ais-refinement-list': MockRefinementList,
-      'ais-menu': MockMenu,
-      'ais-hierarchical-menu': MockHierarchicalMenu,
+      DynamicWidgets,
+      MockRefinementList,
+      MockMenu,
+      MockHierarchicalMenu,
       AisPanel,
     },
   });
 
   expect(wrapper.html()).toMatchInlineSnapshot(`
-<div class="ais-DynamicWidgets">
-  <div class="ais-DynamicWidgets-widget">
-    <div attributes="test1,test2"
-         widget-name="ais-hierarchical-menu"
-    >
-    </div>
-  </div>
-</div>
-`);
-});
-
-it('updates DOM when attributesToRender changes', async () => {
-  const attributesToRender = ['test1'];
-
-  __setState({
-    attributesToRender,
-  });
-
-  const wrapper = mount(DynamicWidgets, {
-    propsData: {
-      transformItems: items => items,
-    },
-    slots: {
-      default: `
-        <ais-hierarchical-menu :attributes="['test1','test2']" />
-        <ais-menu attribute="test3" />
-        <ais-panel>
-          <ais-refinement-list attribute="test4" />
-        </ais-panel>
-      `,
-    },
-    components: {
-      'ais-refinement-list': MockRefinementList,
-      'ais-menu': MockMenu,
-      'ais-hierarchical-menu': MockHierarchicalMenu,
-      AisPanel,
-    },
-  });
-
-  expect(wrapper.html()).toMatchInlineSnapshot(`
-<div class="ais-DynamicWidgets">
-  <div class="ais-DynamicWidgets-widget">
-    <div attributes="test1,test2"
-         widget-name="ais-hierarchical-menu"
-    >
-    </div>
-  </div>
-</div>
-`);
-
-  await wrapper.setData({ state: { attributesToRender: ['test3'] } });
-
-  expect(wrapper.html()).toMatchInlineSnapshot(`
-<div class="ais-DynamicWidgets">
-  <div class="ais-DynamicWidgets-widget">
-    <div attribute="test3"
-         widget-name="ais-menu"
-    >
-    </div>
-  </div>
-</div>
-`);
-
-  await wrapper.setData({ state: { attributesToRender: ['test1', 'test4'] } });
-
-  expect(wrapper.html()).toMatchInlineSnapshot(`
-<div class="ais-DynamicWidgets">
-  <div class="ais-DynamicWidgets-widget">
-    <div attributes="test1,test2"
-         widget-name="ais-hierarchical-menu"
-    >
-    </div>
-  </div>
-  <div class="ais-DynamicWidgets-widget">
-    <div class="ais-Panel">
-      <div class="ais-Panel-body">
-        <div attribute="test4"
-             widget-name="ais-refinement-list"
-        >
+    <div class="ais-DynamicWidgets">
+      <div class="ais-DynamicWidgets-widget">
+        <div widget-name="ais-hierarchical-menu">
+          [
+          "test1",
+          "test2"
+          ]
         </div>
       </div>
     </div>
-  </div>
-</div>
-`);
+  `);
+});
 
-  await wrapper.setData({ state: { attributesToRender: [] } });
+it('updates DOM when attributesToRender changes', async () => {
+  let attributesToRender = ['test1'];
+
+  __setState({
+    get attributesToRender() {
+      return attributesToRender;
+    },
+  });
+
+  const wrapper = mount({
+    template: `
+      <DynamicWidgets :transformItems="items => items">
+        <MockHierarchicalMenu :attributes="['test1','test2']" />
+        <MockMenu attribute="test3" />
+        <AisPanel>
+          <MockRefinementList attribute="test4" />
+        </AisPanel>
+      </DynamicWidgets>
+    `,
+    components: {
+      DynamicWidgets,
+      MockRefinementList,
+      MockMenu,
+      MockHierarchicalMenu,
+      AisPanel,
+    },
+  });
 
   expect(wrapper.html()).toMatchInlineSnapshot(`
-<div class="ais-DynamicWidgets">
-</div>
-`);
+    <div class="ais-DynamicWidgets">
+      <div class="ais-DynamicWidgets-widget">
+        <div widget-name="ais-hierarchical-menu">
+          [
+          "test1",
+          "test2"
+          ]
+        </div>
+      </div>
+    </div>
+  `);
+
+  attributesToRender = ['test3'];
+  wrapper.vm.$forceUpdate();
+  await nextTick();
+
+  expect(wrapper.html()).toMatchInlineSnapshot(`
+    <div class="ais-DynamicWidgets">
+      <div class="ais-DynamicWidgets-widget">
+        <div widget-name="ais-menu">
+          test3
+        </div>
+      </div>
+    </div>
+  `);
+
+  attributesToRender = ['test1', 'test4'];
+  wrapper.vm.$forceUpdate();
+  await nextTick();
+
+  expect(wrapper.html()).toMatchInlineSnapshot(`
+    <div class="ais-DynamicWidgets">
+      <div class="ais-DynamicWidgets-widget">
+        <div widget-name="ais-hierarchical-menu">
+          [
+          "test1",
+          "test2"
+          ]
+        </div>
+      </div>
+      <div class="ais-DynamicWidgets-widget">
+        <div class="ais-Panel">
+          <div class="ais-Panel-body">
+            <div widget-name="ais-refinement-list">
+              test4
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  `);
+
+  attributesToRender = [];
+  wrapper.vm.$forceUpdate();
+  await nextTick();
+
+  expect(wrapper.html()).toMatchInlineSnapshot(`
+    <div class="ais-DynamicWidgets">
+    </div>
+  `);
 });

--- a/src/components/__tests__/DynamicWidgets.js
+++ b/src/components/__tests__/DynamicWidgets.js
@@ -7,21 +7,42 @@ jest.mock('../../mixins/widget');
 const MockRefinementList = {
   props: { attribute: { type: String } },
   template: `
-    <div widget-name="ais-refinement-list" :attribute="attribute" />
+    <div>
+      {{
+        JSON.stringify({
+          widgetName: "ais-refinement-list",
+          attribute,
+        }, null, 2)
+      }}
+    </div>
   `,
 };
 
 const MockMenu = {
   props: { attribute: { type: String } },
   template: `
-    <div widget-name="ais-menu" :attribute="attribute" />
+    <div>
+      {{
+        JSON.stringify({
+          widgetName: "ais-menu",
+          attribute,
+        }, null, 2)
+      }}
+    </div>
   `,
 };
 
 const MockHierarchicalMenu = {
   props: { attributes: { type: Array } },
   template: `
-    <div widget-name="ais-hierarchical-menu" :attributes="attributes.join(',')" />
+    <div>
+      {{
+        JSON.stringify({
+          widgetName: "ais-hierarchical-menu",
+          attributes
+        }, null, 2)
+      }}
+    </div>
   `,
 };
 
@@ -55,23 +76,32 @@ it('renders all children without state', () => {
      hidden="hidden"
 >
   <div class="ais-DynamicWidgets-widget">
-    <div attribute="test1"
-         widget-name="ais-refinement-list"
-    >
+    <div>
+      {
+      "widgetName": "ais-refinement-list",
+      "attribute": "test1"
+      }
     </div>
   </div>
   <div class="ais-DynamicWidgets-widget">
-    <div attribute="test2"
-         widget-name="ais-menu"
-    >
+    <div>
+      {
+      "widgetName": "ais-menu",
+      "attribute": "test2"
+      }
     </div>
   </div>
   <div class="ais-DynamicWidgets-widget">
     <div class="ais-Panel">
       <div class="ais-Panel-body">
-        <div attributes="test3,test4"
-             widget-name="ais-hierarchical-menu"
-        >
+        <div>
+          {
+          "widgetName": "ais-hierarchical-menu",
+          "attributes": [
+          "test3",
+          "test4"
+          ]
+          }
         </div>
       </div>
     </div>
@@ -141,9 +171,11 @@ it('renders attributesToRender (menu)', () => {
   expect(wrapper.html()).toMatchInlineSnapshot(`
 <div class="ais-DynamicWidgets">
   <div class="ais-DynamicWidgets-widget">
-    <div attribute="test1"
-         widget-name="ais-menu"
-    >
+    <div>
+      {
+      "widgetName": "ais-menu",
+      "attribute": "test1"
+      }
     </div>
   </div>
 </div>
@@ -172,9 +204,11 @@ it('renders attributesToRender (refinement list)', () => {
   expect(wrapper.html()).toMatchInlineSnapshot(`
 <div class="ais-DynamicWidgets">
   <div class="ais-DynamicWidgets-widget">
-    <div attribute="test2"
-         widget-name="ais-refinement-list"
-    >
+    <div>
+      {
+      "widgetName": "ais-refinement-list",
+      "attribute": "test2"
+      }
     </div>
   </div>
 </div>
@@ -208,9 +242,11 @@ it('renders attributesToRender (panel)', () => {
   <div class="ais-DynamicWidgets-widget">
     <div class="ais-Panel">
       <div class="ais-Panel-body">
-        <div attribute="test2"
-             widget-name="ais-refinement-list"
-        >
+        <div>
+          {
+          "widgetName": "ais-refinement-list",
+          "attribute": "test2"
+          }
         </div>
       </div>
     </div>
@@ -246,9 +282,14 @@ it('renders attributesToRender (hierarchical menu)', () => {
   expect(wrapper.html()).toMatchInlineSnapshot(`
 <div class="ais-DynamicWidgets">
   <div class="ais-DynamicWidgets-widget">
-    <div attributes="test1,test2"
-         widget-name="ais-hierarchical-menu"
-    >
+    <div>
+      {
+      "widgetName": "ais-hierarchical-menu",
+      "attributes": [
+      "test1",
+      "test2"
+      ]
+      }
     </div>
   </div>
 </div>
@@ -286,9 +327,14 @@ it('updates DOM when attributesToRender changes', async () => {
   expect(wrapper.html()).toMatchInlineSnapshot(`
 <div class="ais-DynamicWidgets">
   <div class="ais-DynamicWidgets-widget">
-    <div attributes="test1,test2"
-         widget-name="ais-hierarchical-menu"
-    >
+    <div>
+      {
+      "widgetName": "ais-hierarchical-menu",
+      "attributes": [
+      "test1",
+      "test2"
+      ]
+      }
     </div>
   </div>
 </div>
@@ -301,9 +347,11 @@ it('updates DOM when attributesToRender changes', async () => {
   expect(wrapper.html()).toMatchInlineSnapshot(`
 <div class="ais-DynamicWidgets">
   <div class="ais-DynamicWidgets-widget">
-    <div attribute="test3"
-         widget-name="ais-menu"
-    >
+    <div>
+      {
+      "widgetName": "ais-menu",
+      "attribute": "test3"
+      }
     </div>
   </div>
 </div>
@@ -316,17 +364,24 @@ it('updates DOM when attributesToRender changes', async () => {
   expect(wrapper.html()).toMatchInlineSnapshot(`
 <div class="ais-DynamicWidgets">
   <div class="ais-DynamicWidgets-widget">
-    <div attributes="test1,test2"
-         widget-name="ais-hierarchical-menu"
-    >
+    <div>
+      {
+      "widgetName": "ais-hierarchical-menu",
+      "attributes": [
+      "test1",
+      "test2"
+      ]
+      }
     </div>
   </div>
   <div class="ais-DynamicWidgets-widget">
     <div class="ais-Panel">
       <div class="ais-Panel-body">
-        <div attribute="test4"
-             widget-name="ais-refinement-list"
-        >
+        <div>
+          {
+          "widgetName": "ais-refinement-list",
+          "attribute": "test4"
+          }
         </div>
       </div>
     </div>

--- a/src/components/__tests__/DynamicWidgets.js
+++ b/src/components/__tests__/DynamicWidgets.js
@@ -53,29 +53,29 @@ it('renders all children without state', () => {
   expect(wrapper.classes()).toContain('ais-DynamicWidgets');
   expect(wrapper).toBeHidden();
   expect(wrapper.element.innerHTML).toMatchInlineSnapshot(`
-    <div class="ais-DynamicWidgets-widget">
-      <div widget-name="ais-refinement-list">
-        test1
+<div class="ais-DynamicWidgets-widget">
+  <div widget-name="ais-refinement-list">
+    test1
+  </div>
+</div>
+<div class="ais-DynamicWidgets-widget">
+  <div widget-name="ais-menu">
+    test2
+  </div>
+</div>
+<div class="ais-DynamicWidgets-widget">
+  <div class="ais-Panel">
+    <div class="ais-Panel-body">
+      <div widget-name="ais-hierarchical-menu">
+        [
+  "test3",
+  "test4"
+]
       </div>
     </div>
-    <div class="ais-DynamicWidgets-widget">
-      <div widget-name="ais-menu">
-        test2
-      </div>
-    </div>
-    <div class="ais-DynamicWidgets-widget">
-      <div class="ais-Panel">
-        <div class="ais-Panel-body">
-          <div widget-name="ais-hierarchical-menu">
-            [
-      "test3",
-      "test4"
-    ]
-          </div>
-        </div>
-      </div>
-    </div>
-  `);
+  </div>
+</div>
+`);
 });
 
 it('renders nothing without children', () => {
@@ -89,9 +89,9 @@ it('renders nothing without children', () => {
     },
   });
   expect(wrapper.html()).toMatchInlineSnapshot(`
-    <div class="ais-DynamicWidgets">
-    </div>
-  `);
+<div class="ais-DynamicWidgets">
+</div>
+`);
 });
 
 it('renders nothing with empty attributesToRender', () => {
@@ -112,9 +112,9 @@ it('renders nothing with empty attributesToRender', () => {
   });
 
   expect(wrapper.html()).toMatchInlineSnapshot(`
-    <div class="ais-DynamicWidgets">
-    </div>
-  `);
+<div class="ais-DynamicWidgets">
+</div>
+`);
 });
 
 it('renders attributesToRender (menu)', () => {
@@ -137,14 +137,14 @@ it('renders attributesToRender (menu)', () => {
   });
 
   expect(wrapper.html()).toMatchInlineSnapshot(`
-    <div class="ais-DynamicWidgets">
-      <div class="ais-DynamicWidgets-widget">
-        <div widget-name="ais-menu">
-          test1
-        </div>
-      </div>
+<div class="ais-DynamicWidgets">
+  <div class="ais-DynamicWidgets-widget">
+    <div widget-name="ais-menu">
+      test1
     </div>
-  `);
+  </div>
+</div>
+`);
 });
 
 it('renders attributesToRender (refinement list)', () => {
@@ -167,14 +167,14 @@ it('renders attributesToRender (refinement list)', () => {
   });
 
   expect(wrapper.html()).toMatchInlineSnapshot(`
-    <div class="ais-DynamicWidgets">
-      <div class="ais-DynamicWidgets-widget">
-        <div widget-name="ais-refinement-list">
-          test2
-        </div>
-      </div>
+<div class="ais-DynamicWidgets">
+  <div class="ais-DynamicWidgets-widget">
+    <div widget-name="ais-refinement-list">
+      test2
     </div>
-  `);
+  </div>
+</div>
+`);
 });
 
 it('renders attributesToRender (panel)', () => {
@@ -200,18 +200,18 @@ it('renders attributesToRender (panel)', () => {
   });
 
   expect(wrapper.html()).toMatchInlineSnapshot(`
-    <div class="ais-DynamicWidgets">
-      <div class="ais-DynamicWidgets-widget">
-        <div class="ais-Panel">
-          <div class="ais-Panel-body">
-            <div widget-name="ais-refinement-list">
-              test2
-            </div>
-          </div>
+<div class="ais-DynamicWidgets">
+  <div class="ais-DynamicWidgets-widget">
+    <div class="ais-Panel">
+      <div class="ais-Panel-body">
+        <div widget-name="ais-refinement-list">
+          test2
         </div>
       </div>
     </div>
-  `);
+  </div>
+</div>
+`);
 });
 
 it('renders attributesToRender (hierarchical menu)', () => {
@@ -239,17 +239,17 @@ it('renders attributesToRender (hierarchical menu)', () => {
   });
 
   expect(wrapper.html()).toMatchInlineSnapshot(`
-    <div class="ais-DynamicWidgets">
-      <div class="ais-DynamicWidgets-widget">
-        <div widget-name="ais-hierarchical-menu">
-          [
-          "test1",
-          "test2"
-          ]
-        </div>
-      </div>
+<div class="ais-DynamicWidgets">
+  <div class="ais-DynamicWidgets-widget">
+    <div widget-name="ais-hierarchical-menu">
+      [
+      "test1",
+      "test2"
+      ]
     </div>
-  `);
+  </div>
+</div>
+`);
 });
 
 it('updates DOM when attributesToRender changes', async () => {
@@ -281,64 +281,64 @@ it('updates DOM when attributesToRender changes', async () => {
   });
 
   expect(wrapper.html()).toMatchInlineSnapshot(`
-    <div class="ais-DynamicWidgets">
-      <div class="ais-DynamicWidgets-widget">
-        <div widget-name="ais-hierarchical-menu">
-          [
-          "test1",
-          "test2"
-          ]
-        </div>
-      </div>
+<div class="ais-DynamicWidgets">
+  <div class="ais-DynamicWidgets-widget">
+    <div widget-name="ais-hierarchical-menu">
+      [
+      "test1",
+      "test2"
+      ]
     </div>
-  `);
+  </div>
+</div>
+`);
 
   attributesToRender = ['test3'];
   wrapper.vm.$forceUpdate();
   await nextTick();
 
   expect(wrapper.html()).toMatchInlineSnapshot(`
-    <div class="ais-DynamicWidgets">
-      <div class="ais-DynamicWidgets-widget">
-        <div widget-name="ais-menu">
-          test3
-        </div>
-      </div>
+<div class="ais-DynamicWidgets">
+  <div class="ais-DynamicWidgets-widget">
+    <div widget-name="ais-menu">
+      test3
     </div>
-  `);
+  </div>
+</div>
+`);
 
   attributesToRender = ['test1', 'test4'];
   wrapper.vm.$forceUpdate();
   await nextTick();
 
   expect(wrapper.html()).toMatchInlineSnapshot(`
-    <div class="ais-DynamicWidgets">
-      <div class="ais-DynamicWidgets-widget">
-        <div widget-name="ais-hierarchical-menu">
-          [
-          "test1",
-          "test2"
-          ]
-        </div>
-      </div>
-      <div class="ais-DynamicWidgets-widget">
-        <div class="ais-Panel">
-          <div class="ais-Panel-body">
-            <div widget-name="ais-refinement-list">
-              test4
-            </div>
-          </div>
+<div class="ais-DynamicWidgets">
+  <div class="ais-DynamicWidgets-widget">
+    <div widget-name="ais-hierarchical-menu">
+      [
+      "test1",
+      "test2"
+      ]
+    </div>
+  </div>
+  <div class="ais-DynamicWidgets-widget">
+    <div class="ais-Panel">
+      <div class="ais-Panel-body">
+        <div widget-name="ais-refinement-list">
+          test4
         </div>
       </div>
     </div>
-  `);
+  </div>
+</div>
+`);
 
   attributesToRender = [];
   wrapper.vm.$forceUpdate();
   await nextTick();
 
   expect(wrapper.html()).toMatchInlineSnapshot(`
-    <div class="ais-DynamicWidgets">
-    </div>
-  `);
+<div class="ais-DynamicWidgets">
+</div>
+`);
 });

--- a/src/components/__tests__/HierarchicalMenu.js
+++ b/src/components/__tests__/HierarchicalMenu.js
@@ -1,4 +1,4 @@
-import { mount } from '../../../test/utils';
+import { mount, nextTick } from '../../../test/utils';
 import { __setState } from '../../mixins/widget';
 import HierarchicalMenu from '../HierarchicalMenu.vue';
 
@@ -370,12 +370,12 @@ describe('default render', () => {
     });
 
     const button = wrapper.find('button');
-    expect(button.attributes().disabled).toBe('disabled');
+    expect(button).toBeDisabled();
     expect(button.classes()).toContain(
       'ais-HierarchicalMenu-showMore--disabled'
     );
 
-    expect(wrapper.html()).toMatchSnapshot();
+    expect(wrapper.htmlCompat()).toMatchSnapshot();
   });
 
   it('renders correctly with show more label', () => {
@@ -435,10 +435,14 @@ describe('default render', () => {
       propsData: defaultProps,
     });
 
+    // wrapper.at(index) is deprecated at VTU@2.
+    // VTU@1: wrapper.at(index)
+    // VTU@2: wrapper[index]
+    // For simplicity, I've used `nth-child` modifier.
     await wrapper
-      .find('.ais-HierarchicalMenu-list--lvl2')
-      .findAll('a')
-      .at(1)
+      .find(
+        '.ais-HierarchicalMenu-list--lvl2 .ais-HierarchicalMenu-item:nth-child(2) a'
+      )
       .trigger('click');
 
     expect(refine).toHaveBeenCalledTimes(1);
@@ -478,11 +482,10 @@ it('calls the Panel mixin with `items.length`', async () => {
 
   expect(mapStateToCanRefine()).toBe(true);
 
-  await wrapper.setData({
-    state: {
-      items: [],
-    },
-  });
+  // should've used wrapper.setData({ state: { items: [] }})
+  // but https://github.com/vuejs/vue-test-utils-next/issues/766
+  wrapper.vm.state.items = [];
+  await nextTick();
 
   expect(mapStateToCanRefine()).toBe(false);
 
@@ -644,11 +647,8 @@ describe('custom default render', () => {
     __setState({
       ...defaultState,
       toggleShowMore: () => {
-        const component = wrapper.vm.$children[0];
-        component.$set(component, 'state', {
-          ...component.state,
-          isShowingMore: true,
-        });
+        const component = wrapper.findComponent(HierarchicalMenu);
+        component.setData({ state: { isShowingMore: true } });
       },
     });
 
@@ -696,8 +696,8 @@ describe('custom default render', () => {
       `,
     });
 
-    expect(wrapper.find('button').attributes().disabled).toBe('disabled');
-    expect(wrapper.html()).toMatchSnapshot();
+    expect(wrapper.find('button')).toBeDisabled();
+    expect(wrapper.htmlCompat()).toMatchSnapshot();
   });
 
   it('calls refine on link click', async () => {
@@ -720,12 +720,7 @@ describe('custom default render', () => {
       `,
     });
 
-    await wrapper
-      .findAll('ol')
-      .at(1)
-      .findAll('a')
-      .at(2)
-      .trigger('click');
+    await wrapper.find('ol ol li:nth-child(3) a').trigger('click');
 
     expect(refine).toHaveBeenCalledTimes(1);
     expect(refine).toHaveBeenCalledWith('Apple > MacBook');
@@ -735,11 +730,8 @@ describe('custom default render', () => {
     __setState({
       ...defaultState,
       toggleShowMore: () => {
-        const component = wrapper.vm.$children[0];
-        component.$set(component, 'state', {
-          ...component.state,
-          isShowingMore: true,
-        });
+        const component = wrapper.findComponent(HierarchicalMenu);
+        component.setData({ state: { isShowingMore: true } });
       },
     });
 
@@ -809,11 +801,8 @@ describe('custom showMoreLabel render', () => {
     __setState({
       ...defaultState,
       toggleShowMore: () => {
-        const component = wrapper.vm.$children[0];
-        component.$set(component, 'state', {
-          ...component.state,
-          isShowingMore: true,
-        });
+        const component = wrapper.findComponent(HierarchicalMenu);
+        component.setData({ state: { isShowingMore: true } });
       },
     });
 

--- a/src/components/__tests__/HierarchicalMenu.js
+++ b/src/components/__tests__/HierarchicalMenu.js
@@ -435,10 +435,6 @@ describe('default render', () => {
       propsData: defaultProps,
     });
 
-    // wrapper.at(index) is deprecated at VTU@2.
-    // VTU@1: wrapper.at(index)
-    // VTU@2: wrapper[index]
-    // For simplicity, I've used `nth-child` modifier.
     await wrapper
       .find(
         '.ais-HierarchicalMenu-list--lvl2 .ais-HierarchicalMenu-item:nth-child(2) a'

--- a/src/components/__tests__/InfiniteHits.js
+++ b/src/components/__tests__/InfiniteHits.js
@@ -171,8 +171,8 @@ it('renders correctly on the first page', () => {
   expect(
     previousButton.classes('ais-InfiniteHits-loadPrevious--disabled')
   ).toEqual(true);
-  expect(previousButton.attributes('disabled')).toEqual('disabled');
-  expect(wrapper.html()).toMatchSnapshot();
+  expect(previousButton).toBeDisabled();
+  expect(wrapper.htmlCompat()).toMatchSnapshot();
 });
 
 it('renders correctly on the last page', () => {
@@ -183,7 +183,7 @@ it('renders correctly on the last page', () => {
 
   const wrapper = mount(InfiniteHits);
 
-  expect(wrapper.html()).toMatchSnapshot();
+  expect(wrapper.htmlCompat()).toMatchSnapshot();
 });
 
 it('renders correctly when not on the first page', () => {

--- a/src/components/__tests__/InstantSearch-integration.js
+++ b/src/components/__tests__/InstantSearch-integration.js
@@ -20,19 +20,28 @@ it('child widgets get added to its parent instantsearch', () => {
     },
   };
 
-  const wrapper = mount(InstantSearch, {
-    propsData: {
-      searchClient: createFakeClient(),
-      indexName: 'something',
+  const wrapper = mount({
+    components: { InstantSearch, ChildComponent },
+    data() {
+      return {
+        props: {
+          searchClient: createFakeClient(),
+          indexName: 'something',
+        },
+      };
     },
-    slots: {
-      default: ChildComponent,
-    },
+    template: `
+      <InstantSearch v-bind="props">
+        <ChildComponent />
+      </InstantSearch>
+    `,
   });
 
-  expect(wrapper.vm.instantSearchInstance.mainIndex.getWidgets()).toContain(
-    widgetInstance
-  );
+  expect(
+    wrapper
+      .findComponent(InstantSearch)
+      .vm.instantSearchInstance.mainIndex.getWidgets()
+  ).toContain(widgetInstance);
 });
 
 describe('middlewares', () => {
@@ -167,9 +176,7 @@ describe('middlewares', () => {
       uiState: { indexName: { query: 'a' } },
     });
 
-    await wrapper.setData({
-      middlewares: [middleware1],
-    });
+    wrapper.vm.middlewares = [middleware1];
     await nextTick();
 
     expect(middlewareSpy1.unsubscribe).toHaveBeenCalledTimes(0);

--- a/src/components/__tests__/InstantSearchSsr.js
+++ b/src/components/__tests__/InstantSearchSsr.js
@@ -98,16 +98,19 @@ it('does not dispose if not yet started', async () => {
 
   const disposeSpy = jest.spyOn(instance, 'dispose');
 
-  const wrapper = mount(InstantSearchSsr, {
+  const wrapper = mount({
     provide: {
       $_ais_ssrInstantSearchInstance: instance,
     },
     components: {
-      AisSearchBox: SearchBox,
+      InstantSearchSsr,
+      SearchBox,
     },
-    slots: {
-      default: SearchBox,
-    },
+    template: `
+      <InstantSearchSsr>
+        <SearchBox />
+      </InstantSearchSsr>
+    `,
   });
 
   wrapper.destroy();
@@ -115,16 +118,19 @@ it('does not dispose if not yet started', async () => {
   // does not yet call, since instance isn't started
   expect(disposeSpy).toHaveBeenCalledTimes(0);
 
-  const wrapperTwo = mount(InstantSearchSsr, {
+  const wrapperTwo = mount({
     provide: {
       $_ais_ssrInstantSearchInstance: instance,
     },
     components: {
-      AisSearchBox: SearchBox,
+      InstantSearchSsr,
+      SearchBox,
     },
-    slots: {
-      default: SearchBox,
-    },
+    template: `
+      <InstantSearchSsr>
+        <SearchBox />
+      </InstantSearchSsr>
+    `,
   });
   await nextTick();
 

--- a/src/components/__tests__/Menu.js
+++ b/src/components/__tests__/Menu.js
@@ -170,9 +170,6 @@ describe('default render', () => {
     });
 
     expect(wrapper.findAll('.ais-Menu-item--selected')).toHaveLength(1);
-    // In vue 3, .text() returned 'Samsung25',
-    // whereas in vue 2, it wass 'Samsung 25'.
-    // Thus, just checking the snapshot ↓
     expect(wrapper.find('.ais-Menu-item--selected .ais-Menu-link').html())
       .toMatchInlineSnapshot(`
 <a class="ais-Menu-link">

--- a/src/components/__tests__/Menu.js
+++ b/src/components/__tests__/Menu.js
@@ -170,7 +170,20 @@ describe('default render', () => {
     });
 
     expect(wrapper.findAll('.ais-Menu-item--selected')).toHaveLength(1);
-    expect(wrapper.find('.ais-Menu-item--selected').text()).toBe('Samsung 25');
+    // In vue 3, .text() returned 'Samsung25',
+    // whereas in vue 2, it wass 'Samsung 25'.
+    // Thus, just checking the snapshot ↓
+    expect(wrapper.find('.ais-Menu-item--selected .ais-Menu-link').html())
+      .toMatchInlineSnapshot(`
+<a class="ais-Menu-link">
+  <span class="ais-Menu-label">
+    Samsung
+  </span>
+  <span class="ais-Menu-count">
+    25
+  </span>
+</a>
+`);
     expect(wrapper.html()).toMatchSnapshot();
   });
 
@@ -202,7 +215,7 @@ describe('default render', () => {
 
     expect(wrapper.findAll('.ais-Menu-showMore')).toHaveLength(1);
     expect(wrapper.find('.ais-Menu-showMore').text()).toBe('Show more');
-    expect(wrapper.html()).toMatchSnapshot();
+    expect(wrapper.htmlCompat()).toMatchSnapshot();
   });
 
   it('renders correctly with show more button toggled', () => {
@@ -219,7 +232,7 @@ describe('default render', () => {
     });
 
     expect(wrapper.find('.ais-Menu-showMore').text()).toBe('Show less');
-    expect(wrapper.html()).toMatchSnapshot();
+    expect(wrapper.htmlCompat()).toMatchSnapshot();
   });
 
   it('renders correctly with a disabled show more button', () => {
@@ -239,8 +252,8 @@ describe('default render', () => {
 
     expect(wrapper.findAll('.ais-Menu-showMore')).toHaveLength(1);
     expect(showMoreWrapper.classes()).toContain('ais-Menu-showMore--disabled');
-    expect(showMoreWrapper.attributes().disabled).toBe('disabled');
-    expect(wrapper.html()).toMatchSnapshot();
+    expect(showMoreWrapper).toBeDisabled();
+    expect(wrapper.htmlCompat()).toMatchSnapshot();
   });
 
   it('renders correctly without a show more button (canRefine)', () => {
@@ -406,7 +419,7 @@ describe('custom default render', () => {
       `,
     });
 
-    expect(wrapper.html()).toMatchSnapshot();
+    expect(wrapper.htmlCompat()).toMatchSnapshot();
   });
 
   it('renders correctly without refinement', () => {
@@ -428,7 +441,7 @@ describe('custom default render', () => {
       `,
     });
 
-    expect(wrapper.html()).toMatchSnapshot();
+    expect(wrapper.htmlCompat()).toMatchSnapshot();
   });
 
   it('renders correctly with an URL for the href', () => {
@@ -449,7 +462,7 @@ describe('custom default render', () => {
       `,
     });
 
-    expect(wrapper.html()).toMatchSnapshot();
+    expect(wrapper.htmlCompat()).toMatchSnapshot();
   });
 
   it('renders correctly with a show more button toggled', () => {
@@ -470,7 +483,7 @@ describe('custom default render', () => {
       `,
     });
 
-    expect(wrapper.html()).toMatchSnapshot();
+    expect(wrapper.htmlCompat()).toMatchSnapshot();
   });
 
   it('renders correctly with a disabled show more button', () => {
@@ -491,7 +504,7 @@ describe('custom default render', () => {
       `,
     });
 
-    expect(wrapper.html()).toMatchSnapshot();
+    expect(wrapper.htmlCompat()).toMatchSnapshot();
   });
 
   it('calls refine on link click', async () => {
@@ -576,7 +589,7 @@ describe('custom showMoreLabel render', () => {
     });
 
     expect(wrapper.find('.ais-Menu-showMore').text()).toBe('Voir plus');
-    expect(wrapper.html()).toMatchSnapshot();
+    expect(wrapper.htmlCompat()).toMatchSnapshot();
   });
 
   it('renders correctly with a custom show more label toggled', () => {
@@ -602,6 +615,6 @@ describe('custom showMoreLabel render', () => {
     });
 
     expect(wrapper.find('.ais-Menu-showMore').text()).toBe('Voir moins');
-    expect(wrapper.html()).toMatchSnapshot();
+    expect(wrapper.htmlCompat()).toMatchSnapshot();
   });
 });

--- a/src/components/__tests__/MenuSelect.js
+++ b/src/components/__tests__/MenuSelect.js
@@ -148,9 +148,9 @@ describe('default render', () => {
 
     expect(selected.element.selected).toBe(true);
 
-    options.wrappers.forEach(option => {
-      expect(option.element.selected).toBe(false);
-    });
+    for (let i = 0; i < options.length; i++) {
+      expect((options[i] || options.at(i)).element.selected).toBe(false);
+    }
   });
 
   it('renders correctly without refinements', () => {
@@ -266,7 +266,7 @@ describe('custom item slot', () => {
         <MenuSelect v-bind="props">
           <template v-slot:item="{ item }">
             <span>
-              {{ item.label }}
+              {{ item.label.toUpperCase() }}
             </span>
           </template>
         </MenuSelect>
@@ -275,12 +275,9 @@ describe('custom item slot', () => {
 
     expect(wrapper.html()).toMatchSnapshot();
 
-    expect(
-      wrapper
-        .findAll('option')
-        .at(1)
-        .html()
-    ).toMatch(/<span>\s+Apple\s+<\/span>/);
+    expect(wrapper.find('option:nth-child(2)').html()).toMatch(
+      /<span>\s*APPLE\s*<\/span>/
+    );
   });
 });
 
@@ -298,7 +295,7 @@ describe('custom default render', () => {
           :value="item.value"
           :selected="item.isRefined"
         >
-          {{item.label}}
+          {{item.label.toUpperCase()}}
         </option>
       </select>
     </template>
@@ -341,19 +338,46 @@ describe('custom default render', () => {
       },
       template: `
         <MenuSelect v-bind="props">
-          ${defaultSlot}
+          <template v-slot="{ items, canRefine, refine }">
+            <select
+              @change="refine($event.currentTarget.value)"
+              :disabled="!canRefine"
+            >
+              <option value="">All</option>
+              <option
+                v-for="item in items"
+                :key="item.value"
+                :value="item.value"
+                :selected="item.isRefined"
+                :data-test="item.value"
+              >
+                {{item.label}}
+              </option>
+            </select>
+          </template>
         </MenuSelect>
       `,
     });
 
-    const selected = wrapper.find('[value="Samsung"]');
-    const options = wrapper.findAll('option:not([value="Samsung"])');
+    // Unlike in vue 2, in vue 3 when value and textContent are the same,
+    // Vue doesn't render the value attribute at all.
+    // For example,
+
+    // In Vue 2,
+    // <option value="Apple">Apple</option>
+
+    // becomes, in Vue 3
+    // <option>Apple</option>
+
+    const selected = wrapper.find('[data-test="Samsung"]');
+    const options = wrapper.findAll('option:not([data-test="Samsung"])');
 
     expect(selected.element.selected).toBe(true);
 
-    options.wrappers.forEach(option => {
-      expect(option.element.selected).toBe(false);
-    });
+    for (let i = 0; i < options.length; i++) {
+      // `[i]` is for VTU@2, and `.at(i)` is for VTU@1.
+      expect((options[i] || options.at(i)).element.selected).toBe(false);
+    }
   });
 
   it('renders correctly without refinements', () => {
@@ -375,7 +399,7 @@ describe('custom default render', () => {
       `,
     });
 
-    expect(wrapper.html()).toMatchSnapshot();
+    expect(wrapper.htmlCompat()).toMatchSnapshot();
   });
 
   it('calls refine on select change', async () => {

--- a/src/components/__tests__/MenuSelect.js
+++ b/src/components/__tests__/MenuSelect.js
@@ -375,7 +375,6 @@ describe('custom default render', () => {
     expect(selected.element.selected).toBe(true);
 
     for (let i = 0; i < options.length; i++) {
-      // `[i]` is for VTU@2, and `.at(i)` is for VTU@1.
       expect((options[i] || options.at(i)).element.selected).toBe(false);
     }
   });

--- a/src/components/__tests__/NumericMenu.js
+++ b/src/components/__tests__/NumericMenu.js
@@ -7,6 +7,7 @@ jest.mock('../../mixins/panel');
 
 const all = {
   label: 'All',
+  value: 'all',
 };
 
 const lessThan10 = {
@@ -177,7 +178,9 @@ describe('default render', () => {
       propsData: props,
     });
 
-    const input = wrapper.findAll('.ais-NumericMenu-radio').at(3);
+    const input = wrapper.find(
+      '.ais-NumericMenu-item:nth-child(4) .ais-NumericMenu-radio'
+    );
 
     await input.trigger('change');
 
@@ -364,7 +367,7 @@ describe('custom default render', () => {
       `,
     });
 
-    const link = wrapper.findAll('a').at(3);
+    const link = wrapper.find('li:nth-child(4) a');
 
     await link.trigger('click');
 

--- a/src/components/__tests__/RangeInput.js
+++ b/src/components/__tests__/RangeInput.js
@@ -1,4 +1,4 @@
-import { mount } from '../../../test/utils';
+import { mount, nextTick } from '../../../test/utils';
 import { __setState } from '../../mixins/widget';
 import RangeInput from '../RangeInput.vue';
 
@@ -390,9 +390,8 @@ describe('refinement', () => {
     expect(refine).toHaveBeenCalledWith(['10', '100']);
 
     // update the state
-    await wrapper.setData({
-      state: { start: [50, 200] }, // min: 10 -> 50, max: 100 -> 200
-    });
+    wrapper.vm.state.start = [50, 200]; // min: 10 -> 50, max: 100 -> 200
+    await nextTick();
 
     await form.trigger('submit');
     expect(refine).toHaveBeenCalledTimes(2);

--- a/src/components/__tests__/RefinementList.js
+++ b/src/components/__tests__/RefinementList.js
@@ -83,7 +83,7 @@ it("renders correctly when it's searchable", () => {
       attribute: 'something',
     },
   });
-  expect(wrapper.html()).toMatchSnapshot();
+  expect(wrapper.htmlCompat()).toMatchSnapshot();
 
   expect(wrapper.find('.ais-SearchBox-input').exists()).toBe(true);
 });
@@ -120,7 +120,7 @@ it("allows search bar classes override when it's searchable", () => {
       },
     },
   });
-  expect(wrapper.html()).toMatchSnapshot();
+  expect(wrapper.htmlCompat()).toMatchSnapshot();
 
   expect(wrapper.find('.ais-SearchBox-form').classes('moar-classes')).toBe(
     true
@@ -141,11 +141,11 @@ it("disables show more if can't refine", async () => {
 
   const showMore = wrapper.find('.ais-RefinementList-showMore');
 
-  expect(showMore.attributes().disabled).toBe('disabled');
+  expect(showMore).toBeDisabled();
   expect(showMore.classes()).toContain('ais-RefinementList-showMore--disabled');
 
   await wrapper.setData({ state: { canToggleShowMore: true } });
-  expect(showMore.attributes().disabled).toBeUndefined();
+  expect(showMore).not.toBeDisabled();
   expect(showMore.classes()).not.toContain(
     'ais-RefinementList-showMore--disabled'
   );
@@ -161,8 +161,8 @@ it('behaves correctly', async () => {
       attribute: 'something',
     },
   });
-  const button = wrapper.find('input[type="checkbox"]');
-  await button.trigger('click');
+  const checkBox = wrapper.find('input[type="checkbox"]');
+  await checkBox.setChecked();
   expect(wrapper.vm.state.refine).toHaveBeenLastCalledWith('yo');
 });
 

--- a/src/components/__tests__/RelevantSort.js
+++ b/src/components/__tests__/RelevantSort.js
@@ -10,7 +10,7 @@ describe('renders correctly', () => {
       isRelevantSorted: false,
     });
     const wrapper = mount(RelevantSort);
-    expect(wrapper.html()).toMatchInlineSnapshot(`""`);
+    expect(wrapper).toHaveEmptyHTML();
   });
 
   test('not relevant sorted', () => {

--- a/src/components/__tests__/SearchBox.js
+++ b/src/components/__tests__/SearchBox.js
@@ -1,5 +1,5 @@
 import SearchBox from '../SearchBox.vue';
-import { mount } from '../../../test/utils';
+import { mount, htmlCompat } from '../../../test/utils';
 import { __setState } from '../../mixins/widget';
 jest.mock('../../mixins/widget');
 
@@ -9,7 +9,7 @@ test('renders HTML correctly', () => {
   __setState(defaultState);
   const wrapper = mount(SearchBox);
 
-  expect(wrapper.html()).toMatchSnapshot();
+  expect(wrapper.htmlCompat()).toMatchSnapshot();
 });
 
 test('with autofocus', () => {
@@ -20,9 +20,7 @@ test('with autofocus', () => {
     },
   });
 
-  expect(wrapper.find('.ais-SearchBox-input').attributes().autofocus).toBe(
-    'autofocus'
-  );
+  expect(wrapper.find('.ais-SearchBox-input')).toBeAutofocused();
 });
 
 test('with placeholder', () => {
@@ -69,9 +67,7 @@ test('with reset button hidden without refinement', () => {
 
   const wrapper = mount(SearchBox);
 
-  expect(wrapper.find('.ais-SearchBox-reset').attributes().hidden).toBe(
-    'hidden'
-  );
+  expect(wrapper.find('.ais-SearchBox-reset')).toBeHidden();
 });
 
 test('with reset button visible with refinement', () => {
@@ -82,9 +78,7 @@ test('with reset button visible with refinement', () => {
 
   const wrapper = mount(SearchBox);
 
-  expect(
-    wrapper.find('.ais-SearchBox-reset').attributes().hidden
-  ).toBeUndefined();
+  expect(wrapper.find('.ais-SearchBox-reset')).not.toBeHidden();
 });
 
 test('with stalled search hides the submit, reset and displays the loader', () => {
@@ -99,30 +93,22 @@ test('with stalled search hides the submit, reset and displays the loader', () =
     },
   });
 
-  expect(wrapper.find('.ais-SearchBox-submit').attributes().hidden).toBe(
-    'hidden'
-  );
+  expect(wrapper.find('.ais-SearchBox-submit')).toBeHidden();
 
-  expect(wrapper.find('.ais-SearchBox-reset').attributes().hidden).toBe(
-    'hidden'
-  );
+  expect(wrapper.find('.ais-SearchBox-reset')).toBeHidden();
 
-  expect(wrapper.contains('.ais-SearchBox-loadingIndicator')).toBe(true);
+  expect(wrapper.find('.ais-SearchBox-loadingIndicator').exists()).toBe(true);
 });
 
 test('with stalled search but no `showLoadingIndicator` displays the submit and hides reset, loader', () => {
   __setState({ ...defaultState, isSearchStalled: true });
   const wrapper = mount(SearchBox);
 
-  expect(
-    wrapper.find('.ais-SearchBox-submit').attributes().hidden
-  ).toBeUndefined();
+  expect(wrapper.find('.ais-SearchBox-submit')).not.toBeHidden();
 
-  expect(wrapper.find('.ais-SearchBox-reset').attributes().hidden).toBe(
-    'hidden'
-  );
+  expect(wrapper.find('.ais-SearchBox-reset')).toBeHidden();
 
-  expect(wrapper.contains('.ais-SearchBox-loadingIndicator')).toBe(false);
+  expect(wrapper.find('.ais-SearchBox-loadingIndicator').exists()).toBe(false);
 });
 
 test('with not stalled search displays the submit and hides reset, loader', () => {
@@ -133,17 +119,11 @@ test('with not stalled search displays the submit and hides reset, loader', () =
     },
   });
 
-  expect(
-    wrapper.find('.ais-SearchBox-submit').attributes().hidden
-  ).toBeUndefined();
+  expect(wrapper.find('.ais-SearchBox-submit')).not.toBeHidden();
 
-  expect(wrapper.find('.ais-SearchBox-reset').attributes().hidden).toBe(
-    'hidden'
-  );
+  expect(wrapper.find('.ais-SearchBox-reset')).toBeHidden();
 
-  expect(
-    wrapper.find('.ais-SearchBox-loadingIndicator').attributes().hidden
-  ).toBe('hidden');
+  expect(wrapper.find('.ais-SearchBox-loadingIndicator')).toBeHidden();
 });
 
 test('blurs input on form submit', async () => {
@@ -172,15 +152,28 @@ test('overriding slots', () => {
     ...defaultState,
     isSearchStalled: true,
   });
-  const wrapper = mount(SearchBox, {
-    propsData: {
-      showLoadingIndicator: true,
+  const wrapper = mount({
+    components: { SearchBox },
+    data() {
+      return {
+        props: {
+          showLoadingIndicator: true,
+        },
+      };
     },
-    slots: {
-      'submit-icon': '<span>SUBMIT</span>',
-      'reset-icon': '<span>RESET</span>',
-      'loading-indicator': '<span>LOADING...</span>',
-    },
+    template: `
+      <SearchBox v-bind="props">
+        <template v-slot:submit-icon>
+          <span>SUBMIT</span>
+        </template>
+        <template v-slot:reset-icon>
+          <span>RESET</span>
+        </template>
+        <template v-slot:loading-indicator>
+          <span>LOADING...</span>
+        </template>
+      </SearchBox>
+    `,
   });
 
   expect(wrapper.find('.ais-SearchBox-submit').html()).toMatch(/SUBMIT/);
@@ -189,7 +182,8 @@ test('overriding slots', () => {
     /LOADING.../
   );
 
-  expect(wrapper.find('.ais-SearchBox-submit').html()).toMatchInlineSnapshot(`
+  expect(htmlCompat(wrapper.find('.ais-SearchBox-submit').html()))
+    .toMatchInlineSnapshot(`
 <button class="ais-SearchBox-submit"
         hidden="hidden"
         title="Search"
@@ -200,7 +194,8 @@ test('overriding slots', () => {
   </span>
 </button>
 `);
-  expect(wrapper.find('.ais-SearchBox-reset').html()).toMatchInlineSnapshot(`
+  expect(htmlCompat(wrapper.find('.ais-SearchBox-reset').html()))
+    .toMatchInlineSnapshot(`
 <button class="ais-SearchBox-reset"
         hidden="hidden"
         title="Clear"

--- a/src/components/__tests__/StateResults.js
+++ b/src/components/__tests__/StateResults.js
@@ -21,7 +21,7 @@ it('renders explanation if no slot is used', () => {
 it("doesn't render if no results", () => {
   __setState({});
   const wrapper = mount(StateResults);
-  expect(wrapper.html()).toBe('');
+  expect(wrapper).toHaveEmptyHTML();
 });
 
 it('gives state & results to default slot', () => {

--- a/src/components/__tests__/VoiceSearch.js
+++ b/src/components/__tests__/VoiceSearch.js
@@ -45,7 +45,7 @@ describe('Rendering', () => {
       isBrowserSupported: false,
     });
     const wrapper = mount(VoiceSearch);
-    expect(wrapper.find('button').attributes().disabled).toBe('disabled');
+    expect(wrapper.find('button')).toBeDisabled();
   });
 
   it('with custom template for buttonText (1)', () => {

--- a/src/components/__tests__/__snapshots__/Menu.js.snap
+++ b/src/components/__tests__/__snapshots__/Menu.js.snap
@@ -330,7 +330,7 @@ exports[`default render renders correctly with a disabled show more button 1`] =
 </div>
 `;
 
-exports[`default render renders correctly with a selected item 1`] = `
+exports[`default render renders correctly with a selected item 2`] = `
 <div class="ais-Menu">
   <ul class="ais-Menu-list">
     <li class="ais-Menu-item">

--- a/src/components/__tests__/__snapshots__/MenuSelect.js.snap
+++ b/src/components/__tests__/__snapshots__/MenuSelect.js.snap
@@ -7,13 +7,13 @@ exports[`custom default render renders correctly 1`] = `
       All
     </option>
     <option value="Apple">
-      Apple
+      APPLE
     </option>
     <option value="Samsung">
-      Samsung
+      SAMSUNG
     </option>
     <option value="Sony">
-      Sony
+      SONY
     </option>
   </select>
 </div>
@@ -41,21 +41,21 @@ exports[`custom item slot renders correctly 1`] = `
             value="Apple"
     >
       <span>
-        Apple
+        APPLE
       </span>
     </option>
     <option class="ais-MenuSelect-option"
             value="Samsung"
     >
       <span>
-        Samsung
+        SAMSUNG
       </span>
     </option>
     <option class="ais-MenuSelect-option"
             value="Sony"
     >
       <span>
-        Sony
+        SONY
       </span>
     </option>
   </select>

--- a/src/components/__tests__/__snapshots__/NumericMenu.js.snap
+++ b/src/components/__tests__/__snapshots__/NumericMenu.js.snap
@@ -136,7 +136,7 @@ exports[`default render renders correctly 1`] = `
         <input class="ais-NumericMenu-radio"
                name="brand"
                type="radio"
-               value
+               value="all"
         >
         <span class="ais-NumericMenu-labelText">
           All
@@ -203,7 +203,7 @@ exports[`default render renders correctly with a selected value 1`] = `
         <input class="ais-NumericMenu-radio"
                name="brand"
                type="radio"
-               value
+               value="all"
         >
         <span class="ais-NumericMenu-labelText">
           All
@@ -270,7 +270,7 @@ exports[`default render renders correctly without refinement 1`] = `
         <input class="ais-NumericMenu-radio"
                name="brand"
                type="radio"
-               value
+               value="all"
         >
         <span class="ais-NumericMenu-labelText">
           All

--- a/src/mixins/__tests__/panel.test.js
+++ b/src/mixins/__tests__/panel.test.js
@@ -1,6 +1,6 @@
-import { mount } from '../../../test/utils';
+import { mount, nextTick } from '../../../test/utils';
 import mitt from 'mitt';
-import Vue from 'vue';
+import { isVue3 } from '../../util/vue-compat';
 import {
   createPanelProviderMixin,
   createPanelConsumerMixin,
@@ -112,13 +112,19 @@ describe('createPanelConsumerMixin', () => {
     expect(emitter.emit).toHaveBeenCalledTimes(1);
     expect(emitter.emit).toHaveBeenLastCalledWith(PANEL_CHANGE_EVENT, false);
 
-    // ↓ this should be replaceable with `wrapper.setData()` but it didn't
-    // trigger the watcher in `createPanelConsumerMixin`.
-    // It's probably a bug from vue-test-utils.
-    // https://github.com/vuejs/vue-test-utils/issues/1756
-    // https://github.com/vuejs/vue-test-utils/issues/149
-    wrapper.vm.$set(wrapper.vm, 'state', { attributeName: true });
-    await Vue.nextTick();
+    if (isVue3) {
+      await wrapper.setData({ state: { attributeName: true } });
+    } else {
+      // ↓ this should be replaceable with `wrapper.setData()` but it didn't
+      // trigger the watcher in `createPanelConsumerMixin`.
+      // It's probably a bug from vue-test-utils.
+      // https://github.com/vuejs/vue-test-utils/issues/1756
+      // https://github.com/vuejs/vue-test-utils/issues/149
+      wrapper.vm.$set(wrapper.vm, 'state', {
+        attributeName: true,
+      });
+      await nextTick();
+    }
 
     expect(emitter.emit).toHaveBeenCalledTimes(2);
     expect(emitter.emit).toHaveBeenLastCalledWith(PANEL_CHANGE_EVENT, true);
@@ -206,8 +212,12 @@ describe('createPanelConsumerMixin', () => {
     expect(emitter.emit).toHaveBeenCalledTimes(1);
     expect(emitter.emit).toHaveBeenLastCalledWith(PANEL_CHANGE_EVENT, true);
 
-    wrapper.vm.$set(wrapper.vm, 'state', null);
-    await Vue.nextTick();
+    if (isVue3) {
+      await wrapper.setData({ state: null });
+    } else {
+      wrapper.vm.$set(wrapper.vm, 'state', null);
+      await nextTick();
+    }
 
     expect(emitter.emit).toHaveBeenCalledTimes(1);
   });
@@ -236,14 +246,22 @@ describe('createPanelConsumerMixin', () => {
     expect(emitter.emit).toHaveBeenCalledTimes(1);
     expect(emitter.emit).toHaveBeenLastCalledWith(PANEL_CHANGE_EVENT, true);
 
-    wrapper.vm.$set(wrapper.vm, 'state', { attributeName: false });
-    await Vue.nextTick();
+    if (isVue3) {
+      await wrapper.setData({ state: { attributeName: false } });
+    } else {
+      wrapper.vm.$set(wrapper.vm, 'state', { attributeName: false });
+      await nextTick();
+    }
 
     expect(emitter.emit).toHaveBeenCalledTimes(2);
     expect(emitter.emit).toHaveBeenLastCalledWith(PANEL_CHANGE_EVENT, false);
 
-    wrapper.vm.$set(wrapper.vm, 'state', { attributeName: false });
-    await Vue.nextTick();
+    if (isVue3) {
+      await wrapper.setData({ state: { attributeName: false } });
+    } else {
+      wrapper.vm.$set(wrapper.vm, 'state', { attributeName: false });
+      await nextTick();
+    }
 
     expect(emitter.emit).toHaveBeenCalledTimes(2);
   });

--- a/src/mixins/__tests__/widget.test.js
+++ b/src/mixins/__tests__/widget.test.js
@@ -24,20 +24,22 @@ describe('on root index', () => {
     const widget = { render: () => {} };
     const factory = jest.fn(() => widget);
     const connector = jest.fn(() => factory);
-    const Test = createFakeComponent({
-      mixins: [createWidgetMixin({ connector })],
-    });
     const widgetParams = {
       attribute: 'brand',
     };
+    const Test = createFakeComponent({
+      mixins: [createWidgetMixin({ connector })],
+      computed: {
+        widgetParams() {
+          return widgetParams;
+        },
+      },
+    });
 
     mount(Test, {
       provide: {
         $_ais_instantSearchInstance: instance,
       },
-      data: () => ({
-        widgetParams,
-      }),
     });
 
     expect(connector).toHaveBeenCalled();
@@ -84,13 +86,16 @@ describe('on root index', () => {
     };
     const factory = jest.fn(() => widget);
     const connector = jest.fn(() => factory);
-    const Test = createFakeComponent({
-      mixins: [createWidgetMixin({ connector })],
-    });
-
     const widgetParams = {
       attribute: 'brand',
     };
+
+    const Test = createFakeComponent({
+      mixins: [createWidgetMixin({ connector })],
+      data: () => ({
+        widgetParams,
+      }),
+    });
 
     const nextWidgetParams = {
       attribute: 'price',
@@ -100,9 +105,6 @@ describe('on root index', () => {
       provide: {
         $_ais_instantSearchInstance: instance,
       },
-      data: () => ({
-        widgetParams,
-      }),
     });
 
     // Simulate render
@@ -166,7 +168,7 @@ describe('on root index', () => {
     // Simulate render
     connector.mock.calls[0][0](state, false);
 
-    expect(wrapper.vm.state).toBe(state);
+    expect(wrapper.vm.state).toEqual(state);
   });
 });
 
@@ -182,6 +184,11 @@ describe('on child index', () => {
     };
     const Test = createFakeComponent({
       mixins: [createWidgetMixin({ connector })],
+      computed: {
+        widgetParams() {
+          return widgetParams;
+        },
+      },
     });
 
     mount(Test, {
@@ -189,9 +196,6 @@ describe('on child index', () => {
         $_ais_instantSearchInstance: instance,
         $_ais_getParentIndex: () => indexWidget,
       },
-      data: () => ({
-        widgetParams,
-      }),
     });
 
     expect(connector).toHaveBeenCalled();
@@ -241,13 +245,16 @@ describe('on child index', () => {
     };
     const factory = jest.fn(() => widget);
     const connector = jest.fn(() => factory);
-    const Test = createFakeComponent({
-      mixins: [createWidgetMixin({ connector })],
-    });
-
     const widgetParams = {
       attribute: 'brand',
     };
+
+    const Test = createFakeComponent({
+      mixins: [createWidgetMixin({ connector })],
+      data: () => ({
+        widgetParams,
+      }),
+    });
 
     const nextWidgetParams = {
       attribute: 'price',
@@ -258,9 +265,6 @@ describe('on child index', () => {
         $_ais_instantSearchInstance: instance,
         $_ais_getParentIndex: () => indexWidget,
       },
-      data: () => ({
-        widgetParams,
-      }),
     });
 
     // Simulate render
@@ -294,13 +298,16 @@ describe('on child index', () => {
     const widget = { render: () => {} };
     const factory = jest.fn(() => widget);
     const connector = jest.fn(() => factory);
-    const Test = createFakeComponent({
-      mixins: [createWidgetMixin({ connector })],
-    });
     const widgetParams = {
       attribute: 'brand',
     };
 
+    const Test = createFakeComponent({
+      mixins: [createWidgetMixin({ connector })],
+      data: () => ({
+        widgetParams,
+      }),
+    });
     const state = {
       items: [],
     };
@@ -310,9 +317,6 @@ describe('on child index', () => {
         $_ais_instantSearchInstance: instance,
         $_ais_getParentIndex: () => indexWidget,
       },
-      data: () => ({
-        widgetParams,
-      }),
     });
 
     // Simulate init
@@ -326,6 +330,6 @@ describe('on child index', () => {
     // Simulate render
     connector.mock.calls[0][0](state, false);
 
-    expect(wrapper.vm.state).toBe(state);
+    expect(wrapper.vm.state).toEqual(state);
   });
 });

--- a/src/util/vue-compat/index-3.js
+++ b/src/util/vue-compat/index-3.js
@@ -4,5 +4,5 @@ const isVue2 = false;
 const isVue3 = true;
 const Vue2 = undefined;
 
-export * from 'vue';
+export { createApp, createSSRApp, h, version, nextTick } from 'vue';
 export { Vue, Vue2, isVue2, isVue3 };

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -7,6 +7,18 @@ import {
   Vue2,
 } from '../../src/util/vue-compat';
 
+export const htmlCompat = function(html) {
+  if (isVue3) {
+    return html
+      .replace(/disabled=""/g, 'disabled="disabled"')
+      .replace(/hidden=""/g, 'hidden="hidden"')
+      .replace(/novalidate=""/g, 'novalidate="novalidate"')
+      .replace(/required=""/g, 'required="required"');
+  } else {
+    return html;
+  }
+};
+
 export const mount = isVue3
   ? (component, options = {}) => {
       const {
@@ -15,6 +27,7 @@ export const mount = isVue3
         provide,
         slots,
         scopedSlots,
+        stubs,
         ...restOptions
       } = options;
       // If we `import` this, it will try to import Vue3-only APIs like `defineComponent`,
@@ -25,6 +38,7 @@ export const mount = isVue3
         global: {
           mixins,
           provide,
+          stubs,
         },
         slots: {
           ...slots,
@@ -32,9 +46,18 @@ export const mount = isVue3
         },
       });
       wrapper.destroy = wrapper.unmount;
+      wrapper.htmlCompat = function() {
+        return htmlCompat(this.html());
+      };
       return wrapper;
     }
-  : require('@vue/test-utils').mount;
+  : (component, options = {}) => {
+      const wrapper = require('@vue/test-utils').mount(component, options);
+      wrapper.htmlCompat = function() {
+        return htmlCompat(this.html());
+      };
+      return wrapper;
+    };
 
 export const createApp = props => {
   if (isVue3) {


### PR DESCRIPTION
## Summary

This PR mainly updates all the incompatible test cases to work with both vue 2 and 3.


### About the scope of this PR

* We have no idea on when VTU is going to release the update. So I prefer replacing `vm.$set()` with `setData()` later in a separate PR.
* Another tasks I'm planning as separate PRs:
  * `renderCompat` for InstantSearch, Configure, ... (covers createElement, h, and conditional props & attrs)
  * shared util for `isVue3 ? this.$slots.default && this.$slots.default() : this.$slots.default`
  * extracting as a script to add dependencies and run tests for vue 3

This PR is a stacked PR on https://github.com/algolia/vue-instantsearch/pull/1020, so it's easier to do them separately. Otherwise, we will apply them both in this branch and in the one for #1020.