### PR TITLE
refactor(vue 3): add utils for compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     },
     {
       "path": "./dist/vue2/cjs/index.js",
-      "maxSize": "16.75 kB"
+      "maxSize": "17.00 kB"
     },
     {
       "path": "./dist/vue3/umd/index.js",
@@ -139,7 +139,7 @@
     },
     {
       "path": "./dist/vue3/cjs/index.js",
-      "maxSize": "18.25 kB"
+      "maxSize": "18.50 kB"
     }
   ],
   "resolutions": {

--- a/src/components/Configure.js
+++ b/src/components/Configure.js
@@ -1,7 +1,7 @@
 import { createWidgetMixin } from '../mixins/widget';
 import { createSuitMixin } from '../mixins/suit';
 import { connectConfigure } from 'instantsearch.js/es/connectors';
-import { isVue3, h } from '../util/vue-compat';
+import { isVue3, renderCompat } from '../util/vue-compat';
 
 export default {
   inheritAttrs: false,
@@ -17,14 +17,14 @@ export default {
       };
     },
   },
-  render(createElement) {
+  render: renderCompat(function(h) {
     const slot = isVue3 ? this.$slots.default : this.$scopedSlots.default;
 
     if (!this.state || !slot) {
       return null;
     }
 
-    return (isVue3 ? h : createElement)(
+    return h(
       'div',
       {
         class: this.suit(),
@@ -36,5 +36,5 @@ export default {
         }),
       ]
     );
-  },
+  }),
 };

--- a/src/components/DynamicWidgets.js
+++ b/src/components/DynamicWidgets.js
@@ -75,7 +75,7 @@ export default {
           {
             class: [this.suit()],
           },
-          isVue3 ? { hidden: true } : { attrs: { hidden: true } }
+          { attrs: { hidden: true } }
         ),
         allComponents
       );

--- a/src/components/DynamicWidgets.js
+++ b/src/components/DynamicWidgets.js
@@ -2,7 +2,7 @@ import { createWidgetMixin } from '../mixins/widget';
 import { EXPERIMENTAL_connectDynamicWidgets } from 'instantsearch.js/es/connectors';
 import { createSuitMixin } from '../mixins/suit';
 import { _objectSpread } from '../util/polyfills';
-import { isVue3, h as _h } from '../util/vue-compat';
+import { isVue3, renderCompat } from '../util/vue-compat';
 
 function getWidgetAttribute(vnode) {
   const props = isVue3
@@ -51,9 +51,8 @@ export default {
       default: undefined,
     },
   },
