### PR TITLE
fix(vue 3): pass renderToString to findResultsState instead of createServerRootMixin

### DIFF
--- a/src/util/__tests__/createServerRootMixin.test.js
+++ b/src/util/__tests__/createServerRootMixin.test.js
@@ -182,9 +182,9 @@ describe('createServerRootMixin', () => {
         ),
         serverPrefetch() {
           expect(() =>
-            this.instantsearch.findResultsState(this)
+            this.instantsearch.findResultsState({ component: this })
           ).toThrowErrorMatchingInlineSnapshot(
-            `"findResultsState requires \`renderToString: (componentInstance) => Promise<string>\` in the second argument."`
+            `"findResultsState requires \`renderToString: (component) => Promise<string>\` in the first argument."`
           );
         },
       };
@@ -231,7 +231,10 @@ describe('createServerRootMixin', () => {
           ])
         ),
         serverPrefetch() {
-          return this.instantsearch.findResultsState(this, renderToString);
+          return this.instantsearch.findResultsState({
+            component: this,
+            renderToString,
+          });
         },
         created() {
           mainIndex = this.instantsearch.mainIndex;
@@ -293,10 +296,10 @@ Array [
           ])
         ),
         async serverPrefetch() {
-          const state = await this.instantsearch.findResultsState(
-            this,
-            renderToString
-          );
+          const state = await this.instantsearch.findResultsState({
+            component: this,
+            renderToString,
+          });
           expect(state).toEqual({
             __identifier: 'stringified',
             hello: {
@@ -377,7 +380,10 @@ Array [
           ])
         ),
         serverPrefetch() {
-          return this.instantsearch.findResultsState(this, renderToString);
+          return this.instantsearch.findResultsState({
+            component: this,
+            renderToString,
+          });
         },
       };
 
@@ -427,7 +433,10 @@ Array [
           ])
         ),
         serverPrefetch() {
-          return this.instantsearch.findResultsState(this, renderToString);
+          return this.instantsearch.findResultsState({
+            component: this,
+            renderToString,
+          });
         },
       };
 
@@ -482,7 +491,10 @@ Array [
             ])
           ),
           serverPrefetch() {
-            return this.instantsearch.findResultsState(this, renderToString);
+            return this.instantsearch.findResultsState({
+              component: this,
+              renderToString,
+            });
           },
         };
 
