### PR TITLE
chore(vue 3): shorten import path for vue3

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,7 @@
 _book/
 docs/
 coverage/
-dist/
+vue2/
 vue3/
 examples/*/node_modules/*
 scripts/es-index-template.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -2,6 +2,7 @@ _book/
 docs/
 coverage/
 dist/
+vue3/
 examples/*/node_modules/*
 scripts/es-index-template.js
 website/examples/*

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,7 @@
 _book/
 docs/
 coverage/
+dist/
 vue2/
 vue3/
 examples/*/node_modules/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,22 @@
-dist/
-vue2/
-es/
-vue3/
-yarn-error.log
+# package manager
 node_modules/
-coverage
+yarn-error.log
+
+# OS-specific files
 .DS_store
+
+# cache
 .nuxt
+
+# secret
 .env
 
 # Generated files
 /website/stories
 /website/examples/*
 !/website/examples/index.html
+coverage
+
+# published files
+vue2/
+vue3/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist/
 es/
+vue3/
 yarn-error.log
 node_modules/
 coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+dist/
 vue2/
 es/
 vue3/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-dist/
+vue2/
 es/
 vue3/
 yarn-error.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ If you have different setup or use different bundler, you may check if it still 
 Vue InstantSearch includes two packages, one for vue 2 and another one for vue 3. So for vue 3, you need to import with this path:
 
 ```js
-import InstantSearch from 'vue-instantsearch/dist/vue3/es';
+import InstantSearch from 'vue-instantsearch/vue3/es';
 ```
 
 ## Regarding vue-router@v4

--- a/examples/vue3-ssr-vite/src/main.js
+++ b/examples/vue3-ssr-vite/src/main.js
@@ -1,4 +1,4 @@
-import { createServerRootMixin } from 'vue-instantsearch/dist/vue3/es';
+import { createServerRootMixin } from 'vue-instantsearch/vue3/es';
 import algoliasearch from 'algoliasearch/lite';
 import { createSSRApp, h } from 'vue';
 import qs from 'qs';

--- a/examples/vue3-ssr-vite/src/pages/Home.vue
+++ b/examples/vue3-ssr-vite/src/pages/Home.vue
@@ -65,7 +65,7 @@ import {
   AisHits,
   AisHighlight,
   AisPagination,
-} from 'vue-instantsearch/dist/vue3/es';
+} from 'vue-instantsearch/vue3/es';
 
 export default {
   components: {

--- a/examples/vue3-ssr-vue-cli/src/app.js
+++ b/examples/vue3-ssr-vue-cli/src/app.js
@@ -1,6 +1,6 @@
 import { createSSRApp, h } from 'vue';
 import algoliasearch from 'algoliasearch/lite';
-import { createServerRootMixin } from 'vue-instantsearch/dist/vue3/es';
+import { createServerRootMixin } from 'vue-instantsearch/vue3/es';
 import qs from 'qs';
 import { renderToString } from '@vue/server-renderer';
 import App from './App.vue';

--- a/examples/vue3-ssr-vue-cli/src/pages/Home.vue
+++ b/examples/vue3-ssr-vue-cli/src/pages/Home.vue
@@ -65,7 +65,7 @@ import {
   AisHits,
   AisHighlight,
   AisPagination,
-} from 'vue-instantsearch/dist/vue3/es';
+} from 'vue-instantsearch/vue3/es';
 
 export default {
   components: {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "version": "4.0.0-beta.1",
   "files": [
     "dist",
+    "vue3",
     "src"
   ],
   "main": "dist/vue2/cjs",
@@ -26,7 +27,7 @@
   "sideEffects": false,
   "repository": "https://github.com/algolia/vue-instantsearch",
   "scripts": {
-    "prebuild": "rm -rf dist",
+    "prebuild": "rm -rf dist && rm -rf vue3",
     "build": "yarn build:vue2 && yarn build:vue3",
     "build:vue2": "./scripts/build-vue2.sh",
     "build:vue3": "./scripts/build-vue3.sh",
@@ -138,11 +139,11 @@
       "maxSize": "17.00 kB"
     },
     {
-      "path": "./dist/vue3/umd/index.js",
+      "path": "./vue3/umd/index.js",
       "maxSize": "55.50 kB"
     },
     {
-      "path": "./dist/vue3/cjs/index.js",
+      "path": "./vue3/cjs/index.js",
       "maxSize": "18.50 kB"
     }
   ],

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "sideEffects": false,
   "repository": "https://github.com/algolia/vue-instantsearch",
   "scripts": {
-    "prebuild": "rm -rf vue2 && rm -rf vue3",
+    "prebuild": "rm -rf vue2 vue3",
     "build": "yarn build:vue2 && yarn build:vue3",
     "build:vue2": "./scripts/build-vue2.sh",
     "build:vue3": "./scripts/build-vue3.sh",

--- a/package.json
+++ b/package.json
@@ -18,16 +18,16 @@
   "license": "MIT",
   "version": "4.0.0-beta.1",
   "files": [
-    "dist",
+    "vue2",
     "vue3",
     "src"
   ],
-  "main": "dist/vue2/cjs",
-  "module": "dist/vue2/es",
+  "main": "vue2/cjs",
+  "module": "vue2/es",
   "sideEffects": false,
   "repository": "https://github.com/algolia/vue-instantsearch",
   "scripts": {
-    "prebuild": "rm -rf dist && rm -rf vue3",
+    "prebuild": "rm -rf vue2 && rm -rf vue3",
     "build": "yarn build:vue2 && yarn build:vue3",
     "build:vue2": "./scripts/build-vue2.sh",
     "build:vue3": "./scripts/build-vue3.sh",
@@ -131,11 +131,11 @@
   },
   "bundlesize": [
     {
-      "path": "./dist/vue2/umd/index.js",
+      "path": "./vue2/umd/index.js",
       "maxSize": "54.00 kB"
     },
     {
-      "path": "./dist/vue2/cjs/index.js",
+      "path": "./vue2/cjs/index.js",
       "maxSize": "17.00 kB"
     },
     {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,8 +20,7 @@ const processEnv = conf => ({
 });
 
 const vuePlugin = process.env.VUE_VERSION === 'vue3' ? vueV3 : vueV2;
-const outputDir =
-  process.env.VUE_VERSION === 'vue3' ? 'dist/vue3' : 'dist/vue2';
+const outputDir = process.env.VUE_VERSION === 'vue3' ? 'vue3' : 'dist/vue2';
 
 const plugins = [
   vuePlugin({ compileTemplate: true, css: false }),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,7 +20,7 @@ const processEnv = conf => ({
 });
 
 const vuePlugin = process.env.VUE_VERSION === 'vue3' ? vueV3 : vueV2;
-const outputDir = process.env.VUE_VERSION === 'vue3' ? 'vue3' : 'dist/vue2';
+const outputDir = process.env.VUE_VERSION === 'vue3' ? 'vue3' : 'vue2';
 
 const plugins = [
   vuePlugin({ compileTemplate: true, css: false }),

--- a/scripts/build-vue2.sh
+++ b/scripts/build-vue2.sh
@@ -12,4 +12,4 @@ VUE_VERSION=vue2 rollup -c
 echo "$originalContent" > src/util/vue-compat/index.js
 
 # put an index file for es output
-cp ./scripts/es-index-template.js dist/vue2/es/index.js
+cp ./scripts/es-index-template.js vue2/es/index.js

--- a/scripts/build-vue3.sh
+++ b/scripts/build-vue3.sh
@@ -12,4 +12,4 @@ VUE_VERSION=vue3 rollup -c
 echo "$originalContent" > src/util/vue-compat/index.js
 
 # put an index file for es output
-cp ./scripts/es-index-template.js dist/vue3/es/index.js
+cp ./scripts/es-index-template.js vue3/es/index.js

--- a/src/components/RangeInput.vue
+++ b/src/components/RangeInput.vue
@@ -80,14 +80,12 @@ export default {
     min: {
       type: Number,
       required: false,
-      // @major: remove this default
-      default: -Infinity,
+      default: undefined,
     },
     max: {
       type: Number,
       required: false,
-      // @major: remove this default
-      default: Infinity,
+      default: undefined,
     },
     precision: {
       type: Number,


### PR DESCRIPTION
## Summary

This PR shortens the import path for vue3

from

```js
import InstantSearch from 'vue-instantsearch/dist/vue3/es';
```

to

```js
import InstantSearch from 'vue-instantsearch/vue3/es';
```