-  render(createElement) {
+  render: renderCompat(function(h) {
     const components = new Map();
-    const h = isVue3 ? _h : createElement;
     const defaultSlot = isVue3
       ? this.$slots.default && this.$slots.default()
       : this.$slots.default;
@@ -90,7 +89,7 @@ export default {
       { class: [this.suit()] },
       this.state.attributesToRender.map(attribute => components.get(attribute))
     );
-  },
+  }),
   computed: {
     widgetParams() {
       return {

--- a/src/components/DynamicWidgets.js
+++ b/src/components/DynamicWidgets.js
@@ -2,7 +2,7 @@ import { createWidgetMixin } from '../mixins/widget';
 import { EXPERIMENTAL_connectDynamicWidgets } from 'instantsearch.js/es/connectors';
 import { createSuitMixin } from '../mixins/suit';
 import { _objectSpread } from '../util/polyfills';
-import { isVue3, renderCompat } from '../util/vue-compat';
+import { isVue3, renderCompat, getDefaultSlot } from '../util/vue-compat';
 
 function getWidgetAttribute(vnode) {
   const props = isVue3
@@ -53,11 +53,8 @@ export default {
   },
   render: renderCompat(function(h) {
     const components = new Map();
-    const defaultSlot = isVue3
-      ? this.$slots.default && this.$slots.default()
-      : this.$slots.default;
 
-    (defaultSlot || []).forEach(vnode => {
+    (getDefaultSlot(this) || []).forEach(vnode => {
       const attribute = getWidgetAttribute(vnode);
       if (attribute) {
         components.set(

--- a/src/components/Index.js
+++ b/src/components/Index.js
@@ -1,7 +1,7 @@
 import { createSuitMixin } from '../mixins/suit';
 import { createWidgetMixin } from '../mixins/widget';
 import indexWidget from 'instantsearch.js/es/widgets/index/index';
-import { isVue3, h } from '../util/vue-compat';
+import { isVue3, renderCompat } from '../util/vue-compat';
 
 // wrapped in a dummy function, since indexWidget doesn't render
 const connectIndex = () => indexWidget;
@@ -29,15 +29,15 @@ export default {
       required: false,
     },
   },
-  render(createElement) {
-    return (isVue3 ? h : createElement)(
+  render: renderCompat(function(h) {
+    return h(
       'div',
       {},
       isVue3
         ? this.$slots.default && this.$slots.default()
         : this.$slots.default
     );
-  },
+  }),
   computed: {
     widgetParams() {
       return {

--- a/src/components/Index.js
+++ b/src/components/Index.js
@@ -1,7 +1,7 @@
 import { createSuitMixin } from '../mixins/suit';
 import { createWidgetMixin } from '../mixins/widget';
 import indexWidget from 'instantsearch.js/es/widgets/index/index';
-import { isVue3, renderCompat } from '../util/vue-compat';
+import { renderCompat, getDefaultSlot } from '../util/vue-compat';
 
 // wrapped in a dummy function, since indexWidget doesn't render
 const connectIndex = () => indexWidget;
@@ -30,13 +30,7 @@ export default {
     },
   },
   render: renderCompat(function(h) {
-    return h(
-      'div',
-      {},
-      isVue3
-        ? this.$slots.default && this.$slots.default()
-        : this.$slots.default
-    );
+    return h('div', {}, getDefaultSlot(this));
   }),
   computed: {
     widgetParams() {

--- a/src/components/InstantSearch.js
+++ b/src/components/InstantSearch.js
@@ -1,7 +1,7 @@
 import instantsearch from 'instantsearch.js/es';
 import { createInstantSearchComponent } from '../util/createInstantSearchComponent';
 import { warn } from '../util/warn';
-import { isVue3, h } from '../util/vue-compat';
+import { isVue3, renderCompat } from '../util/vue-compat';
 
 const oldApiWarning = `Vue InstantSearch: You used the prop api-key or app-id.
 These have been replaced by search-client.
@@ -88,8 +88,8 @@ export default createInstantSearchComponent({
       }),
     };
   },
-  render(createElement) {
-    return (isVue3 ? h : createElement)(
+  render: renderCompat(function(h) {
+    return h(
       'div',
       {
         class: {
@@ -101,5 +101,5 @@ export default createInstantSearchComponent({
         ? this.$slots.default && this.$slots.default()
         : this.$slots.default
     );
-  },
+  }),
 });

--- a/src/components/InstantSearch.js
+++ b/src/components/InstantSearch.js
@@ -1,7 +1,7 @@
 import instantsearch from 'instantsearch.js/es';
 import { createInstantSearchComponent } from '../util/createInstantSearchComponent';
 import { warn } from '../util/warn';
-import { isVue3, renderCompat } from '../util/vue-compat';
+import { renderCompat, getDefaultSlot } from '../util/vue-compat';
 
 const oldApiWarning = `Vue InstantSearch: You used the prop api-key or app-id.
 These have been replaced by search-client.
@@ -97,9 +97,7 @@ export default createInstantSearchComponent({
           [this.suit('', 'ssr')]: false,
         },
       },
-      isVue3
-        ? this.$slots.default && this.$slots.default()
-        : this.$slots.default
+      getDefaultSlot(this)
     );
   }),
 });

--- a/src/components/InstantSearchSsr.js
+++ b/src/components/InstantSearchSsr.js
@@ -1,5 +1,5 @@
 import { createInstantSearchComponent } from '../util/createInstantSearchComponent';
-import { isVue3, renderCompat } from '../util/vue-compat';
+import { renderCompat, getDefaultSlot } from '../util/vue-compat';
 
 export default createInstantSearchComponent({
   name: 'AisInstantSearchSsr',
@@ -24,9 +24,7 @@ export default createInstantSearchComponent({
           [this.suit('', 'ssr')]: true,
         },
       },
-      isVue3
-        ? this.$slots.default && this.$slots.default()
-        : this.$slots.default
+      getDefaultSlot(this)
     );
   }),
 });

--- a/src/components/InstantSearchSsr.js
+++ b/src/components/InstantSearchSsr.js
@@ -1,5 +1,5 @@
 import { createInstantSearchComponent } from '../util/createInstantSearchComponent';
-import { isVue3, h } from '../util/vue-compat';
+import { isVue3, renderCompat } from '../util/vue-compat';
 
 export default createInstantSearchComponent({
   name: 'AisInstantSearchSsr',
@@ -15,8 +15,8 @@ export default createInstantSearchComponent({
       instantSearchInstance: this.$_ais_ssrInstantSearchInstance,
     };
   },
-  render(createElement) {
-    return (isVue3 ? h : createElement)(
+  render: renderCompat(function(h) {
+    return h(
       'div',
       {
         class: {
@@ -28,5 +28,5 @@ export default createInstantSearchComponent({
         ? this.$slots.default && this.$slots.default()
         : this.$slots.default
     );
-  },
+  }),
 });

--- a/src/components/__tests__/Configure.js
+++ b/src/components/__tests__/Configure.js
@@ -38,7 +38,7 @@ it('accepts SearchParameters from attributes', () => {
   });
 });
 
-it('renders null without scoped slots', () => {
+it('renders null without default slot', () => {
   __setState(null);
 
   const wrapper = mount(Configure, {

--- a/src/components/__tests__/InstantSearchSsr.js
+++ b/src/components/__tests__/InstantSearchSsr.js
@@ -1,8 +1,9 @@
-import { renderCompat, mount, nextTick } from '../../../test/utils';
+import { mount, nextTick } from '../../../test/utils';
 import instantsearch from 'instantsearch.js/es';
 import InstantSearchSsr from '../InstantSearchSsr';
 import SearchBox from '../SearchBox.vue';
 import { createFakeClient } from '../../util/testutils/client';
+import { renderCompat } from '../../util/vue-compat';
 
 jest.unmock('instantsearch.js/es');
 

--- a/src/util/__tests__/createServerRootMixin.test.js
+++ b/src/util/__tests__/createServerRootMixin.test.js
@@ -1,4 +1,4 @@
-import { mount, createSSRApp, renderCompat } from '../../../test/utils';
+import { mount, createSSRApp } from '../../../test/utils';
 import Router from 'vue-router';
 import Vuex from 'vuex';
 import { createStore } from 'vuex4';
@@ -12,7 +12,7 @@ import SearchBox from '../../components/SearchBox.vue';
 import { createWidgetMixin } from '../../mixins/widget';
 import { createFakeClient } from '../testutils/client';
 import { createSerializedState } from '../testutils/helper';
-import { isVue3, isVue2, Vue2 } from '../vue-compat';
+import { isVue3, isVue2, Vue2, renderCompat } from '../vue-compat';
 import {
   SearchResults,
   SearchParameters,

--- a/src/util/__tests__/createServerRootMixin.test.js
+++ b/src/util/__tests__/createServerRootMixin.test.js
@@ -174,16 +174,11 @@ describe('createServerRootMixin', () => {
            * but it's not important (and not compatible in vue2), we're leaving it as-is.
            */
           h(InstantSearchSsr, {}, [
-            h(
-              Configure,
-              isVue3
-                ? { hitsPerPage: 100 }
-                : {
-                    attrs: {
-                      hitsPerPage: 100,
-                    },
-                  }
-            ),
+            h(Configure, {
+              attrs: {
+                hitsPerPage: 100,
+              },
+            }),
             h(SearchBox),
           ])
         ),
@@ -262,16 +257,11 @@ Array [
         },
         render: renderCompat(h =>
           h(InstantSearchSsr, {}, [
-            h(
-              Configure,
-              isVue3
-                ? { hitsPerPage: 100 }
-                : {
-                    attrs: {
-                      hitsPerPage: 100,
-                    },
-                  }
-            ),
+            h(Configure, {
+              attrs: {
+                hitsPerPage: 100,
+              },
+            }),
             h(SearchBox),
           ])
         ),
@@ -317,16 +307,11 @@ Array [
         },
         render: renderCompat(h =>
           h(InstantSearchSsr, {}, [
-            h(
-              Configure,
-              isVue3
-                ? { hitsPerPage: 100 }
-                : {
-                    attrs: {
-                      hitsPerPage: 100,
-                    },
-                  }
-            ),
+            h(Configure, {
+              attrs: {
+                hitsPerPage: 100,
+              },
+            }),
             h(SearchBox),
           ])
         ),
@@ -376,16 +361,11 @@ Array [
         },
         render: renderCompat(h =>
           h(InstantSearchSsr, {}, [
-            h(
-              Configure,
-              isVue3
-                ? { hitsPerPage: 100 }
-                : {
-                    attrs: {
-                      hitsPerPage: 100,
-                    },
-                  }
-            ),
+            h(Configure, {
+              attrs: {
+                hitsPerPage: 100,
+              },
+            }),
             h(SearchBox),
           ])
         ),
@@ -396,9 +376,7 @@ Array [
 
       const wrapper = createSSRApp({
         mixins: [forceIsServerMixin],
-        render: renderCompat(h =>
-          h(App, isVue3 ? { someProp } : { props: { someProp } })
-        ),
+        render: renderCompat(h => h(App, { props: { someProp } })),
       });
 
       await renderToString(wrapper);
@@ -533,16 +511,11 @@ Array [
           render: renderCompat(function(h) {
             expect(this.$root).toBe(wrapper);
             return h(InstantSearchSsr, {}, [
-              h(
-                Configure,
-                isVue3
-                  ? { hitsPerPage: 100 }
-                  : {
-                      attrs: {
-                        hitsPerPage: 100,
-                      },
-                    }
-              ),
+              h(Configure, {
+                attrs: {
+                  hitsPerPage: 100,
+                },
+              }),
               h(SearchBox),
             ]);
           }),
@@ -574,16 +547,11 @@ Array [
         ],
         render: renderCompat(h =>
           h(InstantSearchSsr, {}, [
-            h(
-              Configure,
-              isVue3
-                ? { hitsPerPage: 100 }
-                : {
-                    attrs: {
-                      hitsPerPage: 100,
-                    },
-                  }
-            ),
+            h(Configure, {
+              attrs: {
+                hitsPerPage: 100,
+              },
+            }),
             h(SearchBox),
           ])
         ),
@@ -625,16 +593,11 @@ Array [
         ],
         render: renderCompat(h =>
           h(InstantSearchSsr, {}, [
-            h(
-              Configure,
-              isVue3
-                ? { hitsPerPage: 100 }
-                : {
-                    attrs: {
-                      hitsPerPage: 100,
-                    },
-                  }
-            ),
+            h(Configure, {
+              attrs: {
+                hitsPerPage: 100,
+              },
+            }),
             h(SearchBox),
           ])
         ),
@@ -668,16 +631,11 @@ Array [
         ],
         render: renderCompat(h =>
           h(InstantSearchSsr, {}, [
-            h(
-              Configure,
-              isVue3
-                ? { hitsPerPage: 100 }
-                : {
-                    attrs: {
-                      hitsPerPage: 100,
-                    },
-                  }
-            ),
+            h(Configure, {
+              attrs: {
+                hitsPerPage: 100,
+              },
+            }),
             h(SearchBox),
           ])
         ),
@@ -711,16 +669,11 @@ Array [
         ],
         render: renderCompat(h =>
           h(InstantSearchSsr, {}, [
-            h(
-              Configure,
-              isVue3
-                ? { hitsPerPage: 100 }
-                : {
-                    attrs: {
-                      hitsPerPage: 100,
-                    },
-                  }
-            ),
+            h(Configure, {
+              attrs: {
+                hitsPerPage: 100,
+              },
+            }),
             h(SearchBox),
           ])
         ),

--- a/src/util/vue-compat/index-2.js
+++ b/src/util/vue-compat/index-2.js
@@ -7,6 +7,12 @@ const version = Vue.version;
 
 export { Vue, Vue2, isVue2, isVue3, version };
 
+export function renderCompat(fn) {
+  return function(createElement) {
+    return fn.call(this, createElement);
+  };
+}
+
 // Vue3-only APIs
 export const computed = undefined;
 export const createApp = undefined;

--- a/src/util/vue-compat/index-2.js
+++ b/src/util/vue-compat/index-2.js
@@ -13,6 +13,10 @@ export function renderCompat(fn) {
   };
 }
 
+export function getDefaultSlot(component) {
+  return component.$slots.default;
+}
+
 // Vue3-only APIs
 export const computed = undefined;
 export const createApp = undefined;

--- a/src/util/vue-compat/index-3.js
+++ b/src/util/vue-compat/index-3.js
@@ -6,3 +6,9 @@ const Vue2 = undefined;
 
 export { createApp, createSSRApp, h, version, nextTick } from 'vue';
 export { Vue, Vue2, isVue2, isVue3 };
+
+export function renderCompat(fn) {
+  return function() {
+    return fn.call(this, Vue.h);
+  };
+}

--- a/src/util/vue-compat/index-3.js
+++ b/src/util/vue-compat/index-3.js
@@ -12,3 +12,7 @@ export function renderCompat(fn) {
     return fn.call(this, Vue.h);
   };
 }
+
+export function getDefaultSlot(component) {
+  return component.$slots.default && component.$slots.default();
+}

--- a/src/util/vue-compat/index-3.js
+++ b/src/util/vue-compat/index-3.js
@@ -8,8 +8,21 @@ export { createApp, createSSRApp, h, version, nextTick } from 'vue';
 export { Vue, Vue2, isVue2, isVue3 };
 
 export function renderCompat(fn) {
+  function h(tag, props, children) {
+    if (typeof props === 'object' && (props.attrs || props.props)) {
+      // In vue 3, we no longer wrap with `attrs` or `props` key.
+      const flatProps = Object.assign({}, props, props.attrs, props.props);
+      delete flatProps.attrs;
+      delete flatProps.props;
+
+      return Vue.h(tag, flatProps, children);
+    }
+
+    return Vue.h(tag, props, children);
+  }
+
   return function() {
-    return fn.call(this, Vue.h);
+    return fn.call(this, h);
   };
 }
 

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -1,6 +1,5 @@
 import {
   isVue3,
-  h,
   createApp as _createApp,
   createSSRApp as _createSSRApp,
   nextTick as _nextTick,

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -75,10 +75,4 @@ export const createSSRApp = props => {
   }
 };
 
-export function renderCompat(fn) {
-  return function(createElementV2) {
-    return isVue3 ? fn.call(this, h) : fn.call(this, createElementV2);
-  };
-}
-
 export const nextTick = () => (isVue3 ? _nextTick() : Vue2.nextTick());


### PR DESCRIPTION
## Summary

This PR adds `renderCompat` and `getDefaultSlot` to support compatibility between the versions and to have less conditional codes.