@@ -516,7 +528,7 @@ Array [
           serverPrefetch() {
             return (
               this.instantsearch
-                .findResultsState(this, renderToString)
+                .findResultsState({ component: this, renderToString })
                 .then(res => {
                   expect(
                     this.instantsearch.mainIndex.getWidgets().map(w => w.$$type)
@@ -566,7 +578,7 @@ Array [
           serverPrefetch() {
             return (
               this.instantsearch
-                .findResultsState(this, renderToString)
+                .findResultsState({ component: this, renderToString })
                 .then(res => {
                   expect(
                     this.instantsearch.mainIndex.getWidgets().map(w => w.$$type)
@@ -630,7 +642,10 @@ Array [
             ]);
           }),
           serverPrefetch() {
-            return this.instantsearch.findResultsState(this, renderToString);
+            return this.instantsearch.findResultsState({
+              component: this,
+              renderToString,
+            });
           },
         };
 

--- a/src/util/__tests__/createServerRootMixin.test.js
+++ b/src/util/__tests__/createServerRootMixin.test.js
@@ -52,7 +52,6 @@ describe('createServerRootMixin', () => {
         createSSRApp({
           mixins: [
             createServerRootMixin({
-              renderToString,
               searchClient: undefined,
               indexName: 'lol',
             }),
@@ -68,7 +67,6 @@ describe('createServerRootMixin', () => {
         createSSRApp({
           mixins: [
             createServerRootMixin({
-              renderToString,
               searchClient: createFakeClient(),
               indexName: undefined,
             }),
@@ -79,26 +77,10 @@ describe('createServerRootMixin', () => {
       );
     });
 
-    it('requires renderToString', () => {
-      expect(() =>
-        createSSRApp({
-          mixins: [
-            createServerRootMixin({
-              searchClient: createFakeClient(),
-              indexName: 'yup',
-            }),
-          ],
-        })
-      ).toThrowErrorMatchingInlineSnapshot(
-        `"createServerRootMixin requires \`renderToString: (app) => Promise<string>\` in the first argument"`
-      );
-    });
-
     it('creates an instantsearch instance on "data"', () => {
       const App = {
         mixins: [
           createServerRootMixin({
-            renderToString,
             searchClient: createFakeClient(),
             indexName: 'lol',
           }),
@@ -118,7 +100,6 @@ describe('createServerRootMixin', () => {
       const App = {
         mixins: [
           createServerRootMixin({
-            renderToString,
             searchClient: createFakeClient(),
             indexName: 'myIndexName',
           }),
@@ -164,7 +145,6 @@ describe('createServerRootMixin', () => {
         mixins: [
           forceIsServerMixin,
           createServerRootMixin({
-            renderToString,
             searchClient: createFakeClient(),
             indexName: 'hello',
           }),
@@ -179,6 +159,44 @@ describe('createServerRootMixin', () => {
       await renderToString(app);
     });
 
+    it('requires renderToString', async () => {
+      const searchClient = createFakeClient();
+
+      const app = {
+        mixins: [
+          forceIsServerMixin,
+          createServerRootMixin({
+            searchClient,
+            indexName: 'hello',
+          }),
+        ],
+        render: renderCompat(h =>
+          h(InstantSearchSsr, {}, [
+            h(Configure, {
+              attrs: {
+                hitsPerPage: 100,
+              },
+            }),
+            h(SearchBox),
+          ])
+        ),
+        serverPrefetch() {
+          expect(() =>
+            this.instantsearch.findResultsState(this)
+          ).toThrowErrorMatchingInlineSnapshot(
+            `"findResultsState requires \`renderToString: (componentInstance) => Promise<string>\` in the second argument."`
+          );
+        },
+      };
+
+      const wrapper = createSSRApp({
+        mixins: [forceIsServerMixin],
+        render: renderCompat(h => h(app)),
+      });
+
+      await renderToString(wrapper);
+    });
+
     it('detects child widgets', async () => {
       const searchClient = createFakeClient();
       let mainIndex;
@@ -187,7 +205,6 @@ describe('createServerRootMixin', () => {
         mixins: [
           forceIsServerMixin,
           createServerRootMixin({
-            renderToString,
             searchClient,
             indexName: 'hello',
           }),
@@ -214,7 +231,7 @@ describe('createServerRootMixin', () => {
           ])
         ),
         serverPrefetch() {
-          return this.instantsearch.findResultsState(this);
+          return this.instantsearch.findResultsState(this, renderToString);
         },
         created() {
           mainIndex = this.instantsearch.mainIndex;
@@ -261,7 +278,6 @@ Array [
         mixins: [
           forceIsServerMixin,
           createServerRootMixin({
-            renderToString,
             searchClient,
             indexName: 'hello',
           }),
@@ -277,7 +293,10 @@ Array [
           ])
         ),
         async serverPrefetch() {
-          const state = await this.instantsearch.findResultsState(this);
+          const state = await this.instantsearch.findResultsState(
+            this,
+            renderToString
+          );
           expect(state).toEqual({
             __identifier: 'stringified',
             hello: {
@@ -339,7 +358,6 @@ Array [
         mixins: [
           forceIsServerMixin,
           createServerRootMixin({
-            renderToString,
             searchClient,
             indexName: 'hello',
           }),
@@ -359,7 +377,7 @@ Array [
           ])
         ),
         serverPrefetch() {
-          return this.instantsearch.findResultsState(this);
+          return this.instantsearch.findResultsState(this, renderToString);
         },
       };
 
@@ -390,7 +408,6 @@ Array [
         mixins: [
           forceIsServerMixin,
           createServerRootMixin({
-            renderToString,
             searchClient,
             indexName: 'hello',
           }),
@@ -410,7 +427,7 @@ Array [
           ])
         ),
         serverPrefetch() {
-          return this.instantsearch.findResultsState(this);
+          return this.instantsearch.findResultsState(this, renderToString);
         },
       };
 
@@ -440,7 +457,6 @@ Array [
           mixins: [
             forceIsServerMixin,
             createServerRootMixin({
-              renderToString,
               searchClient,
               indexName: 'hello',
             }),
@@ -466,7 +482,7 @@ Array [
             ])
           ),
           serverPrefetch() {
-            return this.instantsearch.findResultsState(this);
+            return this.instantsearch.findResultsState(this, renderToString);
           },
         };
 
@@ -487,7 +503,6 @@ Array [
           mixins: [
             forceIsServerMixin,
             createServerRootMixin({
-              renderToString,
               searchClient,
               indexName: 'hello',
             }),
@@ -501,7 +516,7 @@ Array [
           serverPrefetch() {
             return (
               this.instantsearch
-                .findResultsState(this)
+                .findResultsState(this, renderToString)
                 .then(res => {
                   expect(
                     this.instantsearch.mainIndex.getWidgets().map(w => w.$$type)
@@ -541,7 +556,6 @@ Array [
           mixins: [
             forceIsServerMixin,
             createServerRootMixin({
-              renderToString,
               searchClient,
               indexName: 'hello',
             }),
@@ -552,7 +566,7 @@ Array [
           serverPrefetch() {
             return (
               this.instantsearch
-                .findResultsState(this)
+                .findResultsState(this, renderToString)
                 .then(res => {
                   expect(
                     this.instantsearch.mainIndex.getWidgets().map(w => w.$$type)
@@ -600,7 +614,6 @@ Array [
           mixins: [
             forceIsServerMixin,
             createServerRootMixin({
-              renderToString,
               searchClient,
               indexName: 'hello',
             }),
@@ -617,7 +630,7 @@ Array [
             ]);
           }),
           serverPrefetch() {
-            return this.instantsearch.findResultsState(this);
+            return this.instantsearch.findResultsState(this, renderToString);
           },
         };
 
@@ -638,7 +651,6 @@ Array [
       const app = {
         mixins: [
           createServerRootMixin({
-            renderToString,
             searchClient: createFakeClient(),
             indexName: 'hello',
           }),
@@ -685,7 +697,6 @@ Array [
       const app = {
         mixins: [
           createServerRootMixin({
-            renderToString,
             searchClient: createFakeClient(),
             indexName: 'movies',
           }),
@@ -724,7 +735,6 @@ Array [
       const app = {
         mixins: [
           createServerRootMixin({
-            renderToString,
             searchClient: createFakeClient(),
             indexName: 'hello',
           }),
@@ -763,7 +773,6 @@ Array [
       const app = {
         mixins: [
           createServerRootMixin({
-            renderToString,
             searchClient: createFakeClient(),
             indexName: 'hello',
           }),
@@ -803,7 +812,6 @@ Array [
       mount({
         mixins: [
           createServerRootMixin({
-            renderToString,
             searchClient: createFakeClient(),
             indexName: 'lol',
           }),
@@ -875,7 +883,6 @@ Object {
         mount({
           mixins: [
             createServerRootMixin({
-              renderToString,
               searchClient: createFakeClient(),
               indexName: 'lol',
             }),
@@ -909,7 +916,6 @@ Object {
         mount({
           mixins: [
             createServerRootMixin({
-              renderToString,
               searchClient: createFakeClient(),
               indexName: 'lol',
             }),

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -80,8 +80,7 @@ function augmentInstantSearch(
   instantSearchOptions,
   searchClient,
   indexName,
-  cloneComponent,
-  renderToString
+  cloneComponent
 ) {
   /* eslint-disable no-param-reassign */
 
@@ -93,9 +92,16 @@ function augmentInstantSearch(
   /**
    * main API for SSR, called in serverPrefetch of a root component which contains instantsearch
    * @param {object} componentInstance the calling component's `this`
+   * @param {Function} renderToString the function to render componentInstance to string
    * @returns {Promise} result of the search, to save for .hydrate
    */
-  search.findResultsState = function(componentInstance) {
+  search.findResultsState = function(componentInstance, renderToString) {
+    if (!renderToString) {
+      throw new Error(
+        'findResultsState requires `renderToString: (componentInstance) => Promise<string>` in the second argument.'
+      );
+    }
+
     let app;
     let renderedComponentInstance;
 
@@ -258,7 +264,6 @@ export function createServerRootMixin(instantSearchOptions = {}) {
   const {
     searchClient,
     indexName,
-    renderToString,
     $cloneComponent = defaultCloneComponent,
   } = instantSearchOptions;
 
@@ -268,18 +273,11 @@ export function createServerRootMixin(instantSearchOptions = {}) {
     );
   }
 
-  if (!renderToString) {
-    throw new Error(
-      'createServerRootMixin requires `renderToString: (app) => Promise<string>` in the first argument'
-    );
-  }
-
   const search = augmentInstantSearch(
     instantSearchOptions,
     searchClient,
     indexName,
-    $cloneComponent,
-    renderToString
+    $cloneComponent
   );
 
   // put this in the user's root Vue instance

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -91,28 +91,29 @@ function augmentInstantSearch(
 
   /**
    * main API for SSR, called in serverPrefetch of a root component which contains instantsearch
-   * @param {object} componentInstance the calling component's `this`
-   * @param {Function} renderToString the function to render componentInstance to string
+   * @param {Object} props the object including `component` and `renderToString`
+   * @param {Object} props.component the calling component's `this`
+   * @param {Function} props.renderToString the function to render componentInstance to string
    * @returns {Promise} result of the search, to save for .hydrate
    */
-  search.findResultsState = function(componentInstance, renderToString) {
+  search.findResultsState = function({ component, renderToString }) {
     if (!renderToString) {
       throw new Error(
-        'findResultsState requires `renderToString: (componentInstance) => Promise<string>` in the second argument.'
+        'findResultsState requires `renderToString: (component) => Promise<string>` in the first argument.'
       );
     }
 
     let app;
-    let renderedComponentInstance;
+    let renderedComponent;
 
     return Promise.resolve()
       .then(() => {
-        app = cloneComponent(componentInstance, {
+        app = cloneComponent(component, {
           mixins: [
             {
               created() {
                 // eslint-disable-next-line consistent-this
-                renderedComponentInstance = this;
+                renderedComponent = this;
                 this.instantsearch.helper = helper;
                 this.instantsearch.mainHelper = helper;
 
@@ -130,7 +131,7 @@ function augmentInstantSearch(
       .then(() => searchOnlyWithDerivedHelpers(helper))
       .then(() => {
         const results = {};
-        walkIndex(renderedComponentInstance.instantsearch.mainIndex, widget => {
+        walkIndex(renderedComponent.instantsearch.mainIndex, widget => {
           results[widget.getIndexId()] = widget.getResults();
         });
 


### PR DESCRIPTION
## Summary

This PR fixes the regression from #1035.

## Details

Before #1035, we used to dynamically import `@vue/server-renderer` and called `renderToString()`, but it was only inside `search.findResultsState()`.

After #1035, importing `@vue/server-renderer` is on the user land, but it happens at `main.js` file where it exports `createApp` function.
And the error now happens because it is unnecessarily trying to import `@vue/server-renderer` on the browser and it's not meant to be (`main.js` is used in both client and server).

The solution here is to pass from entry-server.js `renderToString` to `createApp()` , because `serverPrefetch()` is called only on server, and entry-client.js not passing it won't make any issue.

This new API will help people (like me) not put server renderer in client bundle mistakenly, which is hard to figure out afterwards.