### PR TITLE
feat: add experimental composition APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,13 +56,17 @@
     "@vue/server-renderer": "^3.1.2",
     "algoliasearch": ">= 3.32.0 < 5",
     "vue": "^2.6.0 || >=3.0.0-rc.0",
-    "vue-server-renderer": "^2.6.11"
+    "vue-server-renderer": "^2.6.11",
+    "@vue/composition-api": "^1.1.4"
   },
   "peerDependenciesMeta": {
     "vue-server-renderer": {
       "optional": true
     },
     "@vue/server-renderer": {
+      "optional": true
+    },
+    "@vue/composition-api": {
       "optional": true
     }
   },

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     },
     {
       "path": "./vue3/cjs/index.js",
-      "maxSize": "18.50 kB"
+      "maxSize": "18.75 kB"
     }
   ],
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@storybook/addon-options": "3.4.11",
     "@storybook/vue": "3.4.11",
     "@vue/compiler-sfc": "3.0.11",
+    "@vue/composition-api": "1.1.4",
     "@vue/test-utils": "1.2.1",
     "@vue/test-utils2": "npm:@vue/test-utils@2.0.0-rc.11",
     "@wdio/cli": "^5.11.13",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -164,7 +164,6 @@ export default [
               format: 'es',
             },
           ],
-          // preserveModules: true,
           plugins: [applyVueCompatForVue2Compositions, ...plugins],
         },
       ]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,10 @@ import { terser } from 'rollup-plugin-terser';
 import replace from 'rollup-plugin-replace';
 import json from 'rollup-plugin-json';
 
-if (process.env.VUE_VERSION !== 'vue2' && process.env.VUE_VERSION !== 'vue3') {
+const isVue2 = process.env.VUE_VERSION === 'vue2';
+const isVue3 = process.env.VUE_VERSION === 'vue3';
+
+if (!isVue2 && !isVue3) {
   throw new Error(
     'The environment variable VUE_VERSION (`vue2` | `vue3`) is required.'
   );
@@ -19,10 +22,20 @@ const processEnv = conf => ({
   'process.env': `(${JSON.stringify(conf)})`,
 });
 
-const vuePlugin = process.env.VUE_VERSION === 'vue3' ? vueV3 : vueV2;
-const outputDir = process.env.VUE_VERSION === 'vue3' ? 'vue3' : 'vue2';
+const vuePlugin = isVue3 ? vueV3 : vueV2;
+const outputDir = isVue3 ? 'vue3' : 'vue2';
+
+const excludeCompositionsAPI = {
+  load(id){
+    if (id.endsWith("/src/compositions/index.js")) {
+      return ''
+    }
+    return null;
+  }
+}
 
 const plugins = [
+  isVue2 && excludeCompositionsAPI,
   vuePlugin({ compileTemplate: true, css: false }),
   commonjs(),
   json(),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,13 +26,13 @@ const vuePlugin = isVue3 ? vueV3 : vueV2;
 const outputDir = isVue3 ? 'vue3' : 'vue2';
 
 const excludeCompositionsAPI = {
-  load(id){
-    if (id.endsWith("/src/compositions/index.js")) {
-      return ''
+  load(id) {
+    if (id.endsWith('/src/compositions/index.js')) {
+      return '';
     }
     return null;
-  }
-}
+  },
+};
 
 const plugins = [
   isVue2 && excludeCompositionsAPI,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,7 +35,6 @@ const excludeCompositionsAPI = {
 };
 
 const plugins = [
-  isVue2 && excludeCompositionsAPI,
   vuePlugin({ compileTemplate: true, css: false }),
   commonjs(),
   json(),
@@ -68,7 +67,7 @@ export default [
         exports: 'named',
       },
     ],
-    plugins: [...plugins],
+    plugins: [isVue2 && excludeCompositionsAPI, ...plugins].filter(Boolean),
   },
   {
     input: 'src/instantsearch.js',
@@ -81,7 +80,7 @@ export default [
       },
     ],
     preserveModules: true,
-    plugins: [...plugins],
+    plugins: [isVue2 && excludeCompositionsAPI, ...plugins].filter(Boolean),
   },
   {
     input: 'src/instantsearch.umd.js',
@@ -106,4 +105,34 @@ export default [
       }),
     ],
   },
+  ...(isVue2
+    ? [
+        {
+          input: 'src/compositions-for-vue2.js',
+          external,
+          output: [
+            {
+              sourcemap: true,
+              file: `${outputDir}/cjs/compositions.js`,
+              format: 'cjs',
+              exports: 'named',
+            },
+          ],
+          plugins,
+        },
+        {
+          input: 'src/compositions-for-vue2.js',
+          external,
+          output: [
+            {
+              sourcemap: true,
+              file: `${outputDir}/es/compositions.js`,
+              format: 'es',
+            },
+          ],
+          // preserveModules: true,
+          plugins,
+        },
+      ]
+    : []),
 ];

--- a/scripts/build-vue2.sh
+++ b/scripts/build-vue2.sh
@@ -1,15 +1,7 @@
 #!/bin/sh
 set -e
 
