### PR TITLE
fix(ssr): allow component without mixins to be extended

### DIFF
--- a/src/util/createServerRootMixin.js
+++ b/src/util/createServerRootMixin.js
@@ -41,7 +41,7 @@ function defaultCloneComponent(componentInstance, { mixins = [] } = {}) {
 
   if (isVue3) {
     const appOptions = Object.assign({}, componentInstance.$options, options);
-    appOptions.mixins = [...mixins, ...appOptions.mixins];
+    appOptions.mixins = [...mixins, ...(appOptions.mixins || [])];
     app = createSSRApp(appOptions);
     if (componentInstance.$router) {
       app.use(componentInstance.$router);


### PR DESCRIPTION
This can't be tested afaict because we need `forceIsServerMixin` in the test.

discovered while debugging https://github.com/algolia/vue-instantsearch/issues/1125