### PR TITLE
fix(ssr): use dedicated instance per render

### DIFF
--- a/src/components/__tests__/InstantSearch.js
+++ b/src/components/__tests__/InstantSearch.js
@@ -274,7 +274,7 @@ it('does not warn when `routing` have either `router` or `stateMapping`', () => 
   expect(warn).toHaveBeenCalledTimes(0);
 });
 
-it('Does not allow a change in `routing`', () => {
+it('Does not allow a change in `routing`', async () => {
   const wrapper = mount(InstantSearch, {
     propsData: {
       searchClient: {},
@@ -282,9 +282,9 @@ it('Does not allow a change in `routing`', () => {
     },
   });
 
-  expect(
+  await expect(
     wrapper.setProps({
-      routing: false,
+      routing: { stateMapping: {} },
     })
   ).rejects.toMatchInlineSnapshot(`
 [Error: routing configuration can not be changed dynamically at this point.

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -77,7 +77,10 @@ function defaultCloneComponent(componentInstance, { mixins = [] } = {}) {
   return app;
 }
 
-function augmentInstantSearch(instantSearchOptions, cloneComponent) {
+function augmentInstantSearch(instantSearchOptions) {
+  const {
+    $cloneComponent: cloneComponent = defaultCloneComponent,
+  } = instantSearchOptions;
   const search = instantsearch(instantSearchOptions);
 
   let initialResults;
@@ -226,9 +229,16 @@ function augmentInstantSearch(instantSearchOptions, cloneComponent) {
 }
 
 export function createServerRootMixin(instantSearchOptions = {}) {
-  const { $cloneComponent = defaultCloneComponent } = instantSearchOptions;
+  if (!instantSearchOptions.searchClient) {
+    throw new Error(`The \`searchClient\` option is required.
 
-  const search = augmentInstantSearch(instantSearchOptions, $cloneComponent);
+See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/`);
+  }
+  if (!instantSearchOptions.indexName) {
+    throw new Error(`The \`indexName\` option is required.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/`);
+  }
 
   // put this in the user's root Vue instance
   // we can then reuse that InstantSearch instance seamlessly from `ais-instant-search-ssr`
@@ -242,7 +252,7 @@ export function createServerRootMixin(instantSearchOptions = {}) {
       return {
         // this is in data, so that the real & cloned render do not share
         // the same instantsearch instance.
-        instantsearch: search,
+        instantsearch: augmentInstantSearch(instantSearchOptions),
       };
     },
   };

--- a/src/util/vue-compat/index-vue3.js
+++ b/src/util/vue-compat/index-vue3.js
@@ -9,16 +9,20 @@ export { Vue, Vue2, isVue2, isVue3 };
 
 export function renderCompat(fn) {
   function h(tag, props, children) {
+    let flatProps = props;
     if (typeof props === 'object' && (props.attrs || props.props)) {
       // In vue 3, we no longer wrap with `attrs` or `props` key.
-      const flatProps = Object.assign({}, props, props.attrs, props.props);
+      flatProps = Object.assign({}, props, props.attrs, props.props);
       delete flatProps.attrs;
       delete flatProps.props;
-
-      return Vue.h(tag, flatProps, children);
     }
 
-    return Vue.h(tag, props, children);
+    let slots = children;
+    if (typeof tag === 'object' && Array.isArray(children)) {
+      slots = { default: () => children };
+    }
+
+    return Vue.h(tag, flatProps, slots);
   }
 
   return function() {


### PR DESCRIPTION
fixes algolia/instantsearch#5387

We use the same InstantSearch instance for every call of `createServerRootMixin`, but that means we start multiple times, without destroying, causing memory leaks.