-originalContent=`cat src/util/vue-compat/index.js`
-
-# use v2 for src/util/vue-compat
-echo "export * from './index-2';" > src/util/vue-compat/index.js
-
 VUE_VERSION=vue2 rollup -c
-
-# revert src/util/vue-compat
-echo "$originalContent" > src/util/vue-compat/index.js
 
 # put an index file for es output
 cp ./scripts/es-index-template.js vue2/es/index.js

--- a/scripts/build-vue3.sh
+++ b/scripts/build-vue3.sh
@@ -1,15 +1,7 @@
 #!/bin/sh
 set -e
 
-originalContent=`cat src/util/vue-compat/index.js`
-
-# use v3 for src/util/vue-compat
-echo "export * from './index-3';" > src/util/vue-compat/index.js
-
 VUE_VERSION=vue3 rollup -c
-
-# revert src/util/vue-compat
-echo "$originalContent" > src/util/vue-compat/index.js
 
 # put an index file for es output
 cp ./scripts/es-index-template.js vue3/es/index.js

--- a/src/components/__tests__/InstantSearch-integration.js
+++ b/src/components/__tests__/InstantSearch-integration.js
@@ -1,11 +1,9 @@
-import { mount, nextTick } from '../../../test/utils';
+import { mount, nextTick, wait } from '../../../test/utils';
 import InstantSearch from '../InstantSearch';
 import { createWidgetMixin } from '../../mixins/widget';
 import { createFakeClient } from '../../util/testutils/client';
 import SearchBox from '../SearchBox.vue';
 jest.unmock('instantsearch.js/es');
