### PR TITLE
fix(server): extend component correctly if at root

### DIFF
--- a/src/util/__tests__/createServerRootMixin.test.js
+++ b/src/util/__tests__/createServerRootMixin.test.js
@@ -683,7 +683,7 @@ Array [
       expect(instantsearch.mainHelper).toEqual(expect.any(AlgoliaSearchHelper));
     });
 
-    it('works when component is at root (and therefore has no $vnode)vnode', async () => {
+    it('works when component is at root (and therefore has no $vnode)', async () => {
       const searchClient = createFakeClient();
       let mainIndex;
 

--- a/src/util/__tests__/createServerRootMixin.test.js
+++ b/src/util/__tests__/createServerRootMixin.test.js
@@ -683,7 +683,7 @@ Array [
       expect(instantsearch.mainHelper).toEqual(expect.any(AlgoliaSearchHelper));
     });
 
-    it('works if component has no $vnode', async () => {
+    it('works when component is at root (and therefore has no $vnode)vnode', async () => {
       const searchClient = createFakeClient();
       let mainIndex;
 

--- a/src/util/__tests__/createServerRootMixin.test.js
+++ b/src/util/__tests__/createServerRootMixin.test.js
@@ -710,7 +710,7 @@ Array [
           ]),
       };
 
-      const wrapper = {
+      const wrapper = new Vue({
         mixins: [
           forceIsServerMixin,
           createServerRootMixin({
@@ -725,34 +725,34 @@ Array [
           mainIndex = this.instantsearch.mainIndex;
         },
         render: h => h(app),
-      };
+      });
 
       await renderToString(wrapper);
 
       expect(mainIndex.getWidgetState()).toMatchInlineSnapshot(`
-      Object {
-        "hello": Object {
-          "configure": Object {
-            "hitsPerPage": 100,
-          },
-        },
-      }
-      `);
+Object {
+  "hello": Object {
+    "configure": Object {
+      "hitsPerPage": 100,
+    },
+  },
+}
+`);
 
       expect(searchClient.search).toHaveBeenCalledTimes(1);
       expect(searchClient.search.mock.calls[0][0]).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "indexName": "hello",
-          "params": Object {
-            "facets": Array [],
-            "hitsPerPage": 100,
-            "query": "",
-            "tagFilters": "",
-          },
-        },
-      ]
-      `);
+Array [
+  Object {
+    "indexName": "hello",
+    "params": Object {
+      "facets": Array [],
+      "hitsPerPage": 100,
+      "query": "",
+      "tagFilters": "",
+    },
+  },
+]
+`);
     });
   });
 

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -242,8 +242,6 @@ function augmentInstantSearch(
       parent: null,
       uiState: search._initialUiState,
     });
-
-    search.middleware.forEach(({ instance }) => instance.subscribe());
   };
 
   /* eslint-enable no-param-reassign */

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -53,7 +53,10 @@ function defaultCloneComponent(componentInstance) {
 
   const Extended = componentInstance.$vnode
     ? componentInstance.$vnode.componentOptions.Ctor.extend(options)
-    : Vue.component(Object.assign({}, componentInstance.$options, options));
+    : Vue.component(
+        options.name,
+        Object.assign({}, componentInstance.$options, options)
+      );
 
   const app = new Extended({
     propsData: componentInstance.$options.propsData,
@@ -239,6 +242,8 @@ function augmentInstantSearch(
       parent: null,
       uiState: search._initialUiState,
     });
+
+    search.middleware.forEach(({ instance }) => instance.subscribe());
   };
 
   /* eslint-enable no-param-reassign */


### PR DESCRIPTION
Essentially the problem is that $vnode is usually available, but not when the this is a root Vue instance. In that case we are in the "Vue.component" case, which before now always was wrong (it takes two arguments, not one)

Same as #1104
see also #1054