### PR TITLE
fix(vue 3): do not pass props for cloned component in vue 3

### DIFF
--- a/src/util/__tests__/createServerRootMixin.test.js
+++ b/src/util/__tests__/createServerRootMixin.test.js
@@ -396,57 +396,56 @@ Array [
       await renderToString(wrapper);
     });
 
-    it('forwards props', async () => {
-      const searchClient = createFakeClient();
+    if (isVue2) {
+      it('forwards props', async () => {
+        const searchClient = createFakeClient();
 
-      // there are two renders of App, each with an assertion
-      expect.assertions(2);
+        // there are two renders of App, each with an assertion
+        expect.assertions(2);
 
-      const someProp = { data: Math.random() };
+        const someProp = { data: Math.random() };
 
-      const App = {
-        mixins: [
-          forceIsServerMixin,
-          createServerRootMixin({
-            searchClient,
-            indexName: 'hello',
-          }),
-        ],
-        props: {
-          someProp: {
-            required: true,
-            type: Object,
-            validator(value) {
-              expect(value).toBe(someProp);
-              return value === someProp;
+        const App = {
+          mixins: [
+            forceIsServerMixin,
+            createServerRootMixin({
+              searchClient,
+              indexName: 'hello',
+            }),
+          ],
+          props: {
+            someProp: {
+              required: true,
+              type: Object,
+              validator(value) {
+                expect(value).toBe(someProp);
+                return value === someProp;
+              },
             },
           },
-        },
-        render: renderCompat(h =>
-          h(InstantSearchSsr, {}, [
-            h(Configure, {
-              attrs: {
-                hitsPerPage: 100,
-              },
-            }),
-            h(SearchBox),
-          ])
-        ),
-        serverPrefetch() {
-          return this.instantsearch.findResultsState(this);
-        },
-      };
+          render: renderCompat(h =>
+            h(InstantSearchSsr, {}, [
+              h(Configure, {
+                attrs: {
+                  hitsPerPage: 100,
+                },
+              }),
+              h(SearchBox),
+            ])
+          ),
+          serverPrefetch() {
+            return this.instantsearch.findResultsState(this);
+          },
+        };
 
-      const wrapper = createSSRApp({
-        mixins: [forceIsServerMixin],
-        render: renderCompat(h => h(App, { props: { someProp } })),
+        const wrapper = createSSRApp({
+          mixins: [forceIsServerMixin],
+          render: renderCompat(h => h(App, { props: { someProp } })),
+        });
+
+        await renderToString(wrapper);
       });
 
-      await renderToString(wrapper);
-    });
-
-    // FIXME: make these work with Vue 3
-    if (isVue2) {
       it('forwards slots', async done => {
         const searchClient = createFakeClient();
 

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -7,7 +7,6 @@ import {
   createSSRApp,
   renderToString,
 } from '../util/vue-compat';
-import { _objectSpread } from '../util/polyfills';
 const { SearchResults, SearchParameters } = algoliaHelper;
 import { warn } from './warn';
 

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -51,13 +51,7 @@ function defaultCloneComponent(componentInstance, { mixins = [] } = {}) {
   if (isVue3) {
     const appOptions = Object.assign({}, componentInstance.$options, options);
     appOptions.mixins = [...appOptions.mixins, ...mixins];
-    // Unlike Vue 2, there is no componentInstance.$options.propsData in Vue 3.
-    // The only way to pass the propsData is to spread componentInstance
-    // in the second argument, hoping the rest wouldn't make any side effect.
-    // At this point, we don't even have the definition of the props.
-    // So we cannot pass exactly the propsData only.
-    // FIXME: Maybe we need to get the list of props in `createServerRootMixin`.
-    app = createSSRApp(appOptions, _objectSpread({}, componentInstance));
+    app = createSSRApp(appOptions);
     if (componentInstance.$router) {
       app.use(componentInstance.$router);
     }


### PR DESCRIPTION
## Summary

This PR removes the part where it was spreading the component to pass the propsData to the cloned component in Vue 3.

Theoretically we should pass the propsData from the original component to the newly cloned component, but I don't see the concrete real life example for that. Besides, the way we spread the component isn't ideal and we get warning messages from vue.

```
      [Vue warn]: Avoid app logic that relies on enumerating keys on a component instance. The keys will be empty in production mode to avoid performance overhead.
```

If it turns out later to be a valid point with an example, we can discuss and address it.