-
-const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 it('child widgets get added to its parent instantsearch', () => {
   const widgetInstance = {

--- a/src/compositions-for-vue2.js
+++ b/src/compositions-for-vue2.js
@@ -1,0 +1,1 @@
+export * from './compositions';

--- a/src/compositions/__tests__/useConnector.js
+++ b/src/compositions/__tests__/useConnector.js
@@ -1,0 +1,288 @@
+jest.unmock('instantsearch.js/es');
+import InstantSearch from '../../components/InstantSearch';
+import Index from '../../components/Index';
+import { createFakeClient } from '../../util/testutils/client';
+import { isVue3, isVue2, ref } from '../../util/vue-compat';
+import { mount, wait } from '../../../test/utils';
+import { useConnector } from '../useConnector';
+
+if (isVue2) {
+  it('does nothing in Vue 2', () => {});
+} else if (isVue3) {
+  describe('on root index', () => {
+    const setup = ({ ChildComponent }) => {
+      const wrapper = mount({
+        components: { InstantSearch, ChildComponent },
+        data() {
+          return {
+            props: { searchClient: createFakeClient(), indexName: 'something' },
+          };
+        },
+        template: `
+            <InstantSearch v-bind="props">
+              <ChildComponent />
+            </InstantSearch>
+          `,
+      });
+
+      const getWidgets = () =>
+        wrapper
+          .findComponent(InstantSearch)
+          .vm.instantSearchInstance.mainIndex.getWidgets();
+
+      return { wrapper, getWidgets };
+    };
+
+    it('adds a widget on create', () => {
+      const widget = { render: () => {} };
+      const factory = jest.fn(() => widget);
+      const connector = jest.fn(() => factory);
+
+      const ChildComponent = {
+        setup() {
+          const state = useConnector(connector, {}, {});
+          return { state };
+        },
+        template: '<div></div>',
+      };
+
+      const { getWidgets } = setup({ ChildComponent });
+
+      const widgets = getWidgets();
+
+      expect(widgets.length).toBe(1);
+      expect(widgets[0]).toEqual(widget);
+    });
+
+    it('removes a widget on destroy', () => {
+      const widget = { render: () => {}, dispose: () => {} };
+      const factory = jest.fn(() => widget);
+      const connector = jest.fn(() => factory);
+
+      const ChildComponent = {
+        setup() {
+          const state = useConnector(connector, {}, {});
+          return { state };
+        },
+        template: '<div></div>',
+      };
+
+      const { wrapper, getWidgets } = setup({ ChildComponent });
+
+      expect(getWidgets().length).toBe(1);
+
+      wrapper.destroy();
+
+      expect(getWidgets().length).toBe(0);
+    });
+
+    it('returns correct state', async () => {
+      const connector = jest.fn(renderFn => widgetParams => ({
+        render() {
+          renderFn({ widgetParams });
+        },
+        dispose() {},
+      }));
+
+      const widgetParams = {
+        attribute: 'brand',
+      };
+
+      const ChildComponent = {
+        setup() {
+          const state = useConnector(connector, widgetParams, null);
+          return { state };
+        },
+        template: '<div>{{ state && state.widgetParams.attribute }}</div>',
+      };
+
+      const { wrapper } = setup({ ChildComponent });
+
+      await wait(0);
+      expect(wrapper.findComponent(ChildComponent).html())
+        .toMatchInlineSnapshot(`
+        <div>
+          brand
+        </div>
+      `);
+    });
+
+    it('updates widget on widget params change', async () => {
+      const connector = jest.fn(renderFn => widgetParams => ({
+        render() {
+          renderFn({ widgetParams });
+        },
+        dispose() {},
+      }));
+
+      const widgetParams = ref({
+        attribute: 'brand',
+      });
+
+      const ChildComponent = {
+        setup() {
+          const state = useConnector(connector, widgetParams, null);
+          return { state };
+        },
+        template: '<div>{{ state && state.widgetParams.attribute }}</div>',
+      };
+
+      const { wrapper } = setup({ ChildComponent });
+
+      await wait(0);
+      expect(wrapper.findComponent(ChildComponent).html())
+        .toMatchInlineSnapshot(`
+        <div>
+          brand
+        </div>
+      `);
+
+      widgetParams.value = { attribute: 'color' };
+      await wait(0);
+      expect(wrapper.findComponent(ChildComponent).html())
+        .toMatchInlineSnapshot(`
+        <div>
+          color
+        </div>
+      `);
+    });
+  });
+
+  describe('on child index', () => {
+    const setup = ({ ChildComponent }) => {
+      const wrapper = mount({
+        components: { InstantSearch, Index, ChildComponent },
+        data() {
+          return {
+            props: { searchClient: createFakeClient(), indexName: 'something' },
+            propsForIndex: { indexName: 'else' },
+          };
+        },
+        template: `
+            <InstantSearch v-bind="props">
+              <Index v-bind="propsForIndex">
+                <ChildComponent />
+              </Index>
+            </InstantSearch>
+          `,
+      });
+      const getWidgets = () =>
+        wrapper.findComponent(Index).vm.widget.getWidgets();
+
+      return { wrapper, getWidgets };
+    };
+
+    it('adds a widget on create', () => {
+      const widget = { render: () => {} };
+      const factory = jest.fn(() => widget);
+      const connector = jest.fn(() => factory);
+
+      const ChildComponent = {
+        setup() {
+          const state = useConnector(connector, {}, {});
+          return { state };
+        },
+        template: '<div></div>',
+      };
+
+      const { getWidgets } = setup({ ChildComponent });
+
+      const widgets = getWidgets();
+      expect(widgets.length).toBe(1);
+      expect(widgets[0]).toEqual(widget);
+    });
+
+    it('removes a widget on destroy', () => {
+      const widget = { render: () => {}, dispose: () => {} };
+      const factory = jest.fn(() => widget);
+      const connector = jest.fn(() => factory);
+
+      const ChildComponent = {
+        setup() {
+          const state = useConnector(connector, {}, {});
+          return { state };
+        },
+        template: '<div></div>',
+      };
+
+      const { wrapper, getWidgets } = setup({ ChildComponent });
+
+      expect(getWidgets().length).toBe(1);
+
+      wrapper.destroy();
+
+      expect(getWidgets().length).toBe(0);
+    });
+
+    it('returns correct state', async () => {
+      const connector = jest.fn(renderFn => widgetParams => ({
+        render() {
+          renderFn({ widgetParams });
+        },
+        dispose() {},
+      }));
+
+      const widgetParams = {
+        attribute: 'brand',
+      };
+
+      const ChildComponent = {
+        setup() {
+          const state = useConnector(connector, widgetParams, null);
+          return { state };
+        },
+        template: '<div>{{ state && state.widgetParams.attribute }}</div>',
+      };
+
+      const { wrapper } = setup({ ChildComponent });
+
+      await wait(0);
+      expect(wrapper.findComponent(ChildComponent).html())
+        .toMatchInlineSnapshot(`
+        <div>
+          brand
+        </div>
+      `);
+    });
+
+    it('updates widget on widget params change', async () => {
+      const connector = jest.fn(renderFn => widgetParams => ({
+        render() {
+          renderFn({ widgetParams });
+        },
+        dispose() {},
+      }));
+
+      const widgetParams = ref({
+        attribute: 'brand',
+      });
+
+      const ChildComponent = {
+        setup() {
+          const state = useConnector(connector, widgetParams, null);
+          return { state };
+        },
+        template: '<div>{{ state && state.widgetParams.attribute }}</div>',
+      };
+
+      const { wrapper } = setup({ ChildComponent });
+
+      await wait(0);
+      expect(wrapper.findComponent(ChildComponent).html())
+        .toMatchInlineSnapshot(`
+        <div>
+          brand
+        </div>
+      `);
+
+      widgetParams.value = { attribute: 'color' };
+      await wait(0);
+      expect(wrapper.findComponent(ChildComponent).html())
+        .toMatchInlineSnapshot(`
+        <div>
+          color
+        </div>
+      `);
+    });
+  });
+}

--- a/src/compositions/__tests__/useConnector.js
+++ b/src/compositions/__tests__/useConnector.js
@@ -77,23 +77,23 @@ if (isVue2) {
     });
 
     it('returns correct state', async () => {
-      const connector = jest.fn(renderFn => widgetParams => ({
+      const connector = jest.fn(renderFn => props => ({
         render() {
-          renderFn({ widgetParams });
+          renderFn({ props });
         },
         dispose() {},
       }));
 
-      const widgetParams = {
+      const props = {
         attribute: 'brand',
       };
 
       const ChildComponent = {
         setup() {
-          const state = useConnector(connector, widgetParams);
+          const state = useConnector(connector, props);
           return { state };
         },
-        template: '<div>{{ state && state.widgetParams.attribute }}</div>',
+        template: '<div>{{ state && state.props.attribute }}</div>',
       };
 
       const { wrapper } = setup({ ChildComponent });
@@ -107,24 +107,55 @@ if (isVue2) {
       `);
     });
 
-    it('updates widget on widget params change', async () => {
-      const connector = jest.fn(renderFn => widgetParams => ({
+    it('removes widgetParams', async () => {
+      const connector = jest.fn(renderFn => props => ({
         render() {
-          renderFn({ widgetParams });
+          renderFn({ props, widgetParams: props });
         },
         dispose() {},
       }));
 
-      const widgetParams = ref({
+      const props = {
+        attribute: 'brand',
+      };
+
+      const ChildComponent = {
+        setup() {
+          const state = useConnector(connector, props);
+          return { state };
+        },
+        template:
+          '<div>{{ state && state.widgetParams && state.widgetParams.attribute }}</div>',
+      };
+
+      const { wrapper } = setup({ ChildComponent });
+
+      await wait(0);
+      expect(wrapper.findComponent(ChildComponent).html())
+        .toMatchInlineSnapshot(`
+        <div>
+        </div>
+      `);
+    });
+
+    it('updates widget on props change', async () => {
+      const connector = jest.fn(renderFn => props => ({
+        render() {
+          renderFn({ props });
+        },
+        dispose() {},
+      }));
+
+      const props = ref({
         attribute: 'brand',
       });
 
       const ChildComponent = {
         setup() {
-          const state = useConnector(connector, widgetParams);
+          const state = useConnector(connector, props);
           return { state };
         },
-        template: '<div>{{ state && state.widgetParams.attribute }}</div>',
+        template: '<div>{{ state && state.props.attribute }}</div>',
       };
 
       const { wrapper } = setup({ ChildComponent });
@@ -137,7 +168,7 @@ if (isVue2) {
         </div>
       `);
 
-      widgetParams.value = { attribute: 'color' };
+      props.value = { attribute: 'color' };
       await wait(0);
       expect(wrapper.findComponent(ChildComponent).html())
         .toMatchInlineSnapshot(`
@@ -215,23 +246,23 @@ if (isVue2) {
     });
 
     it('returns correct state', async () => {
-      const connector = jest.fn(renderFn => widgetParams => ({
+      const connector = jest.fn(renderFn => props => ({
         render() {
-          renderFn({ widgetParams });
+          renderFn({ props });
         },
         dispose() {},
       }));
 
-      const widgetParams = {
+      const props = {
         attribute: 'brand',
       };
 
       const ChildComponent = {
         setup() {
-          const state = useConnector(connector, widgetParams);
+          const state = useConnector(connector, props);
           return { state };
         },
-        template: '<div>{{ state && state.widgetParams.attribute }}</div>',
+        template: '<div>{{ state && state.props.attribute }}</div>',
       };
 
       const { wrapper } = setup({ ChildComponent });
@@ -245,24 +276,55 @@ if (isVue2) {
       `);
     });
 
-    it('updates widget on widget params change', async () => {
-      const connector = jest.fn(renderFn => widgetParams => ({
+    it('removes widgetParams', async () => {
+      const connector = jest.fn(renderFn => props => ({
         render() {
-          renderFn({ widgetParams });
+          renderFn({ props, widgetParams: props });
         },
         dispose() {},
       }));
 
-      const widgetParams = ref({
+      const props = {
+        attribute: 'brand',
+      };
+
+      const ChildComponent = {
+        setup() {
+          const state = useConnector(connector, props);
+          return { state };
+        },
+        template:
+          '<div>{{ state && state.widgetParams && state.widgetParams.attribute }}</div>',
+      };
+
+      const { wrapper } = setup({ ChildComponent });
+
+      await wait(0);
+      expect(wrapper.findComponent(ChildComponent).html())
+        .toMatchInlineSnapshot(`
+        <div>
+        </div>
+      `);
+    });
+
+    it('updates widget on props change', async () => {
+      const connector = jest.fn(renderFn => props => ({
+        render() {
+          renderFn({ props });
+        },
+        dispose() {},
+      }));
+
+      const props = ref({
         attribute: 'brand',
       });
 
       const ChildComponent = {
         setup() {
-          const state = useConnector(connector, widgetParams);
+          const state = useConnector(connector, props);
           return { state };
         },
-        template: '<div>{{ state && state.widgetParams.attribute }}</div>',
+        template: '<div>{{ state && state.props.attribute }}</div>',
       };
 
       const { wrapper } = setup({ ChildComponent });
@@ -275,7 +337,7 @@ if (isVue2) {
         </div>
       `);
 
-      widgetParams.value = { attribute: 'color' };
+      props.value = { attribute: 'color' };
       await wait(0);
       expect(wrapper.findComponent(ChildComponent).html())
         .toMatchInlineSnapshot(`

--- a/src/compositions/__tests__/useConnector.js
+++ b/src/compositions/__tests__/useConnector.js
@@ -40,7 +40,7 @@ if (isVue2) {
 
       const ChildComponent = {
         setup() {
-          const state = useConnector(connector, {}, {});
+          const state = useConnector(connector, {});
           return { state };
         },
         template: '<div></div>',
@@ -61,7 +61,7 @@ if (isVue2) {
 
       const ChildComponent = {
         setup() {
-          const state = useConnector(connector, {}, {});
+          const state = useConnector(connector, {});
           return { state };
         },
         template: '<div></div>',
@@ -90,7 +90,7 @@ if (isVue2) {
 
       const ChildComponent = {
         setup() {
-          const state = useConnector(connector, widgetParams, null);
+          const state = useConnector(connector, widgetParams);
           return { state };
         },
         template: '<div>{{ state && state.widgetParams.attribute }}</div>',
@@ -121,7 +121,7 @@ if (isVue2) {
 
       const ChildComponent = {
         setup() {
-          const state = useConnector(connector, widgetParams, null);
+          const state = useConnector(connector, widgetParams);
           return { state };
         },
         template: '<div>{{ state && state.widgetParams.attribute }}</div>',
@@ -179,7 +179,7 @@ if (isVue2) {
 
       const ChildComponent = {
         setup() {
-          const state = useConnector(connector, {}, {});
+          const state = useConnector(connector, {});
           return { state };
         },
         template: '<div></div>',
@@ -199,7 +199,7 @@ if (isVue2) {
 
       const ChildComponent = {
         setup() {
-          const state = useConnector(connector, {}, {});
+          const state = useConnector(connector, {});
           return { state };
         },
         template: '<div></div>',
@@ -228,7 +228,7 @@ if (isVue2) {
 
       const ChildComponent = {
         setup() {
-          const state = useConnector(connector, widgetParams, null);
+          const state = useConnector(connector, widgetParams);
           return { state };
         },
         template: '<div>{{ state && state.widgetParams.attribute }}</div>',
@@ -259,7 +259,7 @@ if (isVue2) {
 
       const ChildComponent = {
         setup() {
-          const state = useConnector(connector, widgetParams, null);
+          const state = useConnector(connector, widgetParams);
           return { state };
         },
         template: '<div>{{ state && state.widgetParams.attribute }}</div>',

--- a/src/compositions/index.js
+++ b/src/compositions/index.js
@@ -1,2 +1,6 @@
 export { useConnector as EXPERIMENTAL_useConnector } from './useConnector';
 export { useSearchBox as EXPERIMENTAL_useSearchBox } from './useSearchBox';
+export { useConfigure as EXPERIMENTAL_useConfigure } from './useConfigure';
+export {
+  useRefinementList as EXPERIMENTAL_useRefinementList,
+} from './useRefinementList';

--- a/src/compositions/index.js
+++ b/src/compositions/index.js
@@ -1,0 +1,2 @@
+export { useConnector as EXPERIMENTAL_useConnector } from './useConnector';
+export { useSearchBox as EXPERIMENTAL_useSearchBox } from './useSearchBox';

--- a/src/compositions/useConfigure.js
+++ b/src/compositions/useConfigure.js
@@ -1,0 +1,11 @@
+import { connectConfigure } from 'instantsearch.js/es/connectors';
+import { noop } from '../util/noop';
+import { computed } from '../util/vue-compat';
+import { useConnector } from './useConnector';
+
+export function useConfigure(props) {
+  const widgetParams = computed(() => ({ searchParameters: props }));
+  return useConnector(connectConfigure, widgetParams, {
+    refine: noop,
+  });
+}

--- a/src/compositions/useConfigure.js
+++ b/src/compositions/useConfigure.js
@@ -1,11 +1,8 @@
 import { connectConfigure } from 'instantsearch.js/es/connectors';
-import { noop } from '../util/noop';
 import { computed } from '../util/vue-compat';
 import { useConnector } from './useConnector';
 
 export function useConfigure(props) {
   const widgetParams = computed(() => ({ searchParameters: props }));
-  return useConnector(connectConfigure, widgetParams, {
-    refine: noop,
-  });
+  return useConnector(connectConfigure, widgetParams);
 }

--- a/src/compositions/useConfigure.js
+++ b/src/compositions/useConfigure.js
@@ -3,6 +3,8 @@ import { computed } from '../util/vue-compat';
 import { useConnector } from './useConnector';
 
 export function useConfigure(props) {
-  const widgetParams = computed(() => ({ searchParameters: props }));
-  return useConnector(connectConfigure, widgetParams);
+  return useConnector(
+    connectConfigure,
+    computed(() => ({ searchParameters: props }))
+  );
 }

--- a/src/compositions/useConnector.js
+++ b/src/compositions/useConnector.js
@@ -1,0 +1,38 @@
+import { inject, ref, watch, onMounted, onUnmounted } from '../util/vue-compat';
+
+export function useConnector(connector, props, initialState) {
+  const instantSearchInstance = inject('$_ais_instantSearchInstance');
+  const getParentIndex = inject('$_ais_getParentIndex');
+  const indexWidget = getParentIndex && getParentIndex();
+  const parent = indexWidget || instantSearchInstance;
+  const state = ref(initialState);
+  let widget = ref(null);
+
+  const addWidget = () => {
+    const createWidget = connector(newState => {
+      state.value = newState;
+    });
+    widget.value = createWidget(props);
+    parent.addWidgets([widget.value]);
+  };
+
+  const removeWidget = () => {
+    if (widget.value) {
+      parent.removeWidgets([widget.value]);
+      widget.value = null;
+    }
+  };
+
+  const updateWidget = () => {
+    removeWidget();
+    addWidget();
+  };
+
+  onMounted(addWidget);
+  onUnmounted(removeWidget);
+  watch(() => connector, updateWidget);
+  watch(() => props, updateWidget);
+
+  return state;
+}
+

--- a/src/compositions/useConnector.js
+++ b/src/compositions/useConnector.js
@@ -10,11 +10,13 @@ import { addWidget, removeWidget, forceRender } from '../util/widget';
 
 export function useConnector(connector, widgetParams) {
   const instantSearchInstance = inject('$_ais_instantSearchInstance');
-  const getParentIndex = inject('$_ais_getParentIndex', undefined);
-  const indexWidget = getParentIndex && getParentIndex();
-  const parent = indexWidget || instantSearchInstance;
+  const parent = inject(
+    '$_ais_getParentIndex',
+    () => instantSearchInstance.mainIndex
+  )();
+
   const state = ref(null);
-  const widget = ref(null);
+  let widget;
 
   const render = (newState, isFirstRender) => {
     if (isFirstRender) return;
@@ -25,23 +27,24 @@ export function useConnector(connector, widgetParams) {
   };
 
   const updateWidget = () => {
-    removeWidget(widget.value, parent);
+    removeWidget(widget, parent);
     state.value = null;
-    widget.value = addWidget(connector, parent, widgetParams.value, render);
+    widget = addWidget(connector, parent, widgetParams.value, render);
   };
 
   onMounted(() => {
-    widget.value = addWidget(
+    widget = addWidget(
       connector,
       parent,
       isRef(widgetParams) ? widgetParams.value : widgetParams,
       render
     );
-    forceRender(widget.value, parent, instantSearchInstance);
+    forceRender(widget, parent, instantSearchInstance);
   });
+
   onUnmounted(() => {
-    removeWidget(widget.value, parent);
-    widget.value = null;
+    removeWidget(widget, parent);
+    widget = null;
   });
 
   if (isRef(widgetParams)) {

--- a/src/compositions/useConnector.js
+++ b/src/compositions/useConnector.js
@@ -8,7 +8,7 @@ import {
 } from '../util/vue-compat';
 import { addWidget, removeWidget, forceRender } from '../util/widget';
 
-export function useConnector(connector, widgetParams) {
+export function useConnector(connector, props) {
   const instantSearchInstance = inject('$_ais_instantSearchInstance');
   const parent = inject(
     '$_ais_getParentIndex',
@@ -19,24 +19,26 @@ export function useConnector(connector, widgetParams) {
   let widget;
 
   const render = (newState, isFirstRender) => {
-    if (isFirstRender) return;
-
     // Avoid updating the state on first render
     // otherwise there will be a flash of placeholder data
-    state.value = newState;
+    if (isFirstRender) return;
+
+    const copy = Object.assign({}, newState);
+    delete copy.widgetParams;
+    state.value = copy;
   };
 
   const updateWidget = () => {
     removeWidget(widget, parent);
     state.value = null;
-    widget = addWidget(connector, parent, widgetParams.value, render);
+    widget = addWidget(connector, parent, props.value, render);
   };
 
   onMounted(() => {
     widget = addWidget(
       connector,
       parent,
-      isRef(widgetParams) ? widgetParams.value : widgetParams,
+      isRef(props) ? props.value : props,
       render
     );
     forceRender(widget, parent, instantSearchInstance);
@@ -47,8 +49,8 @@ export function useConnector(connector, widgetParams) {
     widget = null;
   });
 
-  if (isRef(widgetParams)) {
-    watch(widgetParams, updateWidget);
+  if (isRef(props)) {
+    watch(props, updateWidget);
   }
 
   return state;

--- a/src/compositions/useRefinementList.js
+++ b/src/compositions/useRefinementList.js
@@ -5,15 +5,17 @@ import { computed } from '../util/vue-compat';
 export function useRefinementList(props) {
   const state = useConnector(connectRefinementList, props);
 
-  return computed(() => ({
-    ...state.value,
-    items: state.value.items.map(item => ({
-      ...item,
-      _highlightResult: {
-        label: {
-          value: item.highlighted,
-        },
-      },
-    })),
-  }));
+  return computed(() =>
+    Object.assign({}, state.value, {
+      items: state.value.items.map(item =>
+        Object.assign({}, item, {
+          _highlightResult: {
+            label: {
+              value: item.highlighted,
+            },
+          },
+        })
+      ),
+    })
+  );
 }

--- a/src/compositions/useRefinementList.js
+++ b/src/compositions/useRefinementList.js
@@ -1,22 +1,9 @@
 import { connectRefinementList } from 'instantsearch.js/es/connectors';
 import { useConnector } from './useConnector';
-import { noop } from '../util/noop';
 import { computed } from '../util/vue-compat';
 
 export function useRefinementList(props) {
-  const state = useConnector(connectRefinementList, props, {
-    items: [],
-    refine: noop,
-    canRefine: false,
-    canToggleShowMore: false,
-    createURL: () => '#',
-    hasExhaustiveItems: false,
-    isFromSearch: false,
-    isShowingMore: false,
-    searchForItems: noop,
-    sendEvent: noop,
-    toggleShowMore: noop,
-  });
+  const state = useConnector(connectRefinementList, props);
 
   return computed(() => ({
     ...state.value,

--- a/src/compositions/useRefinementList.js
+++ b/src/compositions/useRefinementList.js
@@ -1,0 +1,32 @@
+import { connectRefinementList } from 'instantsearch.js/es/connectors';
+import { useConnector } from './useConnector';
+import { noop } from '../util/noop';
+import { computed } from '../util/vue-compat';
+
+export function useRefinementList(props) {
+  const state = useConnector(connectRefinementList, props, {
+    items: [],
+    refine: noop,
+    canRefine: false,
+    canToggleShowMore: false,
+    createURL: () => '#',
+    hasExhaustiveItems: false,
+    isFromSearch: false,
+    isShowingMore: false,
+    searchForItems: noop,
+    sendEvent: noop,
+    toggleShowMore: noop,
+  });
+
+  return computed(() => ({
+    ...state.value,
+    items: state.value.items.map(item => ({
+      ...item,
+      _highlightResult: {
+        label: {
+          value: item.highlighted,
+        },
+      },
+    })),
+  }));
+}

--- a/src/compositions/useSearchBox.js
+++ b/src/compositions/useSearchBox.js
@@ -1,7 +1,6 @@
 import { connectSearchBox } from 'instantsearch.js/es/connectors';
+import { noop } from '../util/noop';
 import { useConnector } from './useConnector';
-
-const noop = () => {};
 
 export function useSearchBox(props) {
   return useConnector(connectSearchBox, props, {

--- a/src/compositions/useSearchBox.js
+++ b/src/compositions/useSearchBox.js
@@ -1,12 +1,6 @@
 import { connectSearchBox } from 'instantsearch.js/es/connectors';
-import { noop } from '../util/noop';
 import { useConnector } from './useConnector';
 
 export function useSearchBox(props) {
-  return useConnector(connectSearchBox, props, {
-    query: '',
-    refine: noop,
-    clear: noop,
-    isSearchStalled: false,
-  });
+  return useConnector(connectSearchBox, props);
 }

--- a/src/compositions/useSearchBox.js
+++ b/src/compositions/useSearchBox.js
@@ -1,0 +1,13 @@
+import { connectSearchBox } from 'instantsearch.js/es/connectors';
+import { useConnector } from './useConnector';
+
+const noop = () => {};
+
+export function useSearchBox(props) {
+  return useConnector(connectSearchBox, props, {
+    query: '',
+    refine: noop,
+    clear: noop,
+    isSearchStalled: false,
+  });
+}

--- a/src/instantsearch.js
+++ b/src/instantsearch.js
@@ -3,3 +3,5 @@ export { createWidgetMixin } from './mixins/widget';
 export * from './widgets';
 export { plugin as default } from './plugin';
 export { createServerRootMixin } from './util/createServerRootMixin';
+
+export * from './compositions';

--- a/src/mixins/widget.js
+++ b/src/mixins/widget.js
@@ -61,7 +61,6 @@ Read more on using connectors: https://alg.li/vue-custom`
         this.widget = addWidget(
           connector,
           this.getParentIndex(),
-          this.instantSearchInstance,
           nextWidgetParams,
           this.updateState.bind(this)
         );

--- a/src/util/noop.js
+++ b/src/util/noop.js
@@ -1,1 +1,0 @@
-export const noop = () => {};

--- a/src/util/noop.js
+++ b/src/util/noop.js
@@ -1,0 +1,1 @@
+export const noop = () => {};

--- a/src/util/vue-compat/index-2-compositions.js
+++ b/src/util/vue-compat/index-2-compositions.js
@@ -1,0 +1,21 @@
+import Vue from 'vue';
+
+const isVue2 = true;
+const isVue3 = false;
+const Vue2 = Vue;
+const version = Vue.version;
+
+export { Vue, Vue2, isVue2, isVue3, version };
+
+export function renderCompat(fn) {
+  return function(createElement) {
+    return fn.call(this, createElement);
+  };
+}
+
+export function getDefaultSlot(component) {
+  return component.$slots.default;
+}
+
+// Vue3-only APIs
+export * from '@vue/composition-api';

--- a/src/util/vue-compat/index-3.js
+++ b/src/util/vue-compat/index-3.js
@@ -16,6 +16,7 @@ export {
   watch,
   onMounted,
   onUnmounted,
+  computed,
 } from 'vue';
 export { Vue, Vue2, isVue2, isVue3 };
 

--- a/src/util/vue-compat/index-3.js
+++ b/src/util/vue-compat/index-3.js
@@ -12,6 +12,7 @@ export {
   nextTick,
   inject,
   ref,
+  isRef,
   watch,
   onMounted,
   onUnmounted,

--- a/src/util/vue-compat/index-3.js
+++ b/src/util/vue-compat/index-3.js
@@ -4,7 +4,18 @@ const isVue2 = false;
 const isVue3 = true;
 const Vue2 = undefined;
 
-export { createApp, createSSRApp, h, version, nextTick } from 'vue';
+export {
+  createApp,
+  createSSRApp,
+  h,
+  version,
+  nextTick,
+  inject,
+  ref,
+  watch,
+  onMounted,
+  onUnmounted,
+} from 'vue';
 export { Vue, Vue2, isVue2, isVue3 };
 
 export function renderCompat(fn) {

--- a/src/util/vue-compat/index.js
+++ b/src/util/vue-compat/index.js
@@ -1,1 +1,7 @@
+/*
+  By default, we maintain this repository based on Vue 2.
+  That's why this file is exporting from `index-2`,
+  which includes all the variables and methods for Vue 2.
+  When it's built, rollup will replace it with either `index-2.js` or `index-3.js`.
+*/
 export * from './index-2';

--- a/src/util/vue-compat/index.js
+++ b/src/util/vue-compat/index.js
@@ -1,9 +1,1 @@
-/*
-  By default, we maintain this repository based on Vue 2.
-  That's why this file is exporting from `index-2`,
-  which includes all the variables and methods for Vue 2.
-  When `scripts/build-vue3.sh` runs, it will replace with
-  > export * from './index-3';
-  and revert it back after finished.
-*/
 export * from './index-2';

--- a/src/util/widget.js
+++ b/src/util/widget.js
@@ -1,0 +1,27 @@
+export const addWidget = (connector, parent, widgetParams, render) => {
+  const factory = connector(render);
+  const widget = factory(widgetParams);
+  parent.addWidgets([widget]);
+
+  return widget;
+};
+
+export const forceRender = (widget, parent, instantSearchInstance) => {
+  if (
+    instantSearchInstance.__initialSearchResults &&
+    !instantSearchInstance.started
+  ) {
+    if (typeof instantSearchInstance.__forceRender !== 'function') {
+      throw new Error(
+        'You are using server side rendering with <ais-instant-search> instead of <ais-instant-search-ssr>.'
+      );
+    }
+    instantSearchInstance.__forceRender(widget, parent);
+  }
+};
+
+export const removeWidget = (widget, parent) => {
+  if (widget) {
+    parent.removeWidgets([widget]);
+  }
+};

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -75,3 +75,5 @@ export const createSSRApp = props => {
 };
 
 export const nextTick = () => (isVue3 ? _nextTick() : Vue2.nextTick());
+
+export const wait = ms => new Promise(resolve => setTimeout(resolve, ms));

--- a/yarn.lock
+++ b/yarn.lock
@@ -863,6 +863,13 @@
     "@vue/compiler-dom" "3.0.11"
     "@vue/shared" "3.0.11"
 
+"@vue/composition-api@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-1.1.4.tgz#b4cd566e575350b86c22fa02632e4a356ac2e26e"
+  integrity sha512-f618a79X0VepQUoZofaAYzaherBuzfIIYah4gQPcwmXgN3oeuGdhO7DY2s3Rjcw7r9yTEh5sQIowbNWy6INGjg==
+  dependencies:
+    tslib "^2.3.0"
+
 "@vue/shared@3.0.11":
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.11.tgz#20d22dd0da7d358bb21c17f9bde8628152642c77"
@@ -15526,6 +15533,11 @@ tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+tslib@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
## Summary

This PR adds experimental composition APIs.

For now, useConfigure, useRefinementList, useSearchBox, and useConnector are implemented.

In case of `useRefinementList`, I referred to François' PoC with React InstantSearch.

### vue 3

```vue
<template>
  <div>
    <p>query: {{ searchBox.query }}</p>
  </div>
</template>

<script>
import { EXPERIMENTAL_useSearchBox } from 'vue-instantsearch/vue3/es';

export default {
  setup() {
    return { searchBox: EXPERIMENTAL_useSearchBox() };
  }
}
```

### vue 2

```sh
yarn add @vue/composition-api
# or
npm install @vue/composition-api
```

```js
// main.js
import Vue from 'vue';
import VueCompositionAPI from '@vue/composition-api';

Vue.use(VueCompositionAPI);
```

```vue
// Child.vue

<template>
  <div>
    <p>query: {{ searchBox.query }}</p>
  </div>
</template>

<script>
import { EXPERIMENTAL_useSearchBox } from 'vue-instantsearch/vue2/es/compositions';
// Import composition APIs from the path above.
// The rest still remain as `import xxx from 'vue-instantsearch'`.

export default {
  setup() {
    return { searchBox: EXPERIMENTAL_useSearchBox() };
  }
}
```