### PR TITLE
chore(vue 3): enable shipjs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,3 +113,4 @@ workflows:
             branches:
               only:
                 - master
+                - feat/vue3-compat


### PR DESCRIPTION
## Summary

This PR enables shipjs on `feat/vue3-compat` branch. By this change, we can create release pull-requests based on `feat/vue3-compat`.

When we merge the branch to `master`, I will revert this change, so that we can enable `shipjs trigger` only on `master` branch again.