### PR TITLE
fix(nuxt): only write $nuxt if it's writable

### DIFF
--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -112,7 +112,7 @@ function augmentInstantSearch(instantSearchOptions, cloneComponent) {
 
                 const isWritable = descriptor
                   ? descriptor.writable || descriptor.set
-                  : true;
+                  : false;
 
                 if (component.$nuxt && isWritable) {
                   // In case of Nuxt (3), we ensure the context is shared between

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -106,7 +106,7 @@ function augmentInstantSearch(instantSearchOptions, cloneComponent) {
             {
               beforeCreate() {
                 const descriptor = Object.getOwnPropertyDescriptor(
-                  this,
+                  component,
                   '$nuxt'
                 );
 

--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -105,7 +105,16 @@ function augmentInstantSearch(instantSearchOptions, cloneComponent) {
           mixins: [
             {
               beforeCreate() {
-                if (component.$nuxt) {
+                const descriptor = Object.getOwnPropertyDescriptor(
+                  this,
+                  '$nuxt'
+                );
+
+                const isWritable = descriptor
+                  ? descriptor.writable || descriptor.set
+                  : true;
+
+                if (component.$nuxt && isWritable) {
                   // In case of Nuxt (3), we ensure the context is shared between
                   // the real and cloned component
                   this.$nuxt = component.$nuxt;


### PR DESCRIPTION
In some nuxt 2 cases (https://github.com/algolia/vue-instantsearch/commit/acda29326475bd1b73f12b058a0c02df00b8b239#commitcomment-67430759) this.$nuxt is already defined by the framework, but not a setter, so we can't make it equal to the $nuxt of the component.

Luckily in Nuxt 2, setting $nuxt isn't crucial, and can thus be skipped.