### PR TITLE
fix(state-results): clean up slot props

### DIFF
--- a/src/components/StateResults.vue
+++ b/src/components/StateResults.vue
@@ -3,7 +3,10 @@
     :class="suit()"
     v-if="state && state.state && state.results"
   >
-    <slot v-bind="stateResults">
+    <slot
+      :state="state.state"
+      :results="state.results"
+    >
       <p>
         Use this component to have a different layout based on a certain state.
       </p>
@@ -19,7 +22,6 @@
 <script>
 import { createSuitMixin } from '../mixins/suit';
 import { createWidgetMixin } from '../mixins/widget';
-import { _objectSpread } from '../util/polyfills';
 import connectStateResults from '../connectors/connectStateResults';
 
 export default {
@@ -28,12 +30,5 @@ export default {
     createWidgetMixin({ connector: connectStateResults }),
     createSuitMixin({ name: 'StateResults' }),
   ],
-  computed: {
-    stateResults() {
-      // @MAJOR: replace v-bind="stateResults" with :state="state.state" :results="state.results"
-      const { state, results } = this.state;
-      return _objectSpread({}, results, { results, state });
-    },
-  },
 };
 </script>

--- a/src/components/__tests__/StateResults.js
+++ b/src/components/__tests__/StateResults.js
@@ -44,7 +44,6 @@ it('gives state & results to default slot', () => {
   mount(StateResults, {
     scopedSlots: {
       default: props => {
-        expect(props).toEqual(expect.objectContaining(results));
         expect(props.results).toEqual(results);
         expect(props.state).toEqual(state);
       },
@@ -184,7 +183,7 @@ describe('legacy spread props', () => {
       components: { StateResults },
       template: `
         <StateResults>
-          <template v-slot="{ query }">
+          <template v-slot="{ results: { query }}">
             <p v-if="query">
               Query is here
             </p>
@@ -219,7 +218,7 @@ describe('legacy spread props', () => {
       components: { StateResults },
       template: `
         <StateResults>
-          <template v-slot="{ query }">
+          <template v-slot="{ results: { query } }">
             <p v-if="query">
               Query is here
             </p>

--- a/stories/StateResults.stories.js
+++ b/stories/StateResults.stories.js
@@ -7,7 +7,7 @@ storiesOf('ais-state-results', module)
       indexName: 'demo-query-rules',
       filters: '<ais-refinement-list attribute="genre" />',
       hits: `
-      <template v-slot="{ items }">
+      <template v-slot="{ state: { items } }">
         <ol class="playground-hits">
           <li
             v-for="item in items"


### PR DESCRIPTION
## Summary

This PR cleans up the slot props to `ais-state-results` component.

```vue
<ais-state-results>
  <template v-slot="myProps">

  </template>
</ais-state-results>
```

Here, `myProps` used to be something like this:

```js
myProps = {
  ...results,
  results,
  state
}
```

It was an object with `results` and `state` keys and also had `results` object spread.

Now it is an object with only `results` and `state` keys.

### How does it change?

If there is the following code:

```vue
<ais-state-results>
  <template v-slot="{ state, results }">
    // do something with `state` or `results`
  </template>
</ais-state-results>
```

then it's fine. Nothing is broken.

However, 

```vue
<ais-state-results>
  <template v-slot="{ hits }">

  </template>
</ais-state-results>
```

If it was accessing something from results like that, it should be replaced with `v-slot="{ results: { hits } }"`


BREAKING CHANGE