### PR TITLE
fix(vue 3): update @vue/test-utils and use setData for array items

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@storybook/vue": "3.4.11",
     "@vue/compiler-sfc": "3.0.11",
     "@vue/test-utils": "1.2.1",
-    "@vue/test-utils2": "npm:@vue/test-utils@2.0.0-rc.10",
+    "@vue/test-utils2": "npm:@vue/test-utils@2.0.0-rc.11",
     "@wdio/cli": "^5.11.13",
     "@wdio/jasmine-framework": "^5.11.0",
     "@wdio/local-runner": "^5.11.13",

--- a/src/components/__tests__/CurrentRefinements.js
+++ b/src/components/__tests__/CurrentRefinements.js
@@ -1,4 +1,4 @@
-import { mount, nextTick } from '../../../test/utils';
+import { mount } from '../../../test/utils';
 import CurrentRefinements from '../CurrentRefinements.vue';
 import { __setState } from '../../mixins/widget';
 
@@ -177,8 +177,7 @@ it('calls the Panel mixin with `canRefine`', async () => {
 
   expect(mapStateToCanRefine()).toBe(true);
 
-  wrapper.vm.state.items = [];
-  await nextTick();
+  await wrapper.setData({ state: { items: [] } });
 
   expect(mapStateToCanRefine()).toBe(false);
 

--- a/src/components/__tests__/HierarchicalMenu.js
+++ b/src/components/__tests__/HierarchicalMenu.js
@@ -1,4 +1,4 @@
-import { mount, nextTick } from '../../../test/utils';
+import { mount } from '../../../test/utils';
 import { __setState } from '../../mixins/widget';
 import HierarchicalMenu from '../HierarchicalMenu.vue';
 
@@ -478,10 +478,7 @@ it('calls the Panel mixin with `items.length`', async () => {
 
   expect(mapStateToCanRefine()).toBe(true);
 
-  // should've used wrapper.setData({ state: { items: [] }})
-  // but https://github.com/vuejs/vue-test-utils-next/issues/766
-  wrapper.vm.state.items = [];
-  await nextTick();
+  await wrapper.setData({ state: { items: [] } });
 
   expect(mapStateToCanRefine()).toBe(false);
 

--- a/src/components/__tests__/InstantSearch-integration.js
+++ b/src/components/__tests__/InstantSearch-integration.js
@@ -176,8 +176,7 @@ describe('middlewares', () => {
       uiState: { indexName: { query: 'a' } },
     });
 
-    wrapper.vm.middlewares = [middleware1];
-    await nextTick();
+    await wrapper.setData({ middlewares: [middleware1] });
 
     expect(middlewareSpy1.unsubscribe).toHaveBeenCalledTimes(0);
     expect(middlewareSpy2.unsubscribe).toHaveBeenCalledTimes(1);

--- a/src/components/__tests__/RangeInput.js
+++ b/src/components/__tests__/RangeInput.js
@@ -1,4 +1,4 @@
-import { mount, nextTick } from '../../../test/utils';
+import { mount } from '../../../test/utils';
 import { __setState } from '../../mixins/widget';
 import RangeInput from '../RangeInput.vue';
 
@@ -390,8 +390,7 @@ describe('refinement', () => {
     expect(refine).toHaveBeenCalledWith(['10', '100']);
 
     // update the state
-    wrapper.vm.state.start = [50, 200]; // min: 10 -> 50, max: 100 -> 200
-    await nextTick();
+    await wrapper.setData({ state: { start: [50, 200] } }); // min: 10 -> 50, max: 100 -> 200
 
     await form.trigger('submit');
     expect(refine).toHaveBeenCalledTimes(2);

--- a/yarn.lock
+++ b/yarn.lock
@@ -863,10 +863,10 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.11.tgz#20d22dd0da7d358bb21c17f9bde8628152642c77"
   integrity sha512-b+zB8A2so8eCE0JsxjL24J7vdGl8rzPQ09hZNhystm+KqSbKcAej1A+Hbva1rCMmTTqA+hFnUSDc5kouEo0JzA==
 
-"@vue/test-utils2@npm:@vue/test-utils@2.0.0-rc.10":
-  version "2.0.0-rc.10"
-  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-2.0.0-rc.10.tgz#9ed689cd7d5a1c9ef6693806010e464d2ecc13b2"
-  integrity sha512-Z8jY+askU08svsI37NcJSLmWrfkZ/1ATA1DENWezRUX2uv3QyEj7idwx+rfeNSOrlNNBh4NTzypBKOUOklxBRA==
+"@vue/test-utils2@npm:@vue/test-utils@2.0.0-rc.11":
+  version "2.0.0-rc.11"
+  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-2.0.0-rc.11.tgz#62521dc1d758cb0458a375e7eba1a4503e1e27f5"
+  integrity sha512-7XMp3ha/dSvPoJAWx9Ils9CLByu8Ntk/DOPXj8Elp/fqtUXngj/DiXEcBBNLboiS5ux3xYfKfakzz4JNpind+A==
 
 "@vue/test-utils@1.2.1":
   version "1.2.1"


### PR DESCRIPTION
## Summary

This PR updates `@vue/test-utils`
(https://github.com/vuejs/vue-test-utils-next/pull/767)

And updates some of the test cases to use `setData` which was impossible because VTU was wrongly concatenating arrays.