### PR TITLE
feat(dynamicWidgets): pass parameters to connector

### DIFF
--- a/src/components/DynamicWidgets.js
+++ b/src/components/DynamicWidgets.js
@@ -50,6 +50,14 @@ export default {
       type: Function,
       default: undefined,
     },
+    facets: {
+      type: Array,
+      default: undefined,
+    },
+    maxValuesPerFacet: {
+      type: Number,
+      default: undefined,
+    },
   },
   render: renderCompat(function(h) {
     const components = new Map();
@@ -91,6 +99,8 @@ export default {
     widgetParams() {
       return {
         transformItems: this.transformItems,
+        facets: this.facets,
+        maxValuesPerFacet: this.maxValuesPerFacet,
         // we do not pass "widgets" to the connector, since Vue is in charge of rendering
         widgets: [],
       };

--- a/src/components/__tests__/DynamicWidgets.js
+++ b/src/components/__tests__/DynamicWidgets.js
@@ -46,6 +46,51 @@ const MockHierarchicalMenu = {
   `,
 };
 
+it('passes arguments to connector', () => {
+  __setState(null);
+
+  const transformItems = items => items;
+  const facets = ['test'];
+  const maxValuesPerFacet = 100;
+  const wrapper = mount({
+    data() {
+      return { props: { transformItems, facets, maxValuesPerFacet } };
+    },
+    template: `
+      <DynamicWidgets v-bind="props">
+        <MockRefinementList attribute="test1"/>
+        <MockMenu attribute="test2"/>
+        <AisPanel>
+          <MockHierarchicalMenu :attributes="['test3', 'test4']" />
+        </AisPanel>
+      </DynamicWidgets>
+      `,
+    components: {
+      DynamicWidgets,
+      MockRefinementList,
+      MockMenu,
+      MockHierarchicalMenu,
+      AisPanel,
+    },
+  });
+
+  const dynamicWidgets = wrapper.findComponent(DynamicWidgets);
+
+  expect(dynamicWidgets.props()).toEqual({
+    classNames: undefined,
+    transformItems,
+    facets: ['test'],
+    maxValuesPerFacet: 100,
+  });
+
+  expect(dynamicWidgets.vm.widgetParams).toEqual({
+    transformItems,
+    facets: ['test'],
+    maxValuesPerFacet: 100,
+    widgets: [],
+  });
+});
+
 it('renders all children without state', () => {
   __setState(null);
 


### PR DESCRIPTION
FX-621

Adds the parameters "facets" and "maxValuesPerFacet" to the dynamicWidgets, to allow overriding their default values

see: https://github.com/algolia/instantsearch.js/pull/4968