### PR TITLE
feat(dynamicWidgets): add fallback slot to render attributes without matching component

### DIFF
--- a/src/components/DynamicWidgets.js
+++ b/src/components/DynamicWidgets.js
@@ -96,10 +96,18 @@ export default {
       );
     }
 
+    const fallbackSlot = isVue3
+      ? this.$slots.fallback
+      : this.$scopedSlots.fallback;
+
     return h(
       'div',
       { class: [this.suit()] },
-      this.state.attributesToRender.map(attribute => components.get(attribute))
+      this.state.attributesToRender.map(
+        attribute =>
+          components.get(attribute) ||
+          (fallbackSlot && fallbackSlot({ attribute }))
+      )
     );
   }),
   computed: {

--- a/src/components/__tests__/DynamicWidgets.js
+++ b/src/components/__tests__/DynamicWidgets.js
@@ -443,3 +443,50 @@ it('updates DOM when attributesToRender changes', async () => {
 </div>
 `);
 });
+
+it('renders fallback slot for attributes without matching component', () => {
+  __setState({
+    attributesToRender: ['test1', 'test2', 'test3'],
+  });
+
+  const wrapper = mount({
+    template: `
+      <DynamicWidgets :transformItems="items => items">
+        <MockRefinementList attribute="test1" />
+
+        <template v-slot:fallback="{ attribute }">
+          <MockRefinementList :attribute="attribute" />
+        </template>
+      </DynamicWidgets>
+    `,
+    components: {
+      DynamicWidgets,
+      MockRefinementList,
+    },
+  });
+
+  expect(wrapper.html()).toMatchInlineSnapshot(`
+<div class="ais-DynamicWidgets">
+  <div class="ais-DynamicWidgets-widget">
+    <div>
+      {
+      "widgetName": "ais-refinement-list",
+      "attribute": "test1"
+      }
+    </div>
+  </div>
+  <div>
+    {
+    "widgetName": "ais-refinement-list",
+    "attribute": "test2"
+    }
+  </div>
+  <div>
+    {
+    "widgetName": "ais-refinement-list",
+    "attribute": "test3"
+    }
+  </div>
+</div>
+`);
+});

--- a/stories/DynamicWidgets.stories.js
+++ b/stories/DynamicWidgets.stories.js
@@ -22,4 +22,31 @@ storiesOf('ais-dynamic-widgets', module)
         ],
       };
     },
+  }))
+  .add('with fallback', () => ({
+    template: `
+    <ais-dynamic-widgets :transform-items="transformItems">
+      <ais-refinement-list attribute="brand"></ais-refinement-list>
+      <ais-menu attribute="categories"></ais-menu>
+      <ais-panel>
+        <template v-slot:header>hierarchy</template>
+        <ais-hierarchical-menu :attributes="hierarchicalCategories"></ais-hierarchical-menu>
+      </ais-panel>
+
+      <template v-slot:fallback="{ attribute }">
+        <ais-panel>
+          <template v-slot:header>{{ attribute }}</template>
+          <ais-refinement-list :attribute="attribute" />
+        </ais-panel>
+      </template>
+    </ais-dynamic-widgets>`,
+    data() {
+      return {
+        hierarchicalCategories: [
+          'hierarchicalCategories.lvl0',
+          'hierarchicalCategories.lvl1',
+          'hierarchicalCategories.lvl2',
+        ],
+      };
+    },
   }));


### PR DESCRIPTION
[FX-1683](https://algolia.atlassian.net/browse/FX-1683)

Due to library users need, this PR introduces a `fallback` slot to `ais-dynamic-widgets`, which works similarly as `fallbackComponent` for `react-instantsearch`.