### PR TITLE
feat(widgets): pass $$widgetType

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,9 +1,18 @@
-import { isVue3, Vue2, createApp } from '../util/vue-compat';
+import { isVue3, Vue2, createApp, Vue, renderCompat } from '../util/vue-compat';
 import InstantSearch from '../instantsearch';
+import { AisInstantSearch } from '../widgets';
 
 const renderlessComponents = ['AisExperimentalConfigureRelatedItems'];
+const nonWidgetComponents = [
+  'AisInstantSearch',
+  'AisInstantSearchSsr',
+  'AisHighlight',
+  'AisSnippet',
+  'AisPanel',
+  'AisPoweredBy',
+];
 
-it('should have `name` the same as the suit class name everywhere', () => {
+function getAllComponents() {
   let calls;
   if (isVue3) {
     const app = createApp();
@@ -16,37 +25,105 @@ it('should have `name` the same as the suit class name everywhere', () => {
     calls = Vue2.component.mock.calls;
   }
 
-  const allInstalledComponents = calls.filter(
-    ([installedName]) => !renderlessComponents.includes(installedName)
-  );
-  const components = allInstalledComponents.map(
-    ([installedName, { name, mixins }]) => {
-      let suitClass = `Error! ${name} is missing the suit classes`;
+  return calls.map(([installedName, call]) => {
+    const { name, mixins } = call;
+    let suitClass = `Error! ${name} is missing the suit classes`;
+    let widget = `Error! ${name} is missing the widget`;
 
-      try {
-        suitClass = mixins
-          .find(mixin => mixin.methods && mixin.methods.suit)
-          .methods.suit();
-      } catch (e) {
-        /* no suit class, so will fail the assertions */
+    try {
+      suitClass = mixins
+        .find(mixin => mixin.methods && mixin.methods.suit)
+        .methods.suit();
+    } catch (e) {
+      /* no suit class, so will fail the assertions */
+    }
+
+    try {
+      if (nonWidgetComponents.includes(name)) {
+        throw new Error('not a widget');
       }
+      const vm = new Vue({
+        render: renderCompat(h =>
+          h(
+            AisInstantSearch,
+            {
+              props: {
+                indexName: 'instant_search',
+                searchClient: {
+                  search() {
+                    return new Promise({ results: [] });
+                  },
+                },
+              },
+            },
+            [
+              h(call, {
+                props: {
+                  indexName: 'index',
+                  attribute: 'attr',
+                  attributes: ['attr'],
+                  hit: {},
+                  label: '',
+                  items: [{ default: true, value: 1, label: 'one' }],
+                  trackedFilters: {},
+                  matchingPatterns: {},
+                },
+                ref: 'widgetComponent',
+              }),
+            ]
+          )
+        ),
+      }).$mount();
+      widget = vm.$refs.widgetComponent.widget;
+    } catch (e) {
+      /* no widget, so will fail the assertions */
+    }
 
-      return {
-        installedName,
-        name,
-        suitClass,
-      };
+    return {
+      installedName,
+      name,
+      suitClass,
+      widget,
+    };
+  });
+}
+
+const components = getAllComponents();
+
+describe('DOM component', () => {
+  test.each(
+    components.filter(
+      ({ name }) => renderlessComponents.includes(name) === false
+    )
+  )(
+    '$name should have the same `name` as suit class',
+    ({ name, installedName, suitClass }) => {
+      expect(installedName).toBe(name);
+      if (name === 'AisInstantSearchSsr') {
+        expect(suitClass).toBe(`ais-InstantSearch`);
+      } else if (name === 'AisExperimentalDynamicWidgets') {
+        expect(suitClass).toBe(`ais-DynamicWidgets`);
+      } else {
+        expect(suitClass).toBe(`ais-${name.substr(3)}`);
+      }
     }
   );
+});
 
-  components.forEach(({ name, installedName, suitClass }) => {
-    expect(installedName).toBe(name);
-    if (name === 'AisInstantSearchSsr') {
-      expect(suitClass).toBe(`ais-InstantSearch`);
-    } else if (name === 'AisExperimentalDynamicWidgets') {
-      expect(suitClass).toBe(`ais-DynamicWidgets`);
+describe('installed widget', () => {
+  test.each(
+    components.filter(
+      ({ name }) => nonWidgetComponents.includes(name) === false
+    )
+  )('sets widgetType $name', ({ name, widget }) => {
+    if (name === 'AisExperimentalDynamicWidgets') {
+      expect(widget.$$widgetType).toBe('ais.dynamicWidgets');
+    } else if (name === 'AisExperimentalConfigureRelatedItems') {
+      expect(widget.$$widgetType).toBe('ais.configureRelatedItems');
     } else {
-      expect(suitClass).toBe(`ais-${name.substr(3)}`);
+      expect(widget.$$widgetType).toBe(
+        `ais.${name[3].toLowerCase()}${name.substr(4)}`
+      );
     }
   });
 });

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,4 +1,10 @@
-import { isVue3, Vue2, createApp, Vue, renderCompat } from '../util/vue-compat';
+import {
+  isVue3,
+  isVue2,
+  Vue2,
+  createApp,
+  renderCompat,
+} from '../util/vue-compat';
 import InstantSearch from '../instantsearch';
 import { AisInstantSearch } from '../widgets';
 
@@ -42,7 +48,33 @@ function getAllComponents() {
       if (nonWidgetComponents.includes(name)) {
         throw new Error('not a widget');
       }
-      const vm = new Vue({
+
+      const props = {};
+      if (name === 'AisHierarchicalMenu' || name === 'AisBreadcrumb') {
+        props.attributes = ['attr'];
+      } else if (name === 'AisExperimentalConfigureRelatedItems') {
+        props.hit = {};
+        props.matchingPatterns = {};
+      } else if (name === 'AisToggleRefinement') {
+        props.attribute = 'attr';
+        props.label = 'label';
+        props.value = 'value';
+      } else if (name === 'AisSortBy') {
+        props.items = [];
+      } else if (name === 'AisNumericMenu') {
+        props.items = [{ label: 'start', start: 1 }];
+        props.attribute = 'attr';
+      } else if (name === 'AisHitsPerPage') {
+        props.items = [{ default: true, label: 'ten', value: 10 }];
+      } else if (name === 'AisQueryRuleContext') {
+        props.trackedFilters = {};
+      } else if (name === 'AisIndex') {
+        props.indexName = 'indexName';
+      } else {
+        props.attribute = 'attr';
+      }
+
+      const Component = {
         render: renderCompat(h =>
           h(
             AisInstantSearch,
@@ -58,22 +90,20 @@ function getAllComponents() {
             },
             [
               h(call, {
-                props: {
-                  indexName: 'index',
-                  attribute: 'attr',
-                  attributes: ['attr'],
-                  hit: {},
-                  label: '',
-                  items: [{ default: true, value: 1, label: 'one' }],
-                  trackedFilters: {},
-                  matchingPatterns: {},
-                },
+                props,
                 ref: 'widgetComponent',
               }),
             ]
           )
         ),
-      }).$mount();
+      };
+
+      let vm;
+      if (isVue2) {
+        vm = new Vue2(Component).$mount();
+      } else if (isVue3) {
+        vm = createApp(Component).mount(document.createElement('div'));
+      }
       widget = vm.$refs.widgetComponent.widget;
     } catch (e) {
       /* no widget, so will fail the assertions */

--- a/src/components/Autocomplete.vue
+++ b/src/components/Autocomplete.vue
@@ -28,7 +28,14 @@ import { createSuitMixin } from '../mixins/suit';
 export default {
   name: 'AisAutocomplete',
   mixins: [
-    createWidgetMixin({ connector: connectAutocomplete }),
+    createWidgetMixin(
+      {
+        connector: connectAutocomplete,
+      },
+      {
+        $$widgetType: 'ais.autocomplete',
+      }
+    ),
     createSuitMixin({ name: 'Autocomplete' }),
   ],
   props: {

--- a/src/components/Breadcrumb.vue
+++ b/src/components/Breadcrumb.vue
@@ -56,7 +56,14 @@ import { createWidgetMixin } from '../mixins/widget';
 export default {
   name: 'AisBreadcrumb',
   mixins: [
-    createWidgetMixin({ connector: connectBreadcrumb }),
+    createWidgetMixin(
+      {
+        connector: connectBreadcrumb,
+      },
+      {
+        $$widgetType: 'ais.breadcrumb',
+      }
+    ),
     createPanelConsumerMixin({
       mapStateToCanRefine: state => Boolean(state.canRefine),
     }),

--- a/src/components/ClearRefinements.vue
+++ b/src/components/ClearRefinements.vue
@@ -29,7 +29,14 @@ import { createWidgetMixin } from '../mixins/widget';
 export default {
   name: 'AisClearRefinements',
   mixins: [
-    createWidgetMixin({ connector: connectClearRefinements }),
+    createWidgetMixin(
+      {
+        connector: connectClearRefinements,
+      },
+      {
+        $$widgetType: 'ais.clearRefinements',
+      }
+    ),
     createPanelConsumerMixin({
       mapStateToCanRefine: state => Boolean(state.hasRefinements),
     }),

--- a/src/components/Configure.js
+++ b/src/components/Configure.js
@@ -8,7 +8,14 @@ export default {
   name: 'AisConfigure',
   mixins: [
     createSuitMixin({ name: 'Configure' }),
-    createWidgetMixin({ connector: connectConfigure }),
+    createWidgetMixin(
+      {
+        connector: connectConfigure,
+      },
+      {
+        $$widgetType: 'ais.configure',
+      }
+    ),
   ],
   computed: {
     widgetParams() {

--- a/src/components/ConfigureRelatedItems.js
+++ b/src/components/ConfigureRelatedItems.js
@@ -5,7 +5,14 @@ export default {
   inheritAttrs: false,
   name: 'AisExperimentalConfigureRelatedItems',
   mixins: [
-    createWidgetMixin({ connector: EXPERIMENTAL_connectConfigureRelatedItems }),
+    createWidgetMixin(
+      {
+        connector: EXPERIMENTAL_connectConfigureRelatedItems,
+      },
+      {
+        $$widgetType: 'ais.configureRelatedItems',
+      }
+    ),
   ],
   props: {
     hit: {

--- a/src/components/CurrentRefinements.vue
+++ b/src/components/CurrentRefinements.vue
@@ -63,7 +63,14 @@ export default {
   name: 'AisCurrentRefinements',
   mixins: [
     createSuitMixin({ name: 'CurrentRefinements' }),
-    createWidgetMixin({ connector: connectCurrentRefinements }),
+    createWidgetMixin(
+      {
+        connector: connectCurrentRefinements,
+      },
+      {
+        $$widgetType: 'ais.currentRefinements',
+      }
+    ),
     createPanelConsumerMixin({
       mapStateToCanRefine: state =>
         Boolean(state.items) && state.items.length > 0,

--- a/src/components/DynamicWidgets.js
+++ b/src/components/DynamicWidgets.js
@@ -42,7 +42,14 @@ function getWidgetAttribute(vnode) {
 export default {
   name: 'AisDynamicWidgets',
   mixins: [
-    createWidgetMixin({ connector: connectDynamicWidgets }),
+    createWidgetMixin(
+      {
+        connector: connectDynamicWidgets,
+      },
+      {
+        $$widgetType: 'ais.dynamicWidgets',
+      }
+    ),
     createSuitMixin({ name: 'DynamicWidgets' }),
   ],
   props: {

--- a/src/components/HierarchicalMenu.vue
+++ b/src/components/HierarchicalMenu.vue
@@ -53,7 +53,14 @@ export default {
   name: 'AisHierarchicalMenu',
   mixins: [
     createSuitMixin({ name: 'HierarchicalMenu' }),
-    createWidgetMixin({ connector: connectHierarchicalMenu }),
+    createWidgetMixin(
+      {
+        connector: connectHierarchicalMenu,
+      },
+      {
+        $$widgetType: 'ais.hierarchicalMenu',
+      }
+    ),
     createPanelConsumerMixin({
       mapStateToCanRefine,
     }),

--- a/src/components/Hits.vue
+++ b/src/components/Hits.vue
@@ -34,7 +34,14 @@ import { createSuitMixin } from '../mixins/suit';
 export default {
   name: 'AisHits',
   mixins: [
-    createWidgetMixin({ connector: connectHitsWithInsights }),
+    createWidgetMixin(
+      {
+        connector: connectHitsWithInsights,
+      },
+      {
+        $$widgetType: 'ais.hits',
+      }
+    ),
     createSuitMixin({ name: 'Hits' }),
   ],
   props: {

--- a/src/components/HitsPerPage.vue
+++ b/src/components/HitsPerPage.vue
@@ -34,7 +34,14 @@ export default {
   name: 'AisHitsPerPage',
   mixins: [
     createSuitMixin({ name: 'HitsPerPage' }),
-    createWidgetMixin({ connector: connectHitsPerPage }),
+    createWidgetMixin(
+      {
+        connector: connectHitsPerPage,
+      },
+      {
+        $$widgetType: 'ais.hitsPerPage',
+      }
+    ),
     createPanelConsumerMixin({
       mapStateToCanRefine: state => state.hasNoResults === false,
     }),

--- a/src/components/Index.js
+++ b/src/components/Index.js
@@ -10,7 +10,12 @@ export default {
   name: 'AisIndex',
   mixins: [
     createSuitMixin({ name: 'Index' }),
-    createWidgetMixin({ connector: connectIndex }),
+    createWidgetMixin(
+      { connector: connectIndex },
+      {
+        $$widgetType: 'ais.index',
+      }
+    ),
   ],
   provide() {
     return {

--- a/src/components/InfiniteHits.vue
+++ b/src/components/InfiniteHits.vue
@@ -68,7 +68,14 @@ import { createSuitMixin } from '../mixins/suit';
 export default {
   name: 'AisInfiniteHits',
   mixins: [
-    createWidgetMixin({ connector: connectInfiniteHitsWithInsights }),
+    createWidgetMixin(
+      {
+        connector: connectInfiniteHitsWithInsights,
+      },
+      {
+        $$widgetType: 'ais.infiniteHits',
+      }
+    ),
     createSuitMixin({ name: 'InfiniteHits' }),
   ],
   props: {

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -55,7 +55,12 @@ export default {
   name: 'AisMenu',
   mixins: [
     createSuitMixin({ name: 'Menu' }),
-    createWidgetMixin({ connector: connectMenu }),
+    createWidgetMixin(
+      { connector: connectMenu },
+      {
+        $$widgetType: 'ais.menu',
+      }
+    ),
     createPanelConsumerMixin({
       mapStateToCanRefine: state => Boolean(state.canRefine),
     }),

--- a/src/components/MenuSelect.vue
+++ b/src/components/MenuSelect.vue
@@ -47,7 +47,12 @@ export default {
   name: 'AisMenuSelect',
   mixins: [
     createSuitMixin({ name: 'MenuSelect' }),
-    createWidgetMixin({ connector: connectMenu }),
+    createWidgetMixin(
+      { connector: connectMenu },
+      {
+        $$widgetType: 'ais.menuSelect',
+      }
+    ),
     createPanelConsumerMixin({
       mapStateToCanRefine: state => Boolean(state.canRefine),
     }),

--- a/src/components/NumericMenu.vue
+++ b/src/components/NumericMenu.vue
@@ -42,7 +42,14 @@ import { createSuitMixin } from '../mixins/suit';
 export default {
   name: 'AisNumericMenu',
   mixins: [
-    createWidgetMixin({ connector: connectNumericMenu }),
+    createWidgetMixin(
+      {
+        connector: connectNumericMenu,
+      },
+      {
+        $$widgetType: 'ais.numericMenu',
+      }
+    ),
     createSuitMixin({ name: 'NumericMenu' }),
     createPanelConsumerMixin({
       mapStateToCanRefine: state => state.hasNoResults === false,

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -174,7 +174,14 @@ export default {
   name: 'AisPagination',
   mixins: [
     createSuitMixin({ name: 'Pagination' }),
-    createWidgetMixin({ connector: connectPagination }),
+    createWidgetMixin(
+      {
+        connector: connectPagination,
+      },
+      {
+        $$widgetType: 'ais.pagination',
+      }
+    ),
     createPanelConsumerMixin({
       mapStateToCanRefine: state => state.nbPages > 1,
     }),

--- a/src/components/QueryRuleContext.js
+++ b/src/components/QueryRuleContext.js
@@ -6,9 +6,14 @@ export default {
   name: 'AisQueryRuleContext',
   mixins: [
     createSuitMixin({ name: 'QueryRuleContext' }),
-    createWidgetMixin({
-      connector: connectQueryRules,
-    }),
+    createWidgetMixin(
+      {
+        connector: connectQueryRules,
+      },
+      {
+        $$widgetType: 'ais.queryRuleContext',
+      }
+    ),
   ],
   props: {
     trackedFilters: {

--- a/src/components/QueryRuleCustomData.vue
+++ b/src/components/QueryRuleCustomData.vue
@@ -28,9 +28,14 @@ export default {
   name: 'AisQueryRuleCustomData',
   mixins: [
     createSuitMixin({ name: 'QueryRuleCustomData' }),
-    createWidgetMixin({
-      connector: connectQueryRules,
-    }),
+    createWidgetMixin(
+      {
+        connector: connectQueryRules,
+      },
+      {
+        $$widgetType: 'ais.queryRuleCustomData',
+      }
+    ),
   ],
   props: {
     transformItems: {

--- a/src/components/RangeInput.vue
+++ b/src/components/RangeInput.vue
@@ -67,7 +67,14 @@ export default {
   name: 'AisRangeInput',
   mixins: [
     createSuitMixin({ name: 'RangeInput' }),
-    createWidgetMixin({ connector: connectRange }),
+    createWidgetMixin(
+      {
+        connector: connectRange,
+      },
+      {
+        $$widgetType: 'ais.rangeInput',
+      }
+    ),
     createPanelConsumerMixin({
       mapStateToCanRefine,
     }),

--- a/src/components/RatingMenu.vue
+++ b/src/components/RatingMenu.vue
@@ -87,7 +87,14 @@ export default {
   name: 'AisRatingMenu',
   mixins: [
     createSuitMixin({ name: 'RatingMenu' }),
-    createWidgetMixin({ connector: connectRatingMenu }),
+    createWidgetMixin(
+      {
+        connector: connectRatingMenu,
+      },
+      {
+        $$widgetType: 'ais.ratingMenu',
+      }
+    ),
     createPanelConsumerMixin({
       mapStateToCanRefine: state => state.hasNoResults === false,
     }),

--- a/src/components/RefinementList.vue
+++ b/src/components/RefinementList.vue
@@ -110,7 +110,14 @@ export default {
   components: { SearchInput, AisHighlight },
   mixins: [
     createSuitMixin({ name: 'RefinementList' }),
-    createWidgetMixin({ connector: connectRefinementList }),
+    createWidgetMixin(
+      {
+        connector: connectRefinementList,
+      },
+      {
+        $$widgetType: 'ais.refinementList',
+      }
+    ),
     createPanelConsumerMixin({
       mapStateToCanRefine: state => Boolean(state.canRefine),
     }),

--- a/src/components/RelevantSort.vue
+++ b/src/components/RelevantSort.vue
@@ -36,7 +36,14 @@ export default {
   name: 'AisRelevantSort',
   mixins: [
     createSuitMixin({ name: 'RelevantSort' }),
-    createWidgetMixin({ connector: connectRelevantSort }),
+    createWidgetMixin(
+      {
+        connector: connectRelevantSort,
+      },
+      {
+        $$widgetType: 'ais.relevantSort',
+      }
+    ),
   ],
   methods: {
     refine() {

--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -77,7 +77,14 @@ import SearchInput from './SearchInput.vue';
 export default {
   name: 'AisSearchBox',
   mixins: [
-    createWidgetMixin({ connector: connectSearchBox }),
+    createWidgetMixin(
+      {
+        connector: connectSearchBox,
+      },
+      {
+        $$widgetType: 'ais.searchBox',
+      }
+    ),
     createSuitMixin({ name: 'SearchBox' }),
   ],
   components: {

--- a/src/components/SortBy.vue
+++ b/src/components/SortBy.vue
@@ -35,7 +35,12 @@ export default {
   name: 'AisSortBy',
   mixins: [
     createSuitMixin({ name: 'SortBy' }),
-    createWidgetMixin({ connector: connectSortBy }),
+    createWidgetMixin(
+      { connector: connectSortBy },
+      {
+        $$widgetType: 'ais.sortBy',
+      }
+    ),
 
     createPanelConsumerMixin({
       mapStateToCanRefine: state => state.hasNoResults === false,

--- a/src/components/StateResults.vue
+++ b/src/components/StateResults.vue
@@ -25,7 +25,14 @@ import connectStateResults from '../connectors/connectStateResults';
 export default {
   name: 'AisStateResults',
   mixins: [
-    createWidgetMixin({ connector: connectStateResults }),
+    createWidgetMixin(
+      {
+        connector: connectStateResults,
+      },
+      {
+        $$widgetType: 'ais.stateResults',
+      }
+    ),
     createSuitMixin({ name: 'StateResults' }),
   ],
   computed: {

--- a/src/components/Stats.vue
+++ b/src/components/Stats.vue
@@ -20,7 +20,12 @@ import { createSuitMixin } from '../mixins/suit';
 export default {
   name: 'AisStats',
   mixins: [
-    createWidgetMixin({ connector: connectStats }),
+    createWidgetMixin(
+      { connector: connectStats },
+      {
+        $$widgetType: 'ais.stats',
+      }
+    ),
     createSuitMixin({ name: 'Stats' }),
   ],
   computed: {

--- a/src/components/ToggleRefinement.vue
+++ b/src/components/ToggleRefinement.vue
@@ -41,7 +41,14 @@ export default {
   name: 'AisToggleRefinement',
   mixins: [
     createSuitMixin({ name: 'ToggleRefinement' }),
-    createWidgetMixin({ connector: connectToggleRefinement }),
+    createWidgetMixin(
+      {
+        connector: connectToggleRefinement,
+      },
+      {
+        $$widgetType: 'ais.toggleRefinement',
+      }
+    ),
     createPanelConsumerMixin({
       mapStateToCanRefine,
     }),

--- a/src/components/VoiceSearch.vue
+++ b/src/components/VoiceSearch.vue
@@ -84,7 +84,14 @@ import { createWidgetMixin } from '../mixins/widget';
 export default {
   name: 'AisVoiceSearch',
   mixins: [
-    createWidgetMixin({ connector: connectVoiceSearch }),
+    createWidgetMixin(
+      {
+        connector: connectVoiceSearch,
+      },
+      {
+        $$widgetType: 'ais.voiceSearch',
+      }
+    ),
     createSuitMixin({ name: 'VoiceSearch' }),
   ],
   props: {

--- a/src/mixins/widget.js
+++ b/src/mixins/widget.js
@@ -1,7 +1,11 @@
+import { _objectSpread } from '../util/polyfills';
 import { isVue3 } from '../util/vue-compat';
 import { warn } from '../util/warn';
 
-export const createWidgetMixin = ({ connector } = {}) => ({
+export const createWidgetMixin = (
+  { connector } = {},
+  additionalProperties = {}
+) => ({
   inject: {
     instantSearchInstance: {
       from: '$_ais_instantSearchInstance',
@@ -27,7 +31,10 @@ export const createWidgetMixin = ({ connector } = {}) => ({
   created() {
     if (typeof connector === 'function') {
       this.factory = connector(this.updateState, () => {});
-      this.widget = this.factory(this.widgetParams);
+      this.widget = _objectSpread(
+        this.factory(this.widgetParams),
+        additionalProperties
+      );
       this.getParentIndex().addWidgets([this.widget]);
 
       if (
@@ -66,7 +73,10 @@ Read more on using connectors: https://alg.li/vue-custom`
       handler(nextWidgetParams) {
         this.state = null;
         this.getParentIndex().removeWidgets([this.widget]);
-        this.widget = this.factory(nextWidgetParams);
+        this.widget = _objectSpread(
+          this.factory(nextWidgetParams),
+          additionalProperties
+        );
         this.getParentIndex().addWidgets([this.widget]);
       },
       deep: true,


### PR DESCRIPTION
This is used for metadata, and allows to distinguish between builtin widgets and custom ones using `createWidgetMixin` by the users.

The design using `additionalParameters` is inspired by what we chose in React InstantSearch Hooks.

FX-916

Test-wise I've refactored the global "all widgets" test to enforce this too.