### PR TITLE
feat(can-refine): provide `canRefine` for multiple widget slots

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "release": "shipjs prepare"
   },
   "dependencies": {
-    "instantsearch.js": "^4.43.0",
+    "instantsearch.js": "^4.45.0",
     "mitt": "^2.1.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -133,11 +133,11 @@
   "bundlesize": [
     {
       "path": "./vue2/umd/index.js",
-      "maxSize": "56.50 kB"
+      "maxSize": "56.75 kB"
     },
     {
       "path": "./vue3/umd/index.js",
-      "maxSize": "57.75 kB"
+      "maxSize": "58.00 kB"
     },
     {
       "path": "./vue2/cjs/index.js",

--- a/src/components/Breadcrumb.vue
+++ b/src/components/Breadcrumb.vue
@@ -64,9 +64,7 @@ export default {
         $$widgetType: 'ais.breadcrumb',
       }
     ),
-    createPanelConsumerMixin({
-      mapStateToCanRefine: state => Boolean(state.canRefine),
-    }),
+    createPanelConsumerMixin(),
     createSuitMixin({ name: 'Breadcrumb' }),
   ],
   props: {

--- a/src/components/ClearRefinements.vue
+++ b/src/components/ClearRefinements.vue
@@ -37,9 +37,7 @@ export default {
         $$widgetType: 'ais.clearRefinements',
       }
     ),
-    createPanelConsumerMixin({
-      mapStateToCanRefine: state => Boolean(state.hasRefinements),
-    }),
+    createPanelConsumerMixin(),
     createSuitMixin({ name: 'ClearRefinements' }),
   ],
   props: {

--- a/src/components/CurrentRefinements.vue
+++ b/src/components/CurrentRefinements.vue
@@ -71,10 +71,7 @@ export default {
         $$widgetType: 'ais.currentRefinements',
       }
     ),
-    createPanelConsumerMixin({
-      mapStateToCanRefine: state =>
-        Boolean(state.items) && state.items.length > 0,
-    }),
+    createPanelConsumerMixin(),
   ],
   props: {
     includedAttributes: {

--- a/src/components/HierarchicalMenu.vue
+++ b/src/components/HierarchicalMenu.vue
@@ -1,11 +1,11 @@
 <template>
   <div
     v-if="state"
-    :class="[suit(), !canRefine && suit('', 'noRefinement')]"
+    :class="[suit(), !state.canRefine && suit('', 'noRefinement')]"
   >
     <slot
       :items="state.items"
-      :can-refine="canRefine"
+      :can-refine="state.canRefine"
       :can-toggle-show-more="state.canToggleShowMore"
       :is-showing-more="state.isShowingMore"
       :refine="state.refine"
@@ -46,9 +46,6 @@ import { createPanelConsumerMixin } from '../mixins/panel';
 import HierarchicalMenuList from './HierarchicalMenuList.vue';
 import { createSuitMixin } from '../mixins/suit';
 
-const mapStateToCanRefine = state =>
-  Boolean(state.items) && state.items.length > 0;
-
 export default {
   name: 'AisHierarchicalMenu',
   mixins: [
@@ -61,9 +58,7 @@ export default {
         $$widgetType: 'ais.hierarchicalMenu',
       }
     ),
-    createPanelConsumerMixin({
-      mapStateToCanRefine,
-    }),
+    createPanelConsumerMixin(),
   ],
   components: {
     HierarchicalMenuList,
@@ -119,9 +114,6 @@ export default {
         sortBy: this.sortBy,
         transformItems: this.transformItems,
       };
-    },
-    canRefine() {
-      return mapStateToCanRefine(this.state);
     },
   },
 };

--- a/src/components/HitsPerPage.vue
+++ b/src/components/HitsPerPage.vue
@@ -43,9 +43,7 @@ export default {
         $$widgetType: 'ais.hitsPerPage',
       }
     ),
-    createPanelConsumerMixin({
-      mapStateToCanRefine: state => Boolean(state.canRefine),
-    }),
+    createPanelConsumerMixin(),
   ],
   props: {
     items: {

--- a/src/components/HitsPerPage.vue
+++ b/src/components/HitsPerPage.vue
@@ -7,6 +7,7 @@
       :items="state.items"
       :refine="state.refine"
       :hasNoResults="state.hasNoResults"
+      :canRefine="state.canRefine"
     >
       <select
         :class="suit('select')"
@@ -43,7 +44,7 @@ export default {
       }
     ),
     createPanelConsumerMixin({
-      mapStateToCanRefine: state => state.hasNoResults === false,
+      mapStateToCanRefine: state => Boolean(state.canRefine),
     }),
   ],
   props: {

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -61,9 +61,7 @@ export default {
         $$widgetType: 'ais.menu',
       }
     ),
