### PR TITLE
fix(components): forward missing props in SearchBox and VoiceSearch

### DIFF
--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -120,6 +120,10 @@ export default {
       type: String,
       default: undefined,
     },
+    queryHook: {
+      type: Function,
+      default: undefined,
+    },
   },
   data() {
     return {
@@ -129,6 +133,11 @@ export default {
     };
   },
   computed: {
+    widgetParams() {
+      return {
+        queryHook: this.queryHook,
+      };
+    },
     isControlled() {
       return (
         typeof this.value !== 'undefined' ||

--- a/src/components/VoiceSearch.vue
+++ b/src/components/VoiceSearch.vue
@@ -100,6 +100,14 @@ export default {
       required: false,
       default: undefined,
     },
+    language: {
+      type: String,
+      default: undefined,
+    },
+    additionalQueryParameters: {
+      type: Object,
+      default: undefined,
+    },
     buttonTitle: {
       type: String,
       required: false,
@@ -130,6 +138,8 @@ export default {
     widgetParams() {
       return {
         searchAsYouSpeak: this.searchAsYouSpeak,
+        language: this.language,
+        additionalQueryParameters: this.additionalQueryParameters,
       };
     },
     errorNotAllowed() {


### PR DESCRIPTION
fixes #1135

I've wen through the list of all widgets, and only these on VoiceSearch and queryHook on SearchBox were missing.

I didn't add any tests, as none of the widgets test widgetParams (since it's not tested in any other widget, and likely would just be a copy paste of the code)