### PR TITLE
ci(vue3): pin lower version of @babel/core

### DIFF
--- a/scripts/test-vue3.sh
+++ b/scripts/test-vue3.sh
@@ -2,7 +2,7 @@
 set -e
 
 yarn remove vue vue-jest vue-template-compiler babel-preset-es2015
-yarn add vue@3.1.2 @vue/server-renderer@3.1.2 vue-jest@5.0.0-alpha.10 vue-loader@16.1.2 jest@26.6.3 babel-jest@25.2.6 @babel/preset-env@7.14.5 @babel/plugin-transform-runtime@7.14.5 -D -E
+yarn add vue@3.1.2 @vue/server-renderer@3.1.2 vue-jest@5.0.0-alpha.10 vue-loader@16.1.2 jest@26.6.3 babel-jest@26.6.3 @babel/preset-env@7.17.0 @babel/plugin-transform-runtime@7.17.0 -D -E
 echo "export * from './index-3';" > src/util/vue-compat/index.js
 rm .babelrc
 cat <<EOT > babel.config.js

--- a/scripts/test-vue3.sh
+++ b/scripts/test-vue3.sh
@@ -2,7 +2,7 @@
 set -e
 
 yarn remove vue vue-jest vue-template-compiler babel-preset-es2015
-yarn add vue@3.1.2 @vue/server-renderer@3.1.2 vue-jest@5.0.0-alpha.10 vue-loader@16.1.2 jest@26.6.3 babel-jest@26.6.3 @babel/preset-env@7.17.0 @babel/plugin-transform-runtime@7.17.0 -D -E
+yarn add vue@3.1.2 @vue/server-renderer@3.1.2 vue-jest@5.0.0-alpha.10 vue-loader@16.1.2 jest@26.6.3 babel-jest@26.6.3 @babel/preset-env@7.16.11 @babel/plugin-transform-runtime@7.17.0 -D -E
 echo "export * from './index-3';" > src/util/vue-compat/index.js
 rm .babelrc
 cat <<EOT > babel.config.js

--- a/scripts/test-vue3.sh
+++ b/scripts/test-vue3.sh
@@ -2,7 +2,7 @@
 set -e
 
 yarn remove vue vue-jest vue-template-compiler babel-preset-es2015
-yarn add vue@3.1.2 @vue/server-renderer@3.1.2 vue-jest@5.0.0-alpha.10 vue-loader@16.1.2 jest@26.6.3 babel-jest@26.6.3 @babel/preset-env@7.16.11 @babel/plugin-transform-runtime@7.17.0 -D -E
+yarn add vue@3.1.2 @vue/server-renderer@3.1.2 vue-jest@5.0.0-alpha.10 vue-loader@16.1.2 jest@26.6.3 babel-jest@25.2.6 @babel/preset-env@7.14.5 @babel/plugin-transform-runtime@7.14.5 @babel/core@7.14.5 -D -E
 echo "export * from './index-3';" > src/util/vue-compat/index.js
 rm .babelrc
 cat <<EOT > babel.config.js


### PR DESCRIPTION
As we manually install the versions, the latest version of transitive dependencies, which happens to be @babel/core@7.17.0, which has the bug https://github.com/babel/babel/issues/14233.

Really we should solve this problem completely different, maybe with a separate folder, a separate package.json/yarn.lock possibly, but I couldn't find a straightforward way to do that right now.


Test plan: ci for vue 3 is no longer failing