-    createPanelConsumerMixin({
-      mapStateToCanRefine: state => Boolean(state.canRefine),
-    }),
+    createPanelConsumerMixin(),
   ],
   props: {
     attribute: {

--- a/src/components/MenuSelect.vue
+++ b/src/components/MenuSelect.vue
@@ -53,9 +53,7 @@ export default {
         $$widgetType: 'ais.menuSelect',
       }
     ),
-    createPanelConsumerMixin({
-      mapStateToCanRefine: state => Boolean(state.canRefine),
-    }),
+    createPanelConsumerMixin(),
   ],
   props: {
     attribute: {

--- a/src/components/NumericMenu.vue
+++ b/src/components/NumericMenu.vue
@@ -51,9 +51,7 @@ export default {
       }
     ),
     createSuitMixin({ name: 'NumericMenu' }),
-    createPanelConsumerMixin({
-      mapStateToCanRefine: state => Boolean(state.canRefine),
-    }),
+    createPanelConsumerMixin(),
   ],
   props: {
     attribute: {

--- a/src/components/NumericMenu.vue
+++ b/src/components/NumericMenu.vue
@@ -1,11 +1,11 @@
 <template>
   <div
     v-if="state"
-    :class="[suit(), !canRefine && suit('', 'noRefinement')]"
+    :class="[suit(), !state.canRefine && suit('', 'noRefinement')]"
   >
     <slot
       :items="state.items"
-      :can-refine="canRefine"
+      :can-refine="state.canRefine"
       :refine="state.refine"
       :createURL="state.createURL"
       :send-event="state.sendEvent"
@@ -52,7 +52,7 @@ export default {
     ),
     createSuitMixin({ name: 'NumericMenu' }),
     createPanelConsumerMixin({
-      mapStateToCanRefine: state => state.hasNoResults === false,
+      mapStateToCanRefine: state => Boolean(state.canRefine),
     }),
   ],
   props: {
@@ -76,9 +76,6 @@ export default {
         transformItems: this.transformItems,
         items: this.items,
       };
-    },
-    canRefine() {
-      return !this.state.hasNoResults;
     },
   },
 };

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -183,9 +183,7 @@ export default {
         $$widgetType: 'ais.pagination',
       }
     ),
-    createPanelConsumerMixin({
-      mapStateToCanRefine: state => state.nbPages > 1,
-    }),
+    createPanelConsumerMixin(),
   ],
   props: {
     padding: {

--- a/src/components/RangeInput.vue
+++ b/src/components/RangeInput.vue
@@ -1,12 +1,12 @@
 <template>
   <div
     v-if="state"
-    :class="[suit(), !canRefine && suit('', 'noRefinement')]"
+    :class="[suit(), !state.canRefine && suit('', 'noRefinement')]"
   >
     <slot
       :current-refinement="values"
       :refine="refine"
-      :can-refine="canRefine"
+      :can-refine="state.canRefine"
       :range="state.range"
       :send-event="state.sendEvent"
     >
@@ -60,9 +60,6 @@ import { createWidgetMixin } from '../mixins/widget';
 import { createPanelConsumerMixin } from '../mixins/panel';
 import { createSuitMixin } from '../mixins/suit';
 
-const mapStateToCanRefine = state =>
-  state && Boolean(state.range) && state.range.min !== state.range.max;
-
 export default {
   name: 'AisRangeInput',
   mixins: [
@@ -75,9 +72,7 @@ export default {
         $$widgetType: 'ais.rangeInput',
       }
     ),
-    createPanelConsumerMixin({
-      mapStateToCanRefine,
-    }),
+    createPanelConsumerMixin(),
   ],
   props: {
     attribute: {
@@ -118,9 +113,6 @@ export default {
         max: this.max,
         precision: this.precision,
       };
-    },
-    canRefine() {
-      return mapStateToCanRefine(this.state);
     },
     step() {
       return 1 / Math.pow(10, this.precision);

--- a/src/components/RatingMenu.vue
+++ b/src/components/RatingMenu.vue
@@ -96,9 +96,7 @@ export default {
         $$widgetType: 'ais.ratingMenu',
       }
     ),
-    createPanelConsumerMixin({
-      mapStateToCanRefine: state => Boolean(state.canRefine),
-    }),
+    createPanelConsumerMixin(),
   ],
   props: {
     attribute: {

--- a/src/components/RatingMenu.vue
+++ b/src/components/RatingMenu.vue
@@ -8,6 +8,7 @@
       :refine="state.refine"
       :createURL="state.createURL"
       :send-event="state.sendEvent"
+      :can-refine="state.canRefine"
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -96,7 +97,7 @@ export default {
       }
     ),
     createPanelConsumerMixin({
-      mapStateToCanRefine: state => state.hasNoResults === false,
+      mapStateToCanRefine: state => Boolean(state.canRefine),
     }),
   ],
   props: {

--- a/src/components/RefinementList.vue
+++ b/src/components/RefinementList.vue
@@ -118,9 +118,7 @@ export default {
         $$widgetType: 'ais.refinementList',
       }
     ),
-    createPanelConsumerMixin({
-      mapStateToCanRefine: state => Boolean(state.canRefine),
-    }),
+    createPanelConsumerMixin(),
   ],
   props: {
     attribute: {

--- a/src/components/SortBy.vue
+++ b/src/components/SortBy.vue
@@ -8,6 +8,7 @@
       :has-no-results="state.hasNoResults"
       :refine="state.refine"
       :current-refinement="state.currentRefinement"
+      :can-refine="state.canRefine"
     >
       <select
         :class="suit('select')"
@@ -43,7 +44,7 @@ export default {
     ),
 
     createPanelConsumerMixin({
-      mapStateToCanRefine: state => state.hasNoResults === false,
+      mapStateToCanRefine: state => Boolean(state.canRefine),
     }),
   ],
   props: {

--- a/src/components/SortBy.vue
+++ b/src/components/SortBy.vue
@@ -43,9 +43,7 @@ export default {
       }
     ),
 
-    createPanelConsumerMixin({
-      mapStateToCanRefine: state => Boolean(state.canRefine),
-    }),
+    createPanelConsumerMixin(),
   ],
   props: {
     items: {

--- a/src/components/ToggleRefinement.vue
+++ b/src/components/ToggleRefinement.vue
@@ -1,11 +1,11 @@
 <template>
   <div
     v-if="state"
-    :class="[suit(), !canRefine && suit('', 'noRefinement')]"
+    :class="[suit(), !state.canRefine && suit('', 'noRefinement')]"
   >
     <slot
       :value="state.value"
-      :can-refine="canRefine"
+      :can-refine="state.canRefine"
       :refine="state.refine"
       :createURL="state.createURL"
       :send-event="state.sendEvent"
@@ -35,8 +35,6 @@ import { createWidgetMixin } from '../mixins/widget';
 import { createPanelConsumerMixin } from '../mixins/panel';
 import { createSuitMixin } from '../mixins/suit';
 
-const mapStateToCanRefine = state => Boolean(state.value && state.value.count);
-
 export default {
   name: 'AisToggleRefinement',
   mixins: [
@@ -49,9 +47,7 @@ export default {
         $$widgetType: 'ais.toggleRefinement',
       }
     ),
-    createPanelConsumerMixin({
-      mapStateToCanRefine,
-    }),
+    createPanelConsumerMixin(),
   ],
   props: {
     attribute: {
@@ -81,9 +77,6 @@ export default {
         on: this.on,
         off: this.off,
       };
-    },
-    canRefine() {
-      return mapStateToCanRefine(this.state);
     },
   },
 };

--- a/src/components/__tests__/Breadcrumb.js
+++ b/src/components/__tests__/Breadcrumb.js
@@ -182,31 +182,6 @@ describe('default render', () => {
   });
 });
 
-describe('panel', () => {
-  it('calls the Panel mixin with `canRefine`', async () => {
-    __setState({ ...defaultState });
-
-    const wrapper = mount(Breadcrumb, {
-      propsData: defaultProps,
-    });
-
-    const mapStateToCanRefine = () =>
-      wrapper.vm.mapStateToCanRefine(wrapper.vm.state);
-
-    expect(mapStateToCanRefine()).toBe(true);
-
-    await wrapper.setData({
-      state: {
-        canRefine: false,
-      },
-    });
-
-    expect(mapStateToCanRefine()).toBe(false);
-
-    expect(wrapper.vm.mapStateToCanRefine({})).toBe(false);
-  });
-});
-
 describe('custom default render', () => {
   const defaultSlot = `
     <template v-slot="{ items, canRefine, refine, createURL }">

--- a/src/components/__tests__/ClearRefinements.js
+++ b/src/components/__tests__/ClearRefinements.js
@@ -187,26 +187,3 @@ describe('custom resetLabel render', () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 });
-
-it('calls the Panel mixin with `hasRefinement`', async () => {
-  __setState({
-    hasRefinements: true,
-  });
-
-  const wrapper = mount(ClearRefinements);
-
-  const mapStateToCanRefine = () =>
-    wrapper.vm.mapStateToCanRefine(wrapper.vm.state);
-
-  expect(mapStateToCanRefine()).toBe(true);
-
-  await wrapper.setData({
-    state: {
-      hasRefinements: false,
-    },
-  });
-
-  expect(mapStateToCanRefine()).toBe(false);
-
-  expect(wrapper.vm.mapStateToCanRefine({})).toBe(false);
-});

--- a/src/components/__tests__/CurrentRefinements.js
+++ b/src/components/__tests__/CurrentRefinements.js
@@ -167,23 +167,6 @@ describe.each([
   });
 });
 
-it('calls the Panel mixin with `canRefine`', async () => {
-  __setState({ items: [{}] });
-
-  const wrapper = mount(CurrentRefinements);
-
-  const mapStateToCanRefine = () =>
-    wrapper.vm.mapStateToCanRefine(wrapper.vm.state);
-
-  expect(mapStateToCanRefine()).toBe(true);
-
-  await wrapper.setData({ state: { items: [] } });
-
-  expect(mapStateToCanRefine()).toBe(false);
-
-  expect(wrapper.vm.mapStateToCanRefine({})).toBe(false);
-});
-
 it('calls `refine` with a refinement', async () => {
   const spies = [jest.fn(), jest.fn()];
 

--- a/src/components/__tests__/HierarchicalMenu.js
+++ b/src/components/__tests__/HierarchicalMenu.js
@@ -116,6 +116,7 @@ const defaultState = {
   createURL: () => {},
   isShowingMore: false,
   canToggleShowMore: true,
+  canRefine: true,
   toggleShowMore: () => {},
   sendEvent: () => {},
 };
@@ -266,6 +267,7 @@ describe('default render', () => {
     __setState({
       ...defaultState,
       items: [],
+      canRefine: false,
     });
 
     const wrapper = mount(HierarchicalMenu, {
@@ -466,25 +468,6 @@ describe('default render', () => {
   });
 });
 
-it('calls the Panel mixin with `items.length`', async () => {
-  __setState({ ...defaultState });
-
-  const wrapper = mount(HierarchicalMenu, {
-    propsData: defaultProps,
-  });
-
-  const mapStateToCanRefine = () =>
-    wrapper.vm.mapStateToCanRefine(wrapper.vm.state);
-
-  expect(mapStateToCanRefine()).toBe(true);
-
-  await wrapper.setData({ state: { items: [] } });
-
-  expect(mapStateToCanRefine()).toBe(false);
-
-  expect(wrapper.vm.mapStateToCanRefine({})).toBe(false);
-});
-
 it('exposes send-event method for insights middleware', async () => {
   const sendEvent = jest.fn();
   __setState({
@@ -574,6 +557,7 @@ describe('custom default render', () => {
     __setState({
       ...defaultState,
       items: [],
+      canRefine: false,
     });
 
     const wrapper = mount({

--- a/src/components/__tests__/HitsPerPage.js
+++ b/src/components/__tests__/HitsPerPage.js
@@ -77,10 +77,10 @@ it('calls `refine` with the `value` on `change`', async () => {
   expect(wrapper.vm.state.refine).toHaveBeenLastCalledWith(20);
 });
 
-it('calls the Panel mixin with `hasNoResults`', async () => {
+it('calls the Panel mixin with `canRefine`', async () => {
   __setState({
     ...defaultState,
-    hasNoResults: false,
+    canRefine: true,
   });
 
   const wrapper = mount(HitsPerPage, {
@@ -94,7 +94,7 @@ it('calls the Panel mixin with `hasNoResults`', async () => {
 
   await wrapper.setData({
     state: {
-      hasNoResults: true,
+      canRefine: false,
     },
   });
 

--- a/src/components/__tests__/HitsPerPage.js
+++ b/src/components/__tests__/HitsPerPage.js
@@ -76,29 +76,3 @@ it('calls `refine` with the `value` on `change`', async () => {
 
   expect(wrapper.vm.state.refine).toHaveBeenLastCalledWith(20);
 });
-
-it('calls the Panel mixin with `canRefine`', async () => {
-  __setState({
-    ...defaultState,
-    canRefine: true,
-  });
-
-  const wrapper = mount(HitsPerPage, {
-    propsData: defaultProps,
-  });
-
-  const mapStateToCanRefine = () =>
-    wrapper.vm.mapStateToCanRefine(wrapper.vm.state);
-
-  expect(mapStateToCanRefine()).toBe(true);
-
-  await wrapper.setData({
-    state: {
-      canRefine: false,
-    },
-  });
-
-  expect(mapStateToCanRefine()).toBe(false);
-
-  expect(wrapper.vm.mapStateToCanRefine({})).toBe(false);
-});

--- a/src/components/__tests__/Menu.js
+++ b/src/components/__tests__/Menu.js
@@ -325,28 +325,6 @@ describe('default render', () => {
   });
 });
 
-it('calls the Panel mixin with `canRefine`', async () => {
-  __setState({ ...defaultState });
-
-  const wrapper = mount(Menu, {
-    propsData: defaultProps,
-  });
-
-  const mapStateToCanRefine = () =>
-    wrapper.vm.mapStateToCanRefine(wrapper.vm.state);
-
-  expect(mapStateToCanRefine()).toBe(true);
-
-  await wrapper.setData({
-    state: {
-      canRefine: false,
-    },
-  });
-  expect(mapStateToCanRefine()).toBe(false);
-
-  expect(wrapper.vm.mapStateToCanRefine({})).toBe(false);
-});
-
 it('exposes send-event method for insights middleware', async () => {
   const sendEvent = jest.fn();
   __setState({

--- a/src/components/__tests__/MenuSelect.js
+++ b/src/components/__tests__/MenuSelect.js
@@ -201,29 +201,6 @@ describe('default render', () => {
   });
 });
 
-it('calls the Panel mixin with `canRefine`', async () => {
-  __setState({ ...defaultState });
-
-  const wrapper = mount(MenuSelect, {
-    propsData: defaultProps,
-  });
-
-  const mapStateToCanRefine = () =>
-    wrapper.vm.mapStateToCanRefine(wrapper.vm.state);
-
-  expect(mapStateToCanRefine()).toBe(true);
-
-  await wrapper.setData({
-    state: {
-      canRefine: false,
-    },
-  });
-
-  expect(mapStateToCanRefine()).toBe(false);
-
-  expect(wrapper.vm.mapStateToCanRefine({})).toBe(false);
-});
-
 it('exposes send-event method for insights middleware', async () => {
   const sendEvent = jest.fn();
   __setState({

--- a/src/components/__tests__/NumericMenu.js
+++ b/src/components/__tests__/NumericMenu.js
@@ -41,6 +41,7 @@ const moreThan500 = {
 const defaultState = {
   items: [all, lessThan10, from10to100, from100to500, moreThan500],
   hasNoResults: false,
+  canRefine: true,
   createURL: () => {},
   refine: () => {},
 };
@@ -125,7 +126,7 @@ describe('default render', () => {
   it('renders correctly without refinement', () => {
     __setState({
       ...defaultState,
-      hasNoResults: true,
+      canRefine: false,
     });
 
     const props = {
@@ -190,7 +191,7 @@ describe('default render', () => {
   });
 });
 
-it('calls the Panel mixin with `hasNoResults`', async () => {
+it('calls the Panel mixin with `canRefine`', async () => {
   __setState({ ...defaultState });
 
   const wrapper = mount(NumericMenu, {
@@ -204,7 +205,7 @@ it('calls the Panel mixin with `hasNoResults`', async () => {
 
   await wrapper.setData({
     state: {
-      hasNoResults: true,
+      canRefine: false,
     },
   });
 
@@ -281,7 +282,7 @@ describe('custom default render', () => {
   it('renders correctly without refinement', () => {
     __setState({
       ...defaultState,
-      hasNoResults: true,
+      canRefine: false,
     });
 
     const wrapper = mount({

--- a/src/components/__tests__/NumericMenu.js
+++ b/src/components/__tests__/NumericMenu.js
@@ -191,29 +191,6 @@ describe('default render', () => {
   });
 });
 
-it('calls the Panel mixin with `canRefine`', async () => {
-  __setState({ ...defaultState });
-
-  const wrapper = mount(NumericMenu, {
-    propsData: defaultProps,
-  });
-
-  const mapStateToCanRefine = () =>
-    wrapper.vm.mapStateToCanRefine(wrapper.vm.state);
-
-  expect(mapStateToCanRefine()).toBe(true);
-
-  await wrapper.setData({
-    state: {
-      canRefine: false,
-    },
-  });
-
-  expect(mapStateToCanRefine()).toBe(false);
-
-  expect(wrapper.vm.mapStateToCanRefine({})).toBe(false);
-});
-
 it('exposes send-event method for insights middleware', async () => {
   const sendEvent = jest.fn();
   __setState({

--- a/src/components/__tests__/Pagination.js
+++ b/src/components/__tests__/Pagination.js
@@ -143,27 +143,6 @@ it('Moves to the previous page on that button', async () => {
   );
 });
 
-it('calls the Panel mixin with `nbPages`', async () => {
-  __setState({ ...defaultState });
-
-  const wrapper = mount(Pagination);
-
-  const mapStateToCanRefine = () =>
-    wrapper.vm.mapStateToCanRefine(wrapper.vm.state);
-
-  expect(mapStateToCanRefine()).toBe(true);
-
-  await wrapper.setData({
-    state: {
-      nbPages: 1,
-    },
-  });
-
-  expect(mapStateToCanRefine()).toBe(false);
-
-  expect(wrapper.vm.mapStateToCanRefine({})).toBe(false);
-});
-
 it('implements showFirst', async () => {
   __setState({ ...defaultState });
 

--- a/src/components/__tests__/RangeInput.js
+++ b/src/components/__tests__/RangeInput.js
@@ -13,6 +13,7 @@ const defaultRange = {
 const defaultState = {
   start: [0, 1000],
   range: defaultRange,
+  canRefine: true,
   refine: () => {},
 };
 
@@ -245,40 +246,6 @@ describe('rendering', () => {
 
     expect(wrapper.find('.ais-RangeInput-input--max').element.value).toBe('');
   });
-});
-
-it('calls the Panel mixin with `range`', async () => {
-  __setState({
-    ...defaultState,
-    range: {
-      min: 0,
-      max: 10,
-    },
-  });
-
-  const wrapper = mount(RangeInput, {
-    propsData: {
-      attribute: 'price',
-    },
-  });
-
-  const mapStateToCanRefine = () =>
-    wrapper.vm.mapStateToCanRefine(wrapper.vm.state);
-
-  expect(mapStateToCanRefine()).toBe(true);
-
-  await wrapper.setData({
-    state: {
-      range: {
-        min: 0,
-        max: 0,
-      },
-    },
-  });
-
-  expect(mapStateToCanRefine()).toBe(false);
-
-  expect(wrapper.vm.mapStateToCanRefine({})).toBe(false);
 });
 
 it('exposes send-event method for insights middleware', async () => {

--- a/src/components/__tests__/RatingMenu.js
+++ b/src/components/__tests__/RatingMenu.js
@@ -126,29 +126,6 @@ it('calls refine when clicked on link', async () => {
   expect(wrapper.vm.state.refine).toHaveBeenLastCalledWith('1');
 });
 
-it('calls the Panel mixin with `canRefine`', async () => {
-  __setState({ canRefine: true });
-
-  const wrapper = mount(RatingMenu, {
-    propsData: defaultProps,
-  });
-
-  const mapStateToCanRefine = () =>
-    wrapper.vm.mapStateToCanRefine(wrapper.vm.state);
-
-  expect(mapStateToCanRefine()).toBe(true);
-
-  await wrapper.setData({
-    state: {
-      canRefine: false,
-    },
-  });
-
-  expect(mapStateToCanRefine()).toBe(false);
-
-  expect(wrapper.vm.mapStateToCanRefine({})).toBe(false);
-});
-
 it('exposes send-event method for insights middleware', async () => {
   const sendEvent = jest.fn();
   __setState({

--- a/src/components/__tests__/RatingMenu.js
+++ b/src/components/__tests__/RatingMenu.js
@@ -126,8 +126,8 @@ it('calls refine when clicked on link', async () => {
   expect(wrapper.vm.state.refine).toHaveBeenLastCalledWith('1');
 });
 
-it('calls the Panel mixin with `hasNoResults`', async () => {
-  __setState({ hasNoResults: false });
+it('calls the Panel mixin with `canRefine`', async () => {
+  __setState({ canRefine: true });
 
   const wrapper = mount(RatingMenu, {
     propsData: defaultProps,
@@ -140,7 +140,7 @@ it('calls the Panel mixin with `hasNoResults`', async () => {
 
   await wrapper.setData({
     state: {
-      hasNoResults: true,
+      canRefine: false,
     },
   });
 

--- a/src/components/__tests__/RefinementList.js
+++ b/src/components/__tests__/RefinementList.js
@@ -166,29 +166,6 @@ it('behaves correctly', async () => {
   expect(wrapper.vm.state.refine).toHaveBeenLastCalledWith('yo');
 });
 
-it('calls the Panel mixin with `canRefine`', async () => {
-  __setState({ ...defaultState });
-
-  const wrapper = mount(RefinementList, {
-    propsData: { attribute: 'something' },
-  });
-
-  const mapStateToCanRefine = () =>
-    wrapper.vm.mapStateToCanRefine(wrapper.vm.state);
-
-  expect(mapStateToCanRefine()).toBe(true);
-
-  await wrapper.setData({
-    state: {
-      canRefine: false,
-    },
-  });
-
-  expect(mapStateToCanRefine()).toBe(false);
-
-  expect(wrapper.vm.mapStateToCanRefine({})).toBe(false);
-});
-
 it('exposes send-event method for insights middleware', async () => {
   const sendEvent = jest.fn();
   __setState({

--- a/src/components/__tests__/SortBy.js
+++ b/src/components/__tests__/SortBy.js
@@ -107,26 +107,3 @@ it('calls `refine` when the selection changes with the `value`', async () => {
   expect(refine).toHaveBeenLastCalledWith('some_index_quality');
   expect(selectedOption.element.selected).toBe(true);
 });
-
-it('calls the Panel mixin with `canRefine`', async () => {
-  __setState({ ...defaultState });
-
-  const wrapper = mount(SortBy, {
-    propsData: defaultProps,
-  });
-
-  const mapStateToCanRefine = () =>
-    wrapper.vm.mapStateToCanRefine(wrapper.vm.state);
-
-  expect(mapStateToCanRefine()).toBe(true);
-
-  await wrapper.setData({
-    state: {
-      canRefine: false,
-    },
-  });
-
-  expect(mapStateToCanRefine()).toBe(false);
-
-  expect(wrapper.vm.mapStateToCanRefine({})).toBe(false);
-});

--- a/src/components/__tests__/SortBy.js
+++ b/src/components/__tests__/SortBy.js
@@ -12,6 +12,7 @@ const defaultState = {
     { value: 'some_index_quality', label: 'Quality ascending' },
   ],
   hasNoResults: false,
+  canRefine: true,
   currentRefinement: 'some_index',
 };
 
@@ -107,7 +108,7 @@ it('calls `refine` when the selection changes with the `value`', async () => {
   expect(selectedOption.element.selected).toBe(true);
 });
 
-it('calls the Panel mixin with `hasNoResults`', async () => {
+it('calls the Panel mixin with `canRefine`', async () => {
   __setState({ ...defaultState });
 
   const wrapper = mount(SortBy, {
@@ -121,7 +122,7 @@ it('calls the Panel mixin with `hasNoResults`', async () => {
 
   await wrapper.setData({
     state: {
-      hasNoResults: true,
+      canRefine: false,
     },
   });
 

--- a/src/components/__tests__/ToggleRefinement.js
+++ b/src/components/__tests__/ToggleRefinement.js
@@ -13,6 +13,7 @@ const defaultValue = {
 
 const defaultState = {
   value: defaultValue,
+  canRefine: true,
   refine: () => {},
   createURL: () => {},
 };
@@ -82,6 +83,7 @@ describe('default render', () => {
   it('renders correctly without refinement (with 0)', () => {
     __setState({
       ...defaultState,
+      canRefine: false,
       value: {
         ...defaultValue,
         count: 0,
@@ -98,6 +100,7 @@ describe('default render', () => {
   it('renders correctly without refinement (with null)', () => {
     __setState({
       ...defaultState,
+      canRefine: false,
       value: {
         ...defaultValue,
         count: null,
@@ -162,39 +165,6 @@ describe('default render', () => {
   });
 });
 
-it('calls the Panel mixin with `value.count`', async () => {
-  __setState({
-    ...defaultState,
-    value: {
-      // Otherwise setData update the default value
-      // and impact the other tests. We should not
-      // rely on a global state for the tests.
-      ...defaultValue,
-    },
-  });
-
-  const wrapper = mount(Toggle, {
-    propsData: defaultProps,
-  });
-
-  const mapStateToCanRefine = () =>
-    wrapper.vm.mapStateToCanRefine(wrapper.vm.state);
-
-  expect(mapStateToCanRefine()).toBe(true);
-
-  await wrapper.setData({
-    state: {
-      value: {
-        count: 0,
-      },
-    },
-  });
-
-  expect(mapStateToCanRefine()).toBe(false);
-
-  expect(wrapper.vm.mapStateToCanRefine({})).toBe(false);
-});
-
 it('exposes send-event method for insights middleware', async () => {
   const sendEvent = jest.fn();
   __setState({
@@ -255,6 +225,7 @@ describe('custom default render', () => {
   it('renders correctly without refinement', () => {
     __setState({
       ...defaultState,
+      canRefine: false,
       value: {
         ...defaultValue,
         count: 0,

--- a/src/mixins/__mocks__/panel.js
+++ b/src/mixins/__mocks__/panel.js
@@ -1,7 +1,3 @@
 export const createPanelProviderMixin = jest.fn(() => ({}));
 
-export const createPanelConsumerMixin = jest.fn(({ mapStateToCanRefine }) => ({
-  methods: {
-    mapStateToCanRefine,
-  },
-}));
+export const createPanelConsumerMixin = jest.fn(() => ({}));

--- a/src/mixins/__tests__/panel.test.js
+++ b/src/mixins/__tests__/panel.test.js
@@ -86,18 +86,12 @@ describe('createPanelProviderMixin', () => {
 });
 
 describe('createPanelConsumerMixin', () => {
-  const mapStateToCanRefine = state => state.attributeName;
-
-  it('emits PANEL_CHANGE_EVENT on `state.attributeName` change', async () => {
+  it('emits PANEL_CHANGE_EVENT on `state.canRefine` change', async () => {
     const emitter = createFakeEmitter();
     const Test = createFakeComponent();
 
     const wrapper = mount(Test, {
-      mixins: [
-        createPanelConsumerMixin({
-          mapStateToCanRefine,
-        }),
-      ],
+      mixins: [createPanelConsumerMixin()],
       provide: {
         [PANEL_EMITTER_NAMESPACE]: emitter,
       },
@@ -105,7 +99,7 @@ describe('createPanelConsumerMixin', () => {
 
     await wrapper.setData({
       state: {
-        attributeName: false,
+        canRefine: false,
       },
     });
 
@@ -113,7 +107,7 @@ describe('createPanelConsumerMixin', () => {
     expect(emitter.emit).toHaveBeenLastCalledWith(PANEL_CHANGE_EVENT, false);
 
     if (isVue3) {
-      await wrapper.setData({ state: { attributeName: true } });
+      await wrapper.setData({ state: { canRefine: true } });
     } else {
       // ↓ this should be replaceable with `wrapper.setData()` but it didn't
       // trigger the watcher in `createPanelConsumerMixin`.
@@ -121,7 +115,7 @@ describe('createPanelConsumerMixin', () => {
       // https://github.com/vuejs/vue-test-utils/issues/1756
       // https://github.com/vuejs/vue-test-utils/issues/149
       wrapper.vm.$set(wrapper.vm, 'state', {
-        attributeName: true,
+        canRefine: true,
       });
       await nextTick();
     }
@@ -135,11 +129,7 @@ describe('createPanelConsumerMixin', () => {
     const Test = createFakeComponent();
 
     const wrapper = mount(Test, {
-      mixins: [
-        createPanelConsumerMixin({
-          mapStateToCanRefine,
-        }),
-      ],
+      mixins: [createPanelConsumerMixin()],
       provide: {
         [PANEL_EMITTER_NAMESPACE]: emitter,
       },
@@ -147,7 +137,7 @@ describe('createPanelConsumerMixin', () => {
 
     await wrapper.setData({
       state: {
-        attributeName: false,
+        canRefine: false,
       },
     });
 
@@ -156,7 +146,7 @@ describe('createPanelConsumerMixin', () => {
 
     await wrapper.setData({
       state: {
-        attributeName: false,
+        canRefine: false,
       },
     });
 
@@ -168,11 +158,7 @@ describe('createPanelConsumerMixin', () => {
     const Test = createFakeComponent();
 
     const wrapper = mount(Test, {
-      mixins: [
-        createPanelConsumerMixin({
-          mapStateToCanRefine,
-        }),
-      ],
+      mixins: [createPanelConsumerMixin()],
       provide: {
         [PANEL_EMITTER_NAMESPACE]: emitter,
       },
@@ -180,7 +166,7 @@ describe('createPanelConsumerMixin', () => {
 
     await wrapper.setData({
       state: {
-        attributeName: true,
+        canRefine: true,
       },
     });
 
@@ -193,11 +179,7 @@ describe('createPanelConsumerMixin', () => {
     const Test = createFakeComponent();
 
     const wrapper = mount(Test, {
-      mixins: [
-        createPanelConsumerMixin({
-          mapStateToCanRefine,
-        }),
-      ],
+      mixins: [createPanelConsumerMixin()],
       provide: {
         [PANEL_EMITTER_NAMESPACE]: emitter,
       },
@@ -205,7 +187,7 @@ describe('createPanelConsumerMixin', () => {
 
     await wrapper.setData({
       state: {
-        attributeName: true,
+        canRefine: true,
       },
     });
 
@@ -227,11 +209,7 @@ describe('createPanelConsumerMixin', () => {
     const Test = createFakeComponent();
 
     const wrapper = mount(Test, {
-      mixins: [
-        createPanelConsumerMixin({
-          mapStateToCanRefine,
-        }),
-      ],
+      mixins: [createPanelConsumerMixin()],
       provide: {
         [PANEL_EMITTER_NAMESPACE]: emitter,
       },
@@ -239,7 +217,7 @@ describe('createPanelConsumerMixin', () => {
 
     await wrapper.setData({
       state: {
-        attributeName: true,
+        canRefine: true,
       },
     });
 
@@ -247,9 +225,9 @@ describe('createPanelConsumerMixin', () => {
     expect(emitter.emit).toHaveBeenLastCalledWith(PANEL_CHANGE_EVENT, true);
 
     if (isVue3) {
-      await wrapper.setData({ state: { attributeName: false } });
+      await wrapper.setData({ state: { canRefine: false } });
     } else {
-      wrapper.vm.$set(wrapper.vm, 'state', { attributeName: false });
+      wrapper.vm.$set(wrapper.vm, 'state', { canRefine: false });
       await nextTick();
     }
 
@@ -257,9 +235,9 @@ describe('createPanelConsumerMixin', () => {
     expect(emitter.emit).toHaveBeenLastCalledWith(PANEL_CHANGE_EVENT, false);
 
     if (isVue3) {
-      await wrapper.setData({ state: { attributeName: false } });
+      await wrapper.setData({ state: { canRefine: false } });
     } else {
-      wrapper.vm.$set(wrapper.vm, 'state', { attributeName: false });
+      wrapper.vm.$set(wrapper.vm, 'state', { canRefine: false });
       await nextTick();
     }
 

--- a/src/mixins/panel.js
+++ b/src/mixins/panel.js
@@ -39,7 +39,7 @@ export const createPanelProviderMixin = () => ({
   },
 });
 
-export const createPanelConsumerMixin = ({ mapStateToCanRefine }) => ({
+export const createPanelConsumerMixin = () => ({
   inject: {
     emitter: {
       from: PANEL_EMITTER_NAMESPACE,
@@ -64,8 +64,10 @@ export const createPanelConsumerMixin = ({ mapStateToCanRefine }) => ({
           return;
         }
 
-        const previousCanRefine = mapStateToCanRefine(previousState || {});
-        const nextCanRefine = mapStateToCanRefine(nextState);
+        const previousCanRefine = previousState
+          ? previousState.canRefine
+          : false;
+        const nextCanRefine = nextState.canRefine;
 
         if (!this.hasAlreadyEmitted || previousCanRefine !== nextCanRefine) {
           this.emitter.emit(PANEL_CHANGE_EVENT, nextCanRefine);

--- a/src/mixins/panel.js
+++ b/src/mixins/panel.js
@@ -39,7 +39,9 @@ export const createPanelProviderMixin = () => ({
   },
 });
 
-export const createPanelConsumerMixin = ({ mapStateToCanRefine = state => Boolean(state.canRefine) }) => ({
+export const createPanelConsumerMixin = ({
+  mapStateToCanRefine = state => Boolean(state.canRefine),
+} = {}) => ({
   inject: {
     emitter: {
       from: PANEL_EMITTER_NAMESPACE,

--- a/src/mixins/panel.js
+++ b/src/mixins/panel.js
@@ -39,7 +39,7 @@ export const createPanelProviderMixin = () => ({
   },
 });
 
-export const createPanelConsumerMixin = () => ({
+export const createPanelConsumerMixin = ({ mapStateToCanRefine = state => Boolean(state.canRefine) }) => ({
   inject: {
     emitter: {
       from: PANEL_EMITTER_NAMESPACE,
@@ -64,10 +64,8 @@ export const createPanelConsumerMixin = () => ({
           return;
         }
 
-        const previousCanRefine = previousState
-          ? previousState.canRefine
-          : false;
-        const nextCanRefine = nextState.canRefine;
+        const previousCanRefine = mapStateToCanRefine(previousState || {});
+        const nextCanRefine = mapStateToCanRefine(nextState);
 
         if (!this.hasAlreadyEmitted || previousCanRefine !== nextCanRefine) {
           this.emitter.emit(PANEL_CHANGE_EVENT, nextCanRefine);

--- a/yarn.lock
+++ b/yarn.lock
@@ -111,6 +111,19 @@
     "@algolia/logger-common" "4.0.1"
     "@algolia/requester-common" "4.0.1"
 
+"@algolia/ui-components-highlight-vdom@^1.1.2":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@algolia/ui-components-highlight-vdom/-/ui-components-highlight-vdom-1.1.3.tgz#ba3ec05d4657286e2e688e1446c591d0e4217166"
+  integrity sha512-KgSiQ+FQf+e2HDNgw9J66HmpbIdZA9VQpLwDn950DCgo7BEZQrMqgqkMPJhHYZfkPvRfxV+1T3XwS43zib8w4w==
+  dependencies:
+    "@algolia/ui-components-shared" "1.1.3"
+    "@babel/runtime" "^7.0.0"
+
+"@algolia/ui-components-shared@1.1.3", "@algolia/ui-components-shared@^1.1.2":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@algolia/ui-components-shared/-/ui-components-shared-1.1.3.tgz#d62760b20584f628f57e8a144f5796bc42fd68f1"
+  integrity sha512-eBxvljiwvajSsg9Pz9nYNH+QH/b5q66Z4xRDr1LhICNuLibDF64mH+Vv4mg29qPxmmgMWlmWiwJQmQqR9Z229w==
+
 "@ampproject/remapping@^2.0.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.1.0.tgz#72becdf17ee44b2d1ac5651fb12f1952c336fe23"
@@ -332,6 +345,13 @@
   version "7.17.0"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.0.tgz#f0ac33eddbe214e4105363bb17c3341c5ffcc43c"
   integrity sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==
+
+"@babel/runtime@^7.0.0":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
+  integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
 
 "@babel/runtime@^7.6.3", "@babel/runtime@^7.9.6":
   version "7.10.2"
@@ -7869,6 +7889,11 @@ hosted-git-info@^3.0.2:
   dependencies:
     lru-cache "^5.1.1"
 
+htm@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/htm/-/htm-3.1.1.tgz#49266582be0dc66ed2235d5ea892307cc0c24b78"
+  integrity sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==
+
 html-comment-regex@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.2.tgz#97d4688aeb5c81886a364faa0cad1dda14d433a7"
@@ -8348,18 +8373,21 @@ instantsearch.css@7.3.1:
   resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.3.1.tgz#7ab74a8f355091ae040947a9cf5438f379026622"
   integrity sha512-/kaMDna5D+Q9mImNBHEhb9HgHATDOFKYii7N1Iwvrj+lmD9gBJLqVhUw67gftq2O0QI330pFza+CRscIwB1wQQ==
 
-instantsearch.js@^4.43.0:
-  version "4.43.0"
-  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.43.0.tgz#ac5f26bd317649ec3d7b4eebfd2abc13f9b3701e"
-  integrity sha512-KcPm3Swkw5nlQFRVY5v8JebBwJ303ZGmxSMxdAevrGJBmIXpGrcGJF5goBqNa+fUpwpCY6PsICcqQS0YMuXVag==
+instantsearch.js@^4.45.0:
+  version "4.45.0"
+  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.45.0.tgz#52be36dffd9b6b9616184c783bb8ac1f39ff205c"
+  integrity sha512-gjJDnFJO2yfkmOb0X1mZumqMGHlZIxAVNusnKfNh8s4u6SsRCM9p8S3eJi5aYo3mbS9NrePR8B44/gXh4YGcQQ==
   dependencies:
     "@algolia/events" "^4.0.1"
+    "@algolia/ui-components-highlight-vdom" "^1.1.2"
+    "@algolia/ui-components-shared" "^1.1.2"
     "@types/google.maps" "^3.45.3"
     "@types/hogan.js" "^3.0.0"
     "@types/qs" "^6.5.3"
     algoliasearch-helper "^3.10.0"
     classnames "^2.2.5"
     hogan.js "^3.0.2"
+    htm "^3.0.0"
     preact "^10.6.0"
     qs "^6.5.1 < 6.10"
     search-insights "^2.1.0"


### PR DESCRIPTION
Following [FX-740](https://algolia.atlassian.net/browse/FX-740), we want to provide `canRefine` to slots and use it for `createPanelConsumerMixin()`