### PR TITLE
Passing algoliaStateScript and preloadLinks from render

### DIFF
--- a/examples/vue3-ssr-vite/index.html
+++ b/examples/vue3-ssr-vite/index.html
@@ -9,5 +9,6 @@
   <body>
     <div id="app"><!--app-html--></div>
     <script type="module" src="/src/entry-client.js"></script>
+    <!--algolia-state-script-->
   </body>
 </html>

--- a/examples/vue3-ssr-vite/server.js
+++ b/examples/vue3-ssr-vite/server.js
@@ -68,11 +68,12 @@ async function createServer(
         render = require('./dist/server/entry-server.js').render;
       }
 
-      const [appHtml, preloadLinks] = await render(url, manifest);
+      const { appHtml, algoliaStateScript, preloadLinks } = await render(url, manifest);
 
       const html = template
         .replace(`<!--preload-links-->`, preloadLinks)
-        .replace(`<!--app-html-->`, appHtml);
+        .replace(`<!--app-html-->`, appHtml)
+        .replace(`<!--algolia-state-script-->`, algoliaStateScript);
 
       res
         .status(200)

--- a/examples/vue3-ssr-vite/src/entry-server.js
+++ b/examples/vue3-ssr-vite/src/entry-server.js
@@ -23,7 +23,7 @@ export async function render(url, manifest) {
   // which we can then use to determine what files need to be preloaded for this
   // request.
   const preloadLinks = renderPreloadLinks(ctx.modules, manifest);
-  return [html, algoliaStateScript, preloadLinks];
+  return { html, algoliaStateScript, preloadLinks };
 }
 
 function renderPreloadLinks(modules, manifest) {


### PR DESCRIPTION
Hello,

On SRR example with vite `render` function from `entry-server.js` return an array of 3 (html, algoliaStateScript and preloadLinks)
but on `server.js`, `render` is destructured with an array of 2 (html and preloadLinks)
It is better to pass an object to prevent argument shifting.

Now the example handle algoliaStateScript + preloadLinks with running for production !