### PR TITLE
fix(range-input): remove default min and max values from `ais-range-input`

### DIFF
--- a/src/components/RangeInput.vue
+++ b/src/components/RangeInput.vue
@@ -80,14 +80,12 @@ export default {
     min: {
       type: Number,
       required: false,
-      // @major: remove this default
-      default: -Infinity,
+      default: undefined,
     },
     max: {
       type: Number,
       required: false,
-      // @major: remove this default
-      default: Infinity,
+      default: undefined,
     },
     precision: {
       type: Number,


### PR DESCRIPTION
## Summary

This PR removes the default min and max values from `ais-range-input`.

BREAKING CHANGE, but it won't likely affect the behavior.