### PR TITLE
fix(nuxt3): forward $nuxt on the instance by default

### DIFF
--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -105,9 +105,11 @@ function augmentInstantSearch(instantSearchOptions, cloneComponent) {
           mixins: [
             {
               beforeCreate() {
-                // In case of Nuxt (3), we ensure the context is shared
-                // Note that this has no effect outside of Nuxt
-                this.$nuxt = component.$nuxt;
+                if (component.$nuxt) {
+                  // In case of Nuxt (3), we ensure the context is shared between
+                  // the real and cloned component
+                  this.$nuxt = component.$nuxt;
+                }
               },
               created() {
                 instance = this.instantsearch;

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -41,7 +41,7 @@ function defaultCloneComponent(componentInstance, { mixins = [] } = {}) {
 
   if (isVue3) {
     const appOptions = Object.assign({}, componentInstance.$options, options);
-    appOptions.mixins = [...appOptions.mixins, ...mixins];
+    appOptions.mixins = [...mixins, ...appOptions.mixins];
     app = createSSRApp(appOptions);
     if (componentInstance.$router) {
       app.use(componentInstance.$router);
@@ -104,6 +104,11 @@ function augmentInstantSearch(instantSearchOptions, cloneComponent) {
         app = cloneComponent(component, {
           mixins: [
             {
+              beforeCreate() {
+                // In case of Nuxt (3), we ensure the context is shared
+                // Note that this has no effect outside of Nuxt
+                this.$nuxt = component.$nuxt;
+              },
               created() {
                 instance = this.instantsearch;
 


### PR DESCRIPTION
This is similar to how we forward $router and $store, but in this case it needs to happen before the beforeCreate of nuxt happens, as it uses that property