### PR TITLE
fix(vue 3): let users pass renderToString to createServerRootMixin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-  presets: ['es2015'],
-  plugins: ['dynamic-import-node']
+  presets: ['es2015']
 }

--- a/examples/nuxt/pages/search.vue
+++ b/examples/nuxt/pages/search.vue
@@ -64,6 +64,16 @@ import {
   createServerRootMixin,
 } from 'vue-instantsearch'; // eslint-disable-line import/no-unresolved
 import algoliasearch from 'algoliasearch/lite';
+import _renderToString from 'vue-server-renderer/basic';
+
+function renderToString(app) {
+  return new Promise((resolve, reject) => {
+    _renderToString(app, (err, res) => {
+      if (err) reject(err);
+      resolve(res);
+    });
+  });
+}
 
 const searchClient = algoliasearch(
   'latency',
@@ -73,6 +83,7 @@ const searchClient = algoliasearch(
 export default {
   mixins: [
     createServerRootMixin({
+      renderToString,
       searchClient,
       indexName: 'instant_search',
       initialUiState: {

--- a/examples/ssr/src/main.js
+++ b/examples/ssr/src/main.js
@@ -4,6 +4,16 @@ import { createRouter } from './router';
 import { createServerRootMixin } from 'vue-instantsearch';
 import algoliasearch from 'algoliasearch/lite';
 import qs from 'qs';
+import _renderToString from 'vue-server-renderer/basic';
+
+function renderToString(app) {
+  return new Promise((resolve, reject) => {
+    _renderToString(app, (err, res) => {
+      if (err) reject(err);
+      resolve(res);
+    });
+  });
+}
 
 const searchClient = algoliasearch(
   'latency',
@@ -26,6 +36,7 @@ export async function createApp({
   const app = new Vue({
     mixins: [
       createServerRootMixin({
+        renderToString,
         searchClient,
         indexName: 'instant_search',
         routing: {

--- a/examples/vue3-ssr-vite/src/main.js
+++ b/examples/vue3-ssr-vite/src/main.js
@@ -2,6 +2,7 @@ import { createServerRootMixin } from 'vue-instantsearch/dist/vue3/es';
 import algoliasearch from 'algoliasearch/lite';
 import { createSSRApp, h } from 'vue';
 import qs from 'qs';
+import { renderToString } from '@vue/server-renderer';
 
 import App from './App.vue';
 import { createRouter } from './router';
@@ -22,6 +23,7 @@ export function createApp({ context } = {}) {
   const app = createSSRApp({
     mixins: [
       createServerRootMixin({
+        renderToString,
         searchClient,
         indexName: 'instant_search',
         routing: {

--- a/examples/vue3-ssr-vue-cli/src/app.js
+++ b/examples/vue3-ssr-vue-cli/src/app.js
@@ -2,6 +2,7 @@ import { createSSRApp, h } from 'vue';
 import algoliasearch from 'algoliasearch/lite';
 import { createServerRootMixin } from 'vue-instantsearch/dist/vue3/es';
 import qs from 'qs';
+import { renderToString } from '@vue/server-renderer';
 import App from './App.vue';
 import { createRouter } from './router';
 
@@ -17,6 +18,7 @@ export function createApp({ context } = {}) {
   const app = createSSRApp({
     mixins: [
       createServerRootMixin({
+        renderToString,
         indexName: 'instant_search',
         searchClient,
         routing: {

--- a/package.json
+++ b/package.json
@@ -48,14 +48,14 @@
   },
   "dependencies": {
     "algoliasearch-helper": "^3.1.0",
-    "mitt": "^2.1.0",
-    "instantsearch.js": "^4.25.0"
+    "instantsearch.js": "^4.25.0",
+    "mitt": "^2.1.0"
   },
   "peerDependencies": {
+    "@vue/server-renderer": "^3.1.2",
     "algoliasearch": ">= 3.32.0 < 5",
     "vue": "^2.6.0 || >=3.0.0-rc.0",
-    "vue-server-renderer": "^2.6.11",
-    "@vue/server-renderer": "^3.1.2"
+    "vue-server-renderer": "^2.6.11"
   },
   "peerDependenciesMeta": {
     "vue-server-renderer": {
@@ -83,7 +83,6 @@
     "algoliasearch": "4.0.1",
     "babel-eslint": "10.0.1",
     "babel-jest": "23.6.0",
-    "babel-plugin-dynamic-import-node": "2.3.3",
     "babel-preset-es2015": "6.24.1",
     "bundlesize": "0.17.1",
     "concurrently": "4.1.0",

--- a/src/util/__tests__/createServerRootMixin.test.js
+++ b/src/util/__tests__/createServerRootMixin.test.js
@@ -9,13 +9,7 @@ import SearchBox from '../../components/SearchBox.vue';
 import { createWidgetMixin } from '../../mixins/widget';
 import { createFakeClient } from '../testutils/client';
 import { createSerializedState } from '../testutils/helper';
-import {
-  isVue3,
-  isVue2,
-  Vue2,
-  renderCompat,
-  renderToString,
-} from '../vue-compat';
+import { isVue3, isVue2, Vue2, renderCompat } from '../vue-compat';
 import {
   SearchResults,
   SearchParameters,
@@ -23,6 +17,19 @@ import {
 } from 'algoliasearch-helper';
 
 jest.unmock('instantsearch.js/es');
+
+function renderToString(app) {
+  if (isVue3) {
+    return require('@vue/server-renderer').renderToString(app);
+  } else {
+    return new Promise((resolve, reject) => {
+      require('vue-server-renderer/basic')(app, (err, res) => {
+        if (err) reject(err);
+        resolve(res);
+      });
+    });
+  }
+}
 
 const forceIsServerMixin = {
   beforeCreate() {
@@ -45,6 +52,7 @@ describe('createServerRootMixin', () => {
         createSSRApp({
           mixins: [
             createServerRootMixin({
+              renderToString,
               searchClient: undefined,
               indexName: 'lol',
             }),
@@ -60,6 +68,7 @@ describe('createServerRootMixin', () => {
         createSSRApp({
           mixins: [
             createServerRootMixin({
+              renderToString,
               searchClient: createFakeClient(),
               indexName: undefined,
             }),
@@ -70,10 +79,26 @@ describe('createServerRootMixin', () => {
       );
     });
 
+    it('requires renderToString', () => {
+      expect(() =>
+        createSSRApp({
+          mixins: [
+            createServerRootMixin({
+              searchClient: createFakeClient(),
+              indexName: 'yup',
+            }),
+          ],
+        })
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"createServerRootMixin requires \`renderToString: (app) => Promise<string>\` in the first argument"`
+      );
+    });
+
     it('creates an instantsearch instance on "data"', () => {
       const App = {
         mixins: [
           createServerRootMixin({
+            renderToString,
             searchClient: createFakeClient(),
             indexName: 'lol',
           }),
@@ -93,6 +118,7 @@ describe('createServerRootMixin', () => {
       const App = {
         mixins: [
           createServerRootMixin({
+            renderToString,
             searchClient: createFakeClient(),
             indexName: 'myIndexName',
           }),
@@ -138,6 +164,7 @@ describe('createServerRootMixin', () => {
         mixins: [
           forceIsServerMixin,
           createServerRootMixin({
+            renderToString,
             searchClient: createFakeClient(),
             indexName: 'hello',
           }),
@@ -160,6 +187,7 @@ describe('createServerRootMixin', () => {
         mixins: [
           forceIsServerMixin,
           createServerRootMixin({
+            renderToString,
             searchClient,
             indexName: 'hello',
           }),
@@ -233,6 +261,7 @@ Array [
         mixins: [
           forceIsServerMixin,
           createServerRootMixin({
+            renderToString,
             searchClient,
             indexName: 'hello',
           }),
@@ -310,6 +339,7 @@ Array [
         mixins: [
           forceIsServerMixin,
           createServerRootMixin({
+            renderToString,
             searchClient,
             indexName: 'hello',
           }),
@@ -360,6 +390,7 @@ Array [
         mixins: [
           forceIsServerMixin,
           createServerRootMixin({
+            renderToString,
             searchClient,
             indexName: 'hello',
           }),
@@ -409,6 +440,7 @@ Array [
           mixins: [
             forceIsServerMixin,
             createServerRootMixin({
+              renderToString,
               searchClient,
               indexName: 'hello',
             }),
@@ -455,6 +487,7 @@ Array [
           mixins: [
             forceIsServerMixin,
             createServerRootMixin({
+              renderToString,
               searchClient,
               indexName: 'hello',
             }),
@@ -508,6 +541,7 @@ Array [
           mixins: [
             forceIsServerMixin,
             createServerRootMixin({
+              renderToString,
               searchClient,
               indexName: 'hello',
             }),
@@ -566,6 +600,7 @@ Array [
           mixins: [
             forceIsServerMixin,
             createServerRootMixin({
+              renderToString,
               searchClient,
               indexName: 'hello',
             }),
@@ -603,6 +638,7 @@ Array [
       const app = {
         mixins: [
           createServerRootMixin({
+            renderToString,
             searchClient: createFakeClient(),
             indexName: 'hello',
           }),
@@ -649,6 +685,7 @@ Array [
       const app = {
         mixins: [
           createServerRootMixin({
+            renderToString,
             searchClient: createFakeClient(),
             indexName: 'movies',
           }),
@@ -687,6 +724,7 @@ Array [
       const app = {
         mixins: [
           createServerRootMixin({
+            renderToString,
             searchClient: createFakeClient(),
             indexName: 'hello',
           }),
@@ -725,6 +763,7 @@ Array [
       const app = {
         mixins: [
           createServerRootMixin({
+            renderToString,
             searchClient: createFakeClient(),
             indexName: 'hello',
           }),
@@ -764,6 +803,7 @@ Array [
       mount({
         mixins: [
           createServerRootMixin({
+            renderToString,
             searchClient: createFakeClient(),
             indexName: 'lol',
           }),
@@ -835,6 +875,7 @@ Object {
         mount({
           mixins: [
             createServerRootMixin({
+              renderToString,
               searchClient: createFakeClient(),
               indexName: 'lol',
             }),
@@ -868,6 +909,7 @@ Object {
         mount({
           mixins: [
             createServerRootMixin({
+              renderToString,
               searchClient: createFakeClient(),
               indexName: 'lol',
             }),

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -1,12 +1,6 @@
 import instantsearch from 'instantsearch.js/es';
 import algoliaHelper from 'algoliasearch-helper';
-import {
-  isVue3,
-  isVue2,
-  Vue2,
-  createSSRApp,
-  renderToString,
-} from '../util/vue-compat';
+import { isVue3, isVue2, Vue2, createSSRApp } from '../util/vue-compat';
 const { SearchResults, SearchParameters } = algoliaHelper;
 import { warn } from './warn';
 
@@ -86,7 +80,8 @@ function augmentInstantSearch(
   instantSearchOptions,
   searchClient,
   indexName,
-  cloneComponent
+  cloneComponent,
+  renderToString
 ) {
   /* eslint-disable no-param-reassign */
 
@@ -263,6 +258,7 @@ export function createServerRootMixin(instantSearchOptions = {}) {
   const {
     searchClient,
     indexName,
+    renderToString,
     $cloneComponent = defaultCloneComponent,
   } = instantSearchOptions;
 
@@ -272,11 +268,18 @@ export function createServerRootMixin(instantSearchOptions = {}) {
     );
   }
 
+  if (!renderToString) {
+    throw new Error(
+      'createServerRootMixin requires `renderToString: (app) => Promise<string>` in the first argument'
+    );
+  }
+
   const search = augmentInstantSearch(
     instantSearchOptions,
     searchClient,
     indexName,
-    $cloneComponent
+    $cloneComponent,
+    renderToString
   );
 
   // put this in the user's root Vue instance

--- a/src/util/vue-compat/index-2.js
+++ b/src/util/vue-compat/index-2.js
@@ -17,24 +17,6 @@ export function getDefaultSlot(component) {
   return component.$slots.default;
 }
 
-export async function renderToString(app) {
-  let _renderToString;
-  try {
-    _renderToString = (await import('vue-server-renderer/basic')).default;
-  } catch (err) {
-    // error is handled by regular if, in case it's `undefined`
-  }
-  if (!_renderToString) {
-    throw new Error('you need to install vue-server-renderer');
-  }
-  return new Promise((resolve, reject) =>
-    _renderToString(app, (err, res) => {
-      if (err) reject(err);
-      resolve(res);
-    })
-  );
-}
-
 // Vue3-only APIs
 export const computed = undefined;
 export const createApp = undefined;

--- a/src/util/vue-compat/index-3.js
+++ b/src/util/vue-compat/index-3.js
@@ -29,18 +29,3 @@ export function renderCompat(fn) {
 export function getDefaultSlot(component) {
   return component.$slots.default && component.$slots.default();
 }
-
-export async function renderToString(app) {
-  let module;
-  try {
-    // It's an optional peer dependency, so it might be there.
-    // eslint-disable-next-line import/no-unresolved
-    module = await import('@vue/server-renderer');
-  } catch (err) {
-    // error is handled by regular if, in case it's `undefined`
-  }
-  if (!module) {
-    throw new Error('you need to install @vue/server-renderer');
-  }
-  return module.renderToString(app);
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2040,13 +2040,6 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-dynamic-import-node@2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz#84fda19c976ec5c6defef57f9427b3def66e17a3"
-  integrity sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==
-  dependencies:
-    object.assign "^4.1.0"
-
 babel-plugin-istanbul@^4.1.6:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
@@ -3389,7 +3382,7 @@ cacheable-request@^7.0.1:
     normalize-url "^4.1.0"
     responselike "^2.0.0"
 
-call-bind@^1.0.0, call-bind@^1.0.2:
+call-bind@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
   integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
@@ -5153,7 +5146,7 @@ defer-to-connect@^2.0.0:
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.0.tgz#83d6b199db041593ac84d781b5222308ccf4c2c1"
   integrity sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==
 
-define-properties@^1.1.2, define-properties@^1.1.3:
+define-properties@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
@@ -11012,27 +11005,12 @@ object-keys@^1.0.12:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
   integrity sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==
 
-object-keys@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
-  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
-
 object-visit@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
   integrity sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=
   dependencies:
     isobject "^3.0.0"
-
-object.assign@^4.1.0:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
-  integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
-  dependencies:
-    call-bind "^1.0.0"
-    define-properties "^1.1.3"
-    has-symbols "^1.0.1"
-    object-keys "^1.1.1"
 
 object.entries@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
## Summary

This PR removes the code that dynamically importing `vue-server-renderer/basic` or `@vue/server-renderer` and now lets users pass `renderToString` function to `createServerRootMixin`.

Vue CLI and vite failed to run when those dependencies were not installed even though that importing code is never executed. Using `require` is not a good idea (especially in the ESM output). So we let users pass the function, although it's a breaking change.