### PR TITLE
feat(ais-hierarchical-menu): add css class for link of selected menu item

### DIFF
--- a/src/components/HierarchicalMenuList.vue
+++ b/src/components/HierarchicalMenuList.vue
@@ -17,7 +17,10 @@
     >
       <a
         :href="createURL(item.value)"
-        :class="suit('link')"
+        :class="[
+          suit('link'),
+          item.isRefined && suit('link', 'selected')
+        ]"
         @click.prevent="refine(item.value)"
       >
         <span :class="suit('label')">{{ item.label }}</span>

--- a/src/components/__tests__/__snapshots__/HierarchicalMenu.js.snap
+++ b/src/components/__tests__/__snapshots__/HierarchicalMenu.js.snap
@@ -731,7 +731,7 @@ exports[`default render renders correctly a sub categories selected 1`] = `
 <div class="ais-HierarchicalMenu">
   <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--lvl0">
     <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent ais-HierarchicalMenu-item--selected">
-      <a class="ais-HierarchicalMenu-link">
+      <a class="ais-HierarchicalMenu-link ais-HierarchicalMenu-link--selected">
         <span class="ais-HierarchicalMenu-label">
           Apple
         </span>
@@ -761,7 +761,7 @@ exports[`default render renders correctly a sub categories selected 1`] = `
           </a>
         </li>
         <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent ais-HierarchicalMenu-item--selected">
-          <a class="ais-HierarchicalMenu-link">
+          <a class="ais-HierarchicalMenu-link ais-HierarchicalMenu-link--selected">
             <span class="ais-HierarchicalMenu-label">
               MacBook
             </span>


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR adds a new CSS class modifier for the `<ais-hierarchical-menu>` widget, following the addition made in the CSS specs.

| InstantSearch.css class name |
| --- |
| `.ais-HierarchicalMenu-link--selected` |

[FX-1795](https://algolia.atlassian.net/browse/FX